### PR TITLE
fix(privy): reliable wallet login + add ox dep

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -45,6 +45,7 @@
         "framer-motion": "^12.24.0",
         "lucide-react": "^0.525.0",
         "mapbox-gl": "^3.14.0",
+        "ox": "^0.14.29",
         "permissionless": "^0.3.6",
         "process": "^0.11.10",
         "react": "^19.1.0",
@@ -1390,90 +1391,6 @@
         "@solana/web3.js": "^1.98.2",
         "ox": "^0.14.0",
         "zod": "^4.0.0"
-      }
-    },
-    "node_modules/@farcaster/miniapp-core/node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
-      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "license": "MIT"
-    },
-    "node_modules/@farcaster/miniapp-core/node_modules/@noble/curves": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
-      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@farcaster/miniapp-core/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@farcaster/miniapp-core/node_modules/abitype": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.4.tgz",
-      "integrity": "sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/wevm"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4",
-        "zod": "^3.22.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@farcaster/miniapp-core/node_modules/ox": {
-      "version": "0.14.29",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
-      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.2.3",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@farcaster/miniapp-core/node_modules/zod": {
@@ -18104,6 +18021,90 @@
       "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ox": {
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/abitype": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.4.tgz",
+      "integrity": "sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -47,6 +47,7 @@
     "framer-motion": "^12.24.0",
     "lucide-react": "^0.525.0",
     "mapbox-gl": "^3.14.0",
+    "ox": "^0.14.29",
     "permissionless": "^0.3.6",
     "process": "^0.11.10",
     "react": "^19.1.0",

--- a/app/src/pages/auth/PrivyLoginControls.tsx
+++ b/app/src/pages/auth/PrivyLoginControls.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react';
 import { ArrowRight, Loader2, Mail, Wallet } from 'lucide-react';
-import { useLoginWithEmail, useLoginWithOAuth, useLoginWithSiwe } from '@privy-io/react-auth';
+import { useLoginWithEmail, useLoginWithOAuth, usePrivy } from '@privy-io/react-auth';
 
 /*
- * Fully custom (headless) Privy login — no third-party modal. Email is a 2-step OTP (send code → verify),
- * social providers redirect via initOAuth, and external wallets use the SIWE flow (generateSiweMessage →
- * the wallet signs → loginWithSiwe) — NOT connectWallet, which only CONNECTS and never authenticates (no
- * session, no signing prompt). On success Privy flips `authenticated` → LoginPage navigates on.
- * See [[clearpath-privy-migration]].
+ * Custom Privy login. Email is a 2-step OTP (send code → verify) and socials redirect via initOAuth —
+ * both fully our UI. External wallets use Privy's own wallet login `login({ loginMethods: ['wallet'] })`,
+ * which handles connect + SIWE message + signature + session INTERNALLY (a manual generateSiweMessage +
+ * personal_sign produced signatures Privy's /siwe/authenticate rejected as invalid). It opens a small
+ * wallet-only Privy sheet; external wallets need their own extension popup anyway. On success Privy flips
+ * `authenticated` → LoginPage navigates on. See [[clearpath-privy-migration]].
  */
 
 type OAuthProvider = 'google' | 'apple' | 'twitter' | 'discord' | 'github';
@@ -22,7 +23,7 @@ const SOCIALS: { id: OAuthProvider; label: string }[] = [
 export default function PrivyLoginControls() {
   const { sendCode, loginWithCode } = useLoginWithEmail();
   const { initOAuth } = useLoginWithOAuth();
-  const { generateSiweMessage, loginWithSiwe } = useLoginWithSiwe();
+  const { login } = usePrivy();
 
   const [step, setStep] = useState<'email' | 'code'>('email');
   const [email, setEmail] = useState('');
@@ -71,28 +72,10 @@ export default function PrivyLoginControls() {
     }
   };
 
-  const loginWithWallet = async () => {
-    setBusy('wallet');
+  const loginWithWallet = () => {
     setError(null);
-    try {
-      const eth = (window as unknown as {
-        ethereum?: { request: (a: { method: string; params?: unknown[] }) => Promise<unknown> };
-      }).ethereum;
-      if (!eth?.request) throw new Error('No browser wallet found — install MetaMask, or use email / social.');
-      const accounts = (await eth.request({ method: 'eth_requestAccounts' })) as string[];
-      const address = accounts?.[0];
-      if (!address) throw new Error('No wallet account selected.');
-      const chainHex = (await eth.request({ method: 'eth_chainId' })) as string;
-      const chainId = `eip155:${parseInt(chainHex, 16)}` as `eip155:${number}`;
-      const message = await generateSiweMessage({ address, chainId });
-      const signature = (await eth.request({ method: 'personal_sign', params: [message, address] })) as string;
-      await loginWithSiwe({ message, signature, walletClientType: 'metamask', connectorType: 'injected' });
-      // On success Privy authenticates + links the wallet; LoginPage's effect navigates onward.
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Wallet sign-in failed.');
-    } finally {
-      setBusy(null);
-    }
+    // Privy handles connect + SIWE + signature + session; on success `authenticated` flips → navigate.
+    login({ loginMethods: ['wallet'] });
   };
 
   const inputCls =
@@ -194,11 +177,10 @@ export default function PrivyLoginControls() {
       {/* Wallet */}
       <button
         type="button"
-        disabled={busy === 'wallet'}
         onClick={loginWithWallet}
-        className="flex w-full items-center justify-center gap-2 rounded-xl border border-border py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-secondary disabled:opacity-50"
+        className="flex w-full items-center justify-center gap-2 rounded-xl border border-border py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-secondary"
       >
-        {busy === 'wallet' ? <Loader2 className="h-4 w-4 animate-spin" /> : <Wallet className="h-4 w-4" />} Connect a wallet
+        <Wallet className="h-4 w-4" /> Connect a wallet
       </button>
     </div>
   );


### PR DESCRIPTION
Wallet button now uses Privy's login({loginMethods:['wallet']}) (handles SIWE internally) instead of a manual SIWE flow Privy rejected. Adds the missing 'ox' dep (permissionless) to clear the console resolve error.