### PR TITLE
fix(privy): navigate on auth not address (unblocks email/social login)

### DIFF
--- a/app/src/components/ProtectedRoute.tsx
+++ b/app/src/components/ProtectedRoute.tsx
@@ -7,7 +7,7 @@ interface ProtectedRouteProps {
 }
 
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const { isConnected, isAuthenticated } = useAppKitAuth();
+  const { isAuthenticated } = useAppKitAuth();
   const location = useLocation();
   const [isChecking, setIsChecking] = useState(true);
   const [hasCheckedOnce, setHasCheckedOnce] = useState(false);
@@ -29,22 +29,19 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
     if (hasCheckedOnce) {
       setIsChecking(false);
     }
-  }, [isConnected, hasCheckedOnce]);
+  }, [isAuthenticated, hasCheckedOnce]);
 
   // While checking initially, show nothing (prevent flash)
   if (isChecking && !hasCheckedOnce) {
     return null;
   }
 
-  // If not connected, redirect to login
-  if (!isConnected) {
+  // Gate on AUTHENTICATION (the Privy session), not on having an address. The wallet address (the smart
+  // wallet for email/social) is minted asynchronously AFTER login, so requiring it here would bounce a
+  // freshly-authenticated user straight back to /login. The address resolves on its own once inside.
+  if (!isAuthenticated) {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
-  if (location.pathname.startsWith('/account') && !isAuthenticated) {
-    return <Navigate to="/login" state={{ from: location }} replace />;
-  }
-
-  // If connected, show the protected content
   return <>{children}</>;
 }

--- a/app/src/pages/auth/LoginPage.tsx
+++ b/app/src/pages/auth/LoginPage.tsx
@@ -4,14 +4,17 @@ import { useAppKitAuth } from '@/hooks/useAppKitAuth';
 import LoginView from './LoginView';
 
 export default function LoginPage() {
-  const { isConnected, isAuthenticated } = useAppKitAuth();
+  // Navigate as soon as the user is AUTHENTICATED — don't also wait for `isConnected` (an address).
+  // For email/social users the address is the smart wallet, which Privy mints asynchronously AFTER
+  // login, so requiring it left them authenticated-but-stuck on this screen. The address resolves on
+  // its own once the app is loaded.
+  const { isAuthenticated } = useAppKitAuth();
   const navigate = useNavigate();
   const location = useLocation();
   const [hasNavigated, setHasNavigated] = useState(false);
 
   useEffect(() => {
-    // If already connected, route on through (splash handled by App.tsx).
-    if (isConnected && isAuthenticated && !hasNavigated) {
+    if (isAuthenticated && !hasNavigated) {
       setHasNavigated(true);
       const fromState = location.state as
         | { from?: { pathname?: string; search?: string; hash?: string } }
@@ -25,10 +28,10 @@ export default function LoginPage() {
       setTimeout(() => {
         navigate(nextRoute, { replace: true });
       }, 100);
-    } else if (!isConnected || !isAuthenticated) {
+    } else if (!isAuthenticated) {
       setHasNavigated(false);
     }
-  }, [isAuthenticated, isConnected, location.state, navigate, hasNavigated]);
+  }, [isAuthenticated, location.state, navigate, hasNavigated]);
 
   return (
     <LoginView


### PR DESCRIPTION
Email/social authenticated but stayed on /login because LoginPage + ProtectedRoute required an address (the smart wallet, minted async after login). Gate on isAuthenticated instead.