### PR TITLE
feat(app): Receive screen with deposit address (smart wallet) + QR

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -48,6 +48,7 @@
         "ox": "0.11.3",
         "permissionless": "^0.3.6",
         "process": "^0.11.10",
+        "qrcode.react": "^4.2.0",
         "react": "^19.1.0",
         "react-day-picker": "^9.11.1",
         "react-dom": "^19.1.0",
@@ -18880,6 +18881,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/qs": {

--- a/app/package.json
+++ b/app/package.json
@@ -50,6 +50,7 @@
     "ox": "0.11.3",
     "permissionless": "^0.3.6",
     "process": "^0.11.10",
+    "qrcode.react": "^4.2.0",
     "react": "^19.1.0",
     "react-day-picker": "^9.11.1",
     "react-dom": "^19.1.0",

--- a/app/src/components/app-ui/QuickActions.tsx
+++ b/app/src/components/app-ui/QuickActions.tsx
@@ -1,12 +1,13 @@
-import { Plus, SendHorizontal, ArrowLeftRight, ArrowDownToLine, type LucideIcon } from 'lucide-react';
+import { Plus, QrCode, SendHorizontal, ArrowLeftRight, ArrowDownToLine, type LucideIcon } from 'lucide-react';
 import ActionTile from '@/components/app-ui/ActionTile';
 import { useMoneyActions } from '@/context/MoneyActionsContext';
 
 /** Dashboard quick-actions grid — no card wrapper; the tiles are the cards. */
 export default function QuickActions({ className }: { className?: string }) {
-  const { openAddMoney, openWithdraw, openSend, openTransfer } = useMoneyActions();
+  const { openAddMoney, openReceive, openWithdraw, openSend, openTransfer } = useMoneyActions();
   const actions: { icon: LucideIcon; label: string; hint: string; onClick?: () => void }[] = [
     { icon: Plus, label: 'Add money', hint: 'Bank or card', onClick: openAddMoney },
+    { icon: QrCode, label: 'Receive', hint: 'Crypto address', onClick: openReceive },
     { icon: SendHorizontal, label: 'Send', hint: 'To anyone', onClick: openSend },
     { icon: ArrowLeftRight, label: 'Transfer', hint: 'Between accounts', onClick: openTransfer },
     { icon: ArrowDownToLine, label: 'Withdraw', hint: 'To linked bank', onClick: openWithdraw },

--- a/app/src/components/app-ui/ReceiveModal.tsx
+++ b/app/src/components/app-ui/ReceiveModal.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { Check, Copy, QrCode } from 'lucide-react';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { useAppKitAccount } from '@/lib/walletCompat';
+
+/*
+ * "Receive" — shows the user's deposit address (their smart wallet for email/social, their own EOA for
+ * external) as a QR + copyable string. Send USDC on Base here; it lands in their account. The smart
+ * wallet is counterfactual (not deployed until the first tx), but ERC-20 transfers to its address are
+ * safe — the funds are there when it deploys.
+ */
+export default function ReceiveModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
+  const { address } = useAppKitAccount();
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    if (!address) return;
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable */
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-0 p-0 sm:max-w-[420px]">
+        <div className="p-5">
+          <div className="mb-1 flex items-center gap-2 text-base font-semibold text-foreground">
+            <QrCode className="h-[18px] w-[18px]" /> Receive
+          </div>
+          <p className="mb-5 text-xs text-muted-foreground">
+            Send <span className="font-medium text-foreground">USDC on Base</span> to this address — it lands in your account.
+          </p>
+
+          {address ? (
+            <>
+              <div className="mx-auto mb-4 w-fit rounded-2xl bg-white p-3 shadow-sm">
+                <QRCodeSVG value={address} size={184} bgColor="#ffffff" fgColor="#000000" level="M" />
+              </div>
+
+              <div className="rounded-xl border border-border bg-secondary/40 p-3">
+                <div className="mb-1 text-[11px] font-medium text-muted-foreground">Your deposit address</div>
+                <div className="break-all font-mono text-xs leading-relaxed text-foreground">{address}</div>
+              </div>
+
+              <button
+                type="button"
+                onClick={copy}
+                className="mt-3 flex w-full items-center justify-center gap-2 rounded-xl bg-primary py-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.99]"
+              >
+                {copied ? (
+                  <>
+                    <Check className="h-4 w-4" /> Copied
+                  </>
+                ) : (
+                  <>
+                    <Copy className="h-4 w-4" /> Copy address
+                  </>
+                )}
+              </button>
+
+              <p className="mt-3 text-center text-[11px] text-muted-foreground">
+                Only send assets on <span className="font-medium text-foreground">Base</span> to this address.
+              </p>
+            </>
+          ) : (
+            <div className="rounded-xl border border-border bg-secondary/40 p-4 text-center text-sm text-muted-foreground">
+              Setting up your wallet… check back in a moment.
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/context/MoneyActionsContext.tsx
+++ b/app/src/context/MoneyActionsContext.tsx
@@ -5,9 +5,11 @@ import SendModal from '@/components/app-ui/SendModal';
 import RequestModal from '@/components/app-ui/RequestModal';
 import TransferModal from '@/components/app-ui/TransferModal';
 import AutoSaveModal from '@/components/app-ui/AutoSaveModal';
+import ReceiveModal from '@/components/app-ui/ReceiveModal';
 
 interface MoneyActionsValue {
   openAddMoney: () => void;
+  openReceive: () => void;
   openWithdraw: () => void;
   openSend: () => void;
   openRequest: () => void;
@@ -21,6 +23,7 @@ export function useMoneyActions(): MoneyActionsValue {
   return (
     useContext(Ctx) ?? {
       openAddMoney: () => {},
+      openReceive: () => {},
       openWithdraw: () => {},
       openSend: () => {},
       openRequest: () => {},
@@ -32,6 +35,7 @@ export function useMoneyActions(): MoneyActionsValue {
 
 export function MoneyActionsProvider({ children }: { children: ReactNode }) {
   const [addOpen, setAddOpen] = useState(false);
+  const [receiveOpen, setReceiveOpen] = useState(false);
   const [withdrawOpen, setWithdrawOpen] = useState(false);
   const [sendOpen, setSendOpen] = useState(false);
   const [requestOpen, setRequestOpen] = useState(false);
@@ -44,6 +48,7 @@ export function MoneyActionsProvider({ children }: { children: ReactNode }) {
         // not at open — provider off-ramps/on-ramps (instant debit, card) KYC their own users and
         // on-chain moves need none. AddMoney, Withdraw and Transfer each gate their bank path.
         openAddMoney: () => setAddOpen(true),
+        openReceive: () => setReceiveOpen(true),
         openWithdraw: () => setWithdrawOpen(true),
         openSend: () => setSendOpen(true),
         openRequest: () => setRequestOpen(true),
@@ -53,6 +58,7 @@ export function MoneyActionsProvider({ children }: { children: ReactNode }) {
     >
       {children}
       <AddMoneyModal open={addOpen} onOpenChange={setAddOpen} />
+      <ReceiveModal open={receiveOpen} onOpenChange={setReceiveOpen} />
       <WithdrawModal open={withdrawOpen} onOpenChange={setWithdrawOpen} />
       <SendModal open={sendOpen} onOpenChange={setSendOpen} />
       <RequestModal open={requestOpen} onOpenChange={setRequestOpen} />


### PR DESCRIPTION
Adds a Receive quick action + modal showing the user's smart-wallet deposit address as a QR + copyable string (Send USDC on Base). No more hunting in the Privy dashboard.