### PR TITLE
fix(privy): pin ox 0.11.3 for permissionless (smart-wallet creation)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -45,7 +45,7 @@
         "framer-motion": "^12.24.0",
         "lucide-react": "^0.525.0",
         "mapbox-gl": "^3.14.0",
-        "ox": "^0.14.29",
+        "ox": "0.11.3",
         "permissionless": "^0.3.6",
         "process": "^0.11.10",
         "react": "^19.1.0",
@@ -1391,6 +1391,90 @@
         "@solana/web3.js": "^1.98.2",
         "ox": "^0.14.0",
         "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@farcaster/miniapp-core/node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@farcaster/miniapp-core/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@farcaster/miniapp-core/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@farcaster/miniapp-core/node_modules/abitype": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.4.tgz",
+      "integrity": "sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@farcaster/miniapp-core/node_modules/ox": {
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@farcaster/miniapp-core/node_modules/zod": {
@@ -18023,9 +18107,9 @@
       "license": "MIT"
     },
     "node_modules/ox": {
-      "version": "0.14.29",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
-      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.11.3.tgz",
+      "integrity": "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==",
       "funding": [
         {
           "type": "github",

--- a/app/package.json
+++ b/app/package.json
@@ -47,7 +47,7 @@
     "framer-motion": "^12.24.0",
     "lucide-react": "^0.525.0",
     "mapbox-gl": "^3.14.0",
-    "ox": "^0.14.29",
+    "ox": "0.11.3",
     "permissionless": "^0.3.6",
     "process": "^0.11.10",
     "react": "^19.1.0",


### PR DESCRIPTION
permissionless needs ox ^0.11.3 but had 0.14.29 -> Kernel smart-wallet creation broke (email/social got no smart wallet). Pin ox to 0.11.3; viem nests its own 0.14.27.