### PR TITLE
fix(privy): smart-wallet money flows use correct chain + smart-wallet address

### DIFF
--- a/app/src/components/app-ui/AutoSaveModal.tsx
+++ b/app/src/components/app-ui/AutoSaveModal.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { useAccount } from 'wagmi';
 import { useAppKitAccount } from '@/lib/walletCompat';
 import { useSmartWallets } from '@privy-io/react-auth/smart-wallets';
 import { Check, Loader2, Repeat, Sparkles, Trash2, TriangleAlert, Zap } from 'lucide-react';
@@ -25,9 +24,8 @@ const CADENCES: { id: AutopayCadence; label: string }[] = [
 ];
 
 export default function AutoSaveModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
-  const { address } = useAccount();
-  const { embeddedWalletInfo } = useAppKitAccount();
-  const { client: smartWalletClient } = useSmartWallets();
+  const { address, embeddedWalletInfo } = useAppKitAccount();
+  const { getClientForChain } = useSmartWallets();
   const isSmartAccount = embeddedWalletInfo?.accountType === 'smartAccount';
   const bal = useClearBalances();
   const chainId = ACTIVE_CHAIN_ID;
@@ -73,6 +71,7 @@ export default function AutoSaveModal({ open, onOpenChange }: { open: boolean; o
     setStep('working');
     setError(null);
     try {
+      const smartWalletClient = isSmartAccount ? await getClientForChain({ id: chainId }) : undefined;
       await installAutopaySession({ chainId, ownerWallet: address, amountUsdc: amount, cadence, runs, isSmartAccount, smartWalletClient });
       await loadRules();
       setStep('done');

--- a/app/src/components/app-ui/SendModal.tsx
+++ b/app/src/components/app-ui/SendModal.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useAccount } from 'wagmi';
 import { useAppKitAccount } from '@/lib/walletCompat';
 import { useSmartWallets } from '@privy-io/react-auth/smart-wallets';
 import { ACTIVE_CHAIN_ID } from '@/lib/clearNetwork';
@@ -39,9 +38,8 @@ interface Source {
 export default function SendModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
   const { contacts, getContact, openManager } = useContacts();
   const { accounts } = useExternalAccounts();
-  const { address } = useAccount();
-  const { embeddedWalletInfo } = useAppKitAccount();
-  const { client: smartWalletClient } = useSmartWallets();
+  const { address, embeddedWalletInfo } = useAppKitAccount();
+  const { getClientForChain } = useSmartWallets();
   const isSmartAccount = embeddedWalletInfo?.accountType === 'smartAccount';
   const chainId = ACTIVE_CHAIN_ID; // mainnet on app.useclear.org, Base Sepolia on the demo
   const bal = useClearBalances();
@@ -128,9 +126,12 @@ export default function SendModal({ open, onOpenChange }: { open: boolean; onOpe
           const confirmed = await confirmSendTransferLock(t.id, { transferId: t.transferId, escrowTxHash: txHash, aa: true });
           return confirmed?.claimUrl ?? null;
         };
-        if (isSmartAccount && smartWalletClient) {
+        // Bind the smart-wallet client to THIS chain (default client is on Privy's defaultChain, not
+        // necessarily ACTIVE_CHAIN_ID) so the lock UserOp lands on the right chain.
+        const chainClient = isSmartAccount ? await getClientForChain({ id: chainId }) : undefined;
+        if (isSmartAccount && chainClient) {
           // Tier 1: Privy smart wallet — sponsored + silent; no relayer fallback (1271 can't sign EIP-3009).
-          claim = await scLock(smartWalletClient);
+          claim = await scLock(chainClient);
         } else {
           // External: Tier 2 (EIP-5792 + 7702, sponsored) → Tier 3 (EIP-3009 relayer) graceful fallback.
           try {

--- a/app/src/components/app-ui/TransferModal.tsx
+++ b/app/src/components/app-ui/TransferModal.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { useAccount } from 'wagmi';
 import { useAppKitAccount } from '@/lib/walletCompat';
 import { useSmartWallets } from '@privy-io/react-auth/smart-wallets';
 import { ACTIVE_CHAIN_ID } from '@/lib/clearNetwork';
@@ -41,9 +40,8 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
   const { accounts: external, openManager } = useExternalAccounts();
   const { verified, openKyc } = useKyc();
   const bal = useClearBalances();
-  const { address } = useAccount();
-  const { embeddedWalletInfo } = useAppKitAccount();
-  const { client: smartWalletClient } = useSmartWallets();
+  const { address, embeddedWalletInfo } = useAppKitAccount();
+  const { getClientForChain } = useSmartWallets();
   const isSmartAccount = embeddedWalletInfo?.accountType === 'smartAccount';
   const chainId = ACTIVE_CHAIN_ID; // mainnet on app.useclear.org, Base Sepolia on the demo
   const accounts: Acct[] = [
@@ -99,9 +97,13 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
         const scRun = isDeposit ? scDeposit : scRedeem;
         const relayerRun = isDeposit ? gaslessDeposit : gaslessRedeem;
         let hash: string;
-        if (isSmartAccount && smartWalletClient) {
+        // Bind the smart-wallet client to THIS chain. The default client sits on Privy's defaultChain
+        // (Base mainnet); ACTIVE_CHAIN_ID is Base Sepolia on the demo — without this the UserOp lands on
+        // the wrong chain (or nowhere), which is why it "succeeded" with no on-chain tx where you looked.
+        const chainClient = isSmartAccount ? await getClientForChain({ id: chainId }) : undefined;
+        if (isSmartAccount && chainClient) {
           // Tier 1: Privy smart wallet — sponsored + silent; no relayer fallback (1271 can't sign EIP-3009).
-          hash = await scRun({ smartWalletClient, ownerWallet: address, amount: amountStr, chainId });
+          hash = await scRun({ smartWalletClient: chainClient, ownerWallet: address, amount: amountStr, chainId });
         } else {
           // External: Tier 2 (EIP-5792 + 7702, sponsored) → Tier 3 (EIP-3009 relayer) graceful fallback.
           try {


### PR DESCRIPTION
Transfer/Send appeared to succeed (optimistic UI) but no on-chain tx: the smart-wallet client was bound to Privy's defaultChain (mainnet) not ACTIVE_CHAIN_ID (Base Sepolia), and ownerWallet/receiver used the embedded EOA not the smart wallet. Fixed via getClientForChain + useAppKitAccount address.