### PR TITLE
feat(privy): identity-only login, linked wallets (view + on-chain transfers)

### DIFF
--- a/app/src/AppKitProvider.tsx
+++ b/app/src/AppKitProvider.tsx
@@ -68,7 +68,9 @@ export function AppKitProvider({ children }: { children: React.ReactNode }) {
     <PrivyProvider
       appId={appId ?? ''}
       config={{
-        loginMethods: ['email', 'wallet', 'google', 'apple', 'twitter', 'github', 'discord', 'farcaster'],
+        // Login = identity only (email / phone / social). External wallets are NOT a login — users link
+        // them in-app (Privy linked accounts). The Privy smart wallet is the user's primary wallet.
+        loginMethods: ['email', 'sms', 'google', 'apple', 'twitter', 'github', 'discord', 'farcaster'],
         // Email/social users get an embedded EOA; Smart Wallets (dashboard) layer a Kernel SA on top.
         // showWalletUIs:false → the embedded signer signs SILENTLY (no Privy confirm/approve popups).
         // Our own Review screen is the confirmation; smart-wallet sendTransaction defaults to this flag.

--- a/app/src/components/app-ui/LinkedWalletsModal.tsx
+++ b/app/src/components/app-ui/LinkedWalletsModal.tsx
@@ -1,110 +1,69 @@
-import { useState } from 'react';
-import { Loader2, Plus, ShieldCheck, Star, Trash2, Wallet } from 'lucide-react';
+import { Plus, ShieldCheck, Trash2, Wallet } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useLinkedWallets } from '@/context/LinkedWalletsContext';
-import { cn } from '@/lib/utils';
 
-const rand = () => Math.random().toString(16).slice(2, 6).toUpperCase();
-const mockAddress = () => `0x${rand()}…${rand().slice(0, 2)}${rand().slice(0, 2)}`;
+const shorten = (a: string) => (a.length > 12 ? `${a.slice(0, 6)}…${a.slice(-4)}` : a);
 
 /**
- * Manage the user's linked wallets: set a primary, remove one, or link a new one by
- * connecting + signing to prove ownership (mocked here; real flow uses AppKit connect +
- * a signature challenge). The Add-money / Withdraw pickers read this list.
+ * Manage wallets. The Clear smart wallet is your PRIMARY (holds funds, can't be unlinked). Link
+ * external wallets (MetaMask etc.) via Privy to view their balances and transfer USDC/CLRUSD on-chain.
+ * Linking opens Privy's connect + signature flow; unlinking removes it from your Privy account.
  */
 export default function LinkedWalletsModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
-  const { wallets, primaryId, setPrimary, removeWallet, addWallet } = useLinkedWallets();
-  const [linking, setLinking] = useState(false);
-
-  const linkWallet = () => {
-    setLinking(true);
-    setTimeout(() => {
-      addWallet(`Wallet ${wallets.length + 1}`, mockAddress());
-      setLinking(false);
-    }, 1900);
-  };
+  const { wallets, linkWallet, removeWallet } = useLinkedWallets();
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(o) => {
-        if (!linking) onOpenChange(o);
-      }}
-    >
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[440px]">
         <DialogHeader>
-          <DialogTitle>Linked wallets</DialogTitle>
+          <DialogTitle>Wallets</DialogTitle>
         </DialogHeader>
 
-        {linking ? (
-          <div className="flex flex-col items-center justify-center py-12 text-center">
-            <Loader2 className="h-9 w-9 animate-spin text-muted-foreground" />
-            <div className="mt-4 text-sm font-medium text-foreground">Connecting &amp; verifying…</div>
-            <div className="mt-1 text-xs text-muted-foreground">Sign the message in your wallet to prove you own it.</div>
-          </div>
-        ) : (
-          <>
-            <p className="text-xs leading-relaxed text-muted-foreground">
-              Money you add or withdraw moves through these wallets. Link one by connecting and signing to prove ownership.
-            </p>
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          Your Clear account is your primary wallet. Link external wallets to view their balances and move
+          USDC or CLRUSD on-chain.
+        </p>
 
-            <div className="mt-3 space-y-2">
-              {wallets.map((w) => {
-                const isPrimary = w.id === primaryId;
-                return (
-                  <div key={w.id} className="flex items-center gap-3 rounded-xl border border-border p-3">
-                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
-                      <Wallet className="h-[18px] w-[18px]" />
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-1.5">
-                        <span className="truncate text-sm font-medium text-foreground">{w.label}</span>
-                        {isPrimary && (
-                          <span className="shrink-0 rounded-full bg-positive/10 px-1.5 py-0.5 text-[10px] font-medium text-positive">Primary</span>
-                        )}
-                      </div>
-                      <div className="truncate text-xs tabular-nums text-muted-foreground">{w.address}</div>
-                    </div>
-                    {!isPrimary && (
-                      <button
-                        type="button"
-                        onClick={() => setPrimary(w.id)}
-                        aria-label="Set as primary"
-                        className="shrink-0 rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
-                      >
-                        <Star className="h-4 w-4" />
-                      </button>
-                    )}
-                    {wallets.length > 1 && (
-                      <button
-                        type="button"
-                        onClick={() => removeWallet(w.id)}
-                        aria-label="Remove wallet"
-                        className="shrink-0 rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-negative/10 hover:text-negative"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-
-            <button
-              type="button"
-              onClick={linkWallet}
-              className={cn(
-                'mt-3 flex w-full items-center justify-center gap-1.5 rounded-xl border border-dashed border-border py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:border-foreground/40 hover:text-foreground',
+        <div className="mt-3 space-y-2">
+          {wallets.map((w) => (
+            <div key={w.id} className="flex items-center gap-3 rounded-xl border border-border p-3">
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
+                <Wallet className="h-[18px] w-[18px]" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5">
+                  <span className="truncate text-sm font-medium text-foreground">{w.label}</span>
+                  {w.isPrimary && (
+                    <span className="shrink-0 rounded-full bg-positive/10 px-1.5 py-0.5 text-[10px] font-medium text-positive">Primary</span>
+                  )}
+                </div>
+                <div className="truncate text-xs tabular-nums text-muted-foreground">{shorten(w.address)}</div>
+              </div>
+              {w.external && (
+                <button
+                  type="button"
+                  onClick={() => removeWallet(w.id)}
+                  aria-label="Unlink wallet"
+                  className="shrink-0 rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-negative/10 hover:text-negative"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
               )}
-            >
-              <Plus className="h-4 w-4" /> Link a wallet
-            </button>
+            </div>
+          ))}
+        </div>
 
-            <p className="mt-3 flex items-center justify-center gap-1 text-center text-[11px] text-muted-foreground">
-              <ShieldCheck className="h-3 w-3" /> Only wallets you've verified can receive or send funds.
-            </p>
-          </>
-        )}
+        <button
+          type="button"
+          onClick={linkWallet}
+          className="mt-3 flex w-full items-center justify-center gap-1.5 rounded-xl border border-dashed border-border py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:border-foreground/40 hover:text-foreground"
+        >
+          <Plus className="h-4 w-4" /> Link a wallet
+        </button>
+
+        <p className="mt-3 flex items-center justify-center gap-1 text-center text-[11px] text-muted-foreground">
+          <ShieldCheck className="h-3 w-3" /> Linking proves ownership with a signature — Clear never moves funds without you.
+        </p>
       </DialogContent>
     </Dialog>
   );

--- a/app/src/components/app-ui/LinkedWalletsModal.tsx
+++ b/app/src/components/app-ui/LinkedWalletsModal.tsx
@@ -1,16 +1,29 @@
-import { Plus, ShieldCheck, Trash2, Wallet } from 'lucide-react';
+import { ExternalLink, Plus, ShieldCheck, Trash2, Wallet } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useLinkedWallets } from '@/context/LinkedWalletsContext';
+import { useClearBalances } from '@/hooks/useClearBalances';
+import { useLinkedWalletBalances } from '@/hooks/useLinkedWalletBalances';
+import { ACTIVE_CHAIN_ID } from '@/lib/clearNetwork';
 
 const shorten = (a: string) => (a.length > 12 ? `${a.slice(0, 6)}…${a.slice(-4)}` : a);
+const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const explorerBase = ACTIVE_CHAIN_ID === 84532 ? 'https://sepolia.basescan.org' : 'https://basescan.org';
 
 /**
  * Manage wallets. The Clear smart wallet is your PRIMARY (holds funds, can't be unlinked). Link
  * external wallets (MetaMask etc.) via Privy to view their balances and transfer USDC/CLRUSD on-chain.
- * Linking opens Privy's connect + signature flow; unlinking removes it from your Privy account.
+ * Balances: the primary comes from useClearBalances; linked wallets from Alchemy tokens/by-address
+ * (one cheap call, only while this modal is open). "View transactions" links out to the explorer.
  */
 export default function LinkedWalletsModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
-  const { wallets, linkWallet, removeWallet } = useLinkedWallets();
+  const { wallets, externalWallets, linkWallet, removeWallet } = useLinkedWallets();
+  const clear = useClearBalances();
+  const { balances, loading } = useLinkedWalletBalances(externalWallets.map((w) => w.address), open);
+
+  const balanceFor = (w: { isPrimary: boolean; address: string }) => {
+    if (w.isPrimary) return { usdc: clear.cash, clrusd: clear.savings };
+    return balances[w.address.toLowerCase()];
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -25,32 +38,48 @@ export default function LinkedWalletsModal({ open, onOpenChange }: { open: boole
         </p>
 
         <div className="mt-3 space-y-2">
-          {wallets.map((w) => (
-            <div key={w.id} className="flex items-center gap-3 rounded-xl border border-border p-3">
-              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
-                <Wallet className="h-[18px] w-[18px]" />
-              </span>
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-1.5">
-                  <span className="truncate text-sm font-medium text-foreground">{w.label}</span>
-                  {w.isPrimary && (
-                    <span className="shrink-0 rounded-full bg-positive/10 px-1.5 py-0.5 text-[10px] font-medium text-positive">Primary</span>
-                  )}
+          {wallets.map((w) => {
+            const bal = balanceFor(w);
+            return (
+              <div key={w.id} className="flex items-center gap-3 rounded-xl border border-border p-3">
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
+                  <Wallet className="h-[18px] w-[18px]" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5">
+                    <span className="truncate text-sm font-medium text-foreground">{w.label}</span>
+                    {w.isPrimary && (
+                      <span className="shrink-0 rounded-full bg-positive/10 px-1.5 py-0.5 text-[10px] font-medium text-positive">Primary</span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <span className="tabular-nums">{shorten(w.address)}</span>
+                    <a
+                      href={`${explorerBase}/address/${w.address}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-0.5 text-muted-foreground/80 transition-colors hover:text-foreground"
+                    >
+                      Transactions <ExternalLink className="h-3 w-3" />
+                    </a>
+                  </div>
+                  <div className="mt-0.5 text-xs tabular-nums text-foreground/80">
+                    {bal ? `${fmt(bal.usdc)} USDC · ${fmt(bal.clrusd)} CLRUSD` : loading && !w.isPrimary ? 'Loading…' : `${fmt(0)} USDC · ${fmt(0)} CLRUSD`}
+                  </div>
                 </div>
-                <div className="truncate text-xs tabular-nums text-muted-foreground">{shorten(w.address)}</div>
+                {w.external && (
+                  <button
+                    type="button"
+                    onClick={() => removeWallet(w.id)}
+                    aria-label="Unlink wallet"
+                    className="shrink-0 self-start rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-negative/10 hover:text-negative"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                )}
               </div>
-              {w.external && (
-                <button
-                  type="button"
-                  onClick={() => removeWallet(w.id)}
-                  aria-label="Unlink wallet"
-                  className="shrink-0 rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-negative/10 hover:text-negative"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
-              )}
-            </div>
-          ))}
+            );
+          })}
         </div>
 
         <button

--- a/app/src/components/app-ui/TransferModal.tsx
+++ b/app/src/components/app-ui/TransferModal.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useState } from 'react';
 import { useAppKitAccount } from '@/lib/walletCompat';
 import { useSmartWallets } from '@privy-io/react-auth/smart-wallets';
-import { ACTIVE_CHAIN_ID } from '@/lib/clearNetwork';
+import { ACTIVE_CHAIN_ID, clearContracts } from '@/lib/clearNetwork';
 import { ArrowDownUp, ArrowLeft, Check, ChevronDown, Landmark, Loader2, PiggyBank, ShieldCheck, TriangleAlert, Wallet, Zap } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { useExternalAccounts } from '@/context/ExternalAccountsContext';
+import { useLinkedWallets } from '@/context/LinkedWalletsContext';
 import { useKyc } from '@/context/KycContext';
 import { useClearBalances } from '@/hooks/useClearBalances';
 import { gaslessDeposit, gaslessRedeem } from '@/lib/gaslessMoney';
-import { scDeposit, scRedeem } from '@/lib/sendCalls';
+import { scDeposit, scRedeem, scTransferToken } from '@/lib/sendCalls';
 import { cn } from '@/lib/utils';
 
 /*
@@ -22,22 +23,28 @@ import { cn } from '@/lib/utils';
  * needs a SEPARATE ACH processor (e.g. Plaid Transfer / Dwolla / processor token); KYC-gated.
  */
 
-type Scope = 'internal' | 'external';
+type Scope = 'internal' | 'external' | 'wallet';
 interface Acct {
   id: string;
   name: string;
   detail: string;
   scope: Scope;
   balance?: number;
+  address?: string; // linked-wallet on-chain destination
   icon: typeof Wallet;
 }
 
 const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const shorten = (a: string) => (a.length > 12 ? `${a.slice(0, 6)}…${a.slice(-4)}` : a);
+// Allowed "To" scopes for a given "From": internal can go internal (deposit/redeem) or to a linked
+// wallet (on-chain send); external stays bank↔bank. (Linked wallets aren't a "From" yet — see #3b.)
+const toScopesFor = (s?: Scope): Scope[] => (s === 'internal' ? ['internal', 'wallet'] : s === 'external' ? ['external'] : ['internal']);
 const QUICK = [50, 100, 500, 1000];
 const INSTANT_FEE = 0.015;
 
 export default function TransferModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
   const { accounts: external, openManager } = useExternalAccounts();
+  const { externalWallets } = useLinkedWallets();
   const { verified, openKyc } = useKyc();
   const bal = useClearBalances();
   const { address, embeddedWalletInfo } = useAppKitAccount();
@@ -48,6 +55,7 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
     { id: 'cash', name: 'Cash', detail: 'USDC', scope: 'internal', balance: bal.cash, icon: Wallet },
     { id: 'savings', name: 'Savings', detail: 'CLRUSD', scope: 'internal', balance: bal.savings, icon: PiggyBank },
     ...external.map((a) => ({ id: a.id, name: a.name, detail: `${a.type} ••${a.mask}`, scope: 'external' as Scope, icon: Landmark })),
+    ...externalWallets.map((w) => ({ id: w.id, name: w.label, detail: shorten(w.address), scope: 'wallet' as Scope, address: w.address, icon: Wallet })),
   ];
 
   const [step, setStep] = useState<'compose' | 'review' | 'status'>('compose');
@@ -84,32 +92,39 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
       return () => clearTimeout(t);
     }
 
-    // Internal Cash↔Savings = real gasless deposit/redeem against the ESA vault.
+    // Internal Cash↔Savings (ESA mint/redeem) and Cash/Savings → linked wallet (ERC-20 transfer) —
+    // all real, gasless, on-chain via the smart wallet.
     let cancelled = false;
     (async () => {
       try {
         if (!address) throw new Error('Connect your wallet to transfer.');
         const isDeposit = fromId === 'cash' && toId === 'savings';
         const isRedeem = fromId === 'savings' && toId === 'cash';
-        if (!isDeposit && !isRedeem) throw new Error('Unsupported transfer.');
-        // Smart accounts (AppKit email/social) MUST use EIP-5792 — the EIP-3009 relayer can't validate
-        // their EIP-1271 signature. EOAs use EIP-3009 (gasless), or 5792 if their wallet advertises it.
-        const scRun = isDeposit ? scDeposit : scRedeem;
-        const relayerRun = isDeposit ? gaslessDeposit : gaslessRedeem;
-        let hash: string;
-        // Bind the smart-wallet client to THIS chain. The default client sits on Privy's defaultChain
-        // (Base mainnet); ACTIVE_CHAIN_ID is Base Sepolia on the demo — without this the UserOp lands on
-        // the wrong chain (or nowhere), which is why it "succeeded" with no on-chain tx where you looked.
+        const isOnchainOut = (fromId === 'cash' || fromId === 'savings') && to?.scope === 'wallet';
+        if (!isDeposit && !isRedeem && !isOnchainOut) throw new Error('Unsupported transfer.');
+        // Bind the smart-wallet client to THIS chain (default client sits on Privy's defaultChain, not
+        // necessarily ACTIVE_CHAIN_ID) so the UserOp lands on-chain.
         const chainClient = isSmartAccount ? await getClientForChain({ id: chainId }) : undefined;
-        if (isSmartAccount && chainClient) {
-          // Tier 1: Privy smart wallet — sponsored + silent; no relayer fallback (1271 can't sign EIP-3009).
-          hash = await scRun({ smartWalletClient: chainClient, ownerWallet: address, amount: amountStr, chainId });
+        let hash: string;
+        if (isOnchainOut) {
+          // Cash (USDC) or Savings (CLRUSD) → linked external wallet: one sponsored ERC-20 transfer.
+          if (!chainClient) throw new Error('Your wallet is still setting up — try again in a moment.');
+          const c = clearContracts(chainId);
+          if (!c) throw new Error('On-chain transfers are unavailable on this network.');
+          const token = fromId === 'cash' ? c.usdc : c.clrusd;
+          hash = await scTransferToken({ smartWalletClient: chainClient, ownerWallet: address, token, to: to!.address as `0x${string}`, amount: amountStr, chainId });
         } else {
-          // External: Tier 2 (EIP-5792 + 7702, sponsored) → Tier 3 (EIP-3009 relayer) graceful fallback.
-          try {
-            hash = await scRun({ ownerWallet: address, amount: amountStr, chainId });
-          } catch {
-            hash = await relayerRun({ ownerWallet: address, amount: amountStr, chainId });
+          // Smart accounts use the sponsored UserOp; EOAs use the EIP-3009 relayer (gasless) as fallback.
+          const scRun = isDeposit ? scDeposit : scRedeem;
+          const relayerRun = isDeposit ? gaslessDeposit : gaslessRedeem;
+          if (isSmartAccount && chainClient) {
+            hash = await scRun({ smartWalletClient: chainClient, ownerWallet: address, amount: amountStr, chainId });
+          } else {
+            try {
+              hash = await scRun({ ownerWallet: address, amount: amountStr, chainId });
+            } catch {
+              hash = await relayerRun({ ownerWallet: address, amount: amountStr, chainId });
+            }
           }
         }
         if (cancelled) return;
@@ -118,7 +133,9 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
         // Optimistic: reflect the move immediately, reconcile when the chain indexes.
         const amt = Number(amountStr) || 0;
         if (isDeposit) bal.applyOptimistic(-amt, amt);
-        else bal.applyOptimistic(amt, -amt);
+        else if (isRedeem) bal.applyOptimistic(amt, -amt);
+        else if (fromId === 'cash') bal.applyOptimistic(-amt, 0); // on-chain out from Cash
+        else bal.applyOptimistic(0, -amt); // on-chain out from Savings
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : 'Transfer failed.');
       }
@@ -130,8 +147,8 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
   }, [step]);
 
   const from = accounts.find((a) => a.id === fromId) ?? accounts[0];
-  const toOptions = accounts.filter((a) => a.scope === from?.scope && a.id !== fromId);
-  const to = accounts.find((a) => a.id === toId && a.scope === from?.scope) ?? toOptions[0];
+  const toOptions = accounts.filter((a) => toScopesFor(from?.scope).includes(a.scope) && a.id !== fromId);
+  const to = accounts.find((a) => a.id === toId && toScopesFor(from?.scope).includes(a.scope)) ?? toOptions[0];
   const isExternal = from?.scope === 'external';
 
   // keep `to` valid when `from` (and thus scope) changes
@@ -256,7 +273,7 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
 
             {/* from → swap → to */}
             <div className="relative mt-5 space-y-2">
-              <Picker label="From" acct={from} isOpen={fromOpen} setOpen={(o) => { setFromOpen(o); setToOpen(false); }} options={accounts} />
+              <Picker label="From" acct={from} isOpen={fromOpen} setOpen={(o) => { setFromOpen(o); setToOpen(false); }} options={accounts.filter((a) => a.scope !== 'wallet')} />
               <div className="flex justify-center">
                 <button
                   type="button"
@@ -362,7 +379,7 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
               Transfer {fmt(amount)}
             </button>
             <p className="mt-2 flex items-center justify-center gap-1 text-center text-[11px] text-muted-foreground">
-              <ShieldCheck className="h-3 w-3" /> {isExternal ? 'Securely via your bank' : 'Stays within your Clear accounts'}
+              <ShieldCheck className="h-3 w-3" /> {isExternal ? 'Securely via your bank' : to?.scope === 'wallet' ? 'On-chain to your linked wallet · gasless' : 'Stays within your Clear accounts'}
             </p>
           </div>
         )}

--- a/app/src/context/LinkedWalletsContext.tsx
+++ b/app/src/context/LinkedWalletsContext.tsx
@@ -1,73 +1,103 @@
 import { createContext, useContext, useState, type ReactNode } from 'react';
+import { useLinkAccount, useUnlinkWallet, usePrivy } from '@privy-io/react-auth';
+import { useAppKitAccount } from '@/lib/walletCompat';
 import LinkedWalletsModal from '@/components/app-ui/LinkedWalletsModal';
 
 export interface LinkedWallet {
-  id: string;
+  id: string; // 'smart' for the Clear wallet, else the lowercased address
   label: string;
   address: string;
+  isPrimary: boolean; // the Clear smart wallet (primary, can't be unlinked)
+  external: boolean; // a Privy-linked external wallet (MetaMask etc.)
 }
 
 interface LinkedWalletsValue {
-  wallets: LinkedWallet[];
+  wallets: LinkedWallet[]; // [Clear smart wallet] + external linked wallets
+  externalWallets: LinkedWallet[]; // external only
   primaryId: string;
   primary: LinkedWallet | undefined;
-  addWallet: (label: string, address: string, makePrimary?: boolean) => string;
-  setPrimary: (id: string) => void;
-  removeWallet: (id: string) => void;
+  smartWallet: string | undefined; // the Clear smart-wallet address (primary)
+  linkWallet: () => void; // Privy connect + link an external wallet
+  removeWallet: (id: string) => void; // unlink an external wallet (no-op for primary)
   openManager: () => void;
 }
 
 const Ctx = createContext<LinkedWalletsValue | null>(null);
 
 /**
- * The user's linked (connected + signature-verified) wallets — the source of truth for the
- * Add-money destination and Withdraw source pickers, and managed via the LinkedWalletsModal.
- * In production the AppKit-connected wallet is auto-linked as primary; seeded with mock here.
+ * The user's wallets. The Clear smart wallet (Privy) is PRIMARY — it holds funds and is the fiat
+ * on/off-ramp endpoint. External wallets are LINKED via Privy (user.linkedAccounts) for two things:
+ * viewing their balances/txns and on-chain USDC/CLRUSD transfers to/from the Clear wallet. Login is
+ * identity-only, so external wallets are never a login — only linked here. See [[clearpath-privy-migration]].
  */
 export function useLinkedWallets(): LinkedWalletsValue {
   return (
     useContext(Ctx) ?? {
       wallets: [],
-      primaryId: '',
+      externalWallets: [],
+      primaryId: 'smart',
       primary: undefined,
-      addWallet: () => '',
-      setPrimary: () => {},
+      smartWallet: undefined,
+      linkWallet: () => {},
       removeWallet: () => {},
       openManager: () => {},
     }
   );
 }
 
-const SEED: LinkedWallet[] = [
-  { id: 'w1', label: 'Main account', address: '0x12A4…9b3F' },
-  { id: 'w2', label: 'Savings vault', address: '0x88cD…2e1A' },
-];
+const prettyClient = (t?: string) => {
+  if (!t) return 'Wallet';
+  const map: Record<string, string> = {
+    metamask: 'MetaMask',
+    rabby: 'Rabby',
+    coinbase_wallet: 'Coinbase Wallet',
+    rainbow: 'Rainbow',
+    phantom: 'Phantom',
+    wallet_connect: 'WalletConnect',
+    zerion: 'Zerion',
+  };
+  return map[t] ?? t.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+};
+
+type RawLinked = { type?: string; address?: string; walletClientType?: string; chainType?: string };
 
 export function LinkedWalletsProvider({ children }: { children: ReactNode }) {
-  const [wallets, setWallets] = useState<LinkedWallet[]>(SEED);
-  const [primaryId, setPrimaryId] = useState('w1');
+  const { user } = usePrivy();
+  const { address: smartWallet } = useAppKitAccount();
+  const { linkWallet: privyLinkWallet } = useLinkAccount();
+  const { unlink } = useUnlinkWallet();
   const [managerOpen, setManagerOpen] = useState(false);
 
-  const addWallet = (label: string, address: string, makePrimary = false) => {
-    const id = `w${Date.now()}`;
-    setWallets((ws) => [...ws, { id, label, address }]);
-    if (makePrimary) setPrimaryId(id);
-    return id;
+  // External wallets linked to the Privy user (exclude the embedded/smart 'privy' wallet).
+  const externalWallets: LinkedWallet[] = ((user?.linkedAccounts as RawLinked[] | undefined) ?? [])
+    .filter((a) => a.type === 'wallet' && a.walletClientType !== 'privy' && (a.chainType ? a.chainType === 'ethereum' : true))
+    .filter((a) => !!a.address && a.address.toLowerCase() !== smartWallet?.toLowerCase())
+    .map((a) => ({
+      id: (a.address ?? '').toLowerCase(),
+      label: prettyClient(a.walletClientType),
+      address: a.address ?? '',
+      isPrimary: false,
+      external: true,
+    }));
+
+  const primary: LinkedWallet | undefined = smartWallet
+    ? { id: 'smart', label: 'Clear account', address: smartWallet, isPrimary: true, external: false }
+    : undefined;
+
+  const wallets: LinkedWallet[] = [...(primary ? [primary] : []), ...externalWallets];
+
+  const removeWallet = (id: string) => {
+    const w = externalWallets.find((x) => x.id === id);
+    if (w?.address) void unlink({ address: w.address }).catch(() => {});
   };
-  const setPrimary = (id: string) => setPrimaryId(id);
-  const removeWallet = (id: string) =>
-    setWallets((ws) => {
-      const next = ws.filter((w) => w.id !== id);
-      if (id === primaryId && next[0]) setPrimaryId(next[0].id);
-      return next;
-    });
 
   const value: LinkedWalletsValue = {
     wallets,
-    primaryId,
-    primary: wallets.find((w) => w.id === primaryId) ?? wallets[0],
-    addWallet,
-    setPrimary,
+    externalWallets,
+    primaryId: 'smart',
+    primary,
+    smartWallet,
+    linkWallet: () => privyLinkWallet(),
     removeWallet,
     openManager: () => setManagerOpen(true),
   };

--- a/app/src/hooks/useLinkedWalletBalances.ts
+++ b/app/src/hooks/useLinkedWalletBalances.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import { ethers } from 'ethers';
+import { getTokensByAddressPortfolio } from '@/utils/apiClient';
+import { ACTIVE_CHAIN_ID, clearContracts } from '@/lib/clearNetwork';
+
+export interface LinkedBalance {
+  usdc: number;
+  clrusd: number;
+}
+
+/**
+ * USDC/CLRUSD balances for a set of addresses via Alchemy's `tokens/by-address` Data API — one cheap
+ * call per ≤2 addresses (Alchemy's documented cap), prices off (we treat both as $1). Runs ONLY while
+ * `enabled` (e.g. the Wallets modal is open), so it costs nothing on idle. The smart wallet's balance
+ * comes from useClearBalances; this is for the linked external wallets. See [[clearpath-alchemy-cu]].
+ */
+export function useLinkedWalletBalances(addresses: string[], enabled: boolean) {
+  const [balances, setBalances] = useState<Record<string, LinkedBalance>>({});
+  const [loading, setLoading] = useState(false);
+  const key = enabled ? addresses.map((a) => a.toLowerCase()).sort().join(',') : '';
+
+  useEffect(() => {
+    if (!enabled || addresses.length === 0) {
+      setBalances({});
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      const c = clearContracts(ACTIVE_CHAIN_ID);
+      const usdcAddr = c?.usdc?.toLowerCase();
+      const clrusdAddr = c?.clrusd?.toLowerCase();
+      const out: Record<string, LinkedBalance> = {};
+      // Alchemy tokens/by-address caps at 2 addresses/request → batch by 2 (usually just one call).
+      for (let i = 0; i < addresses.length; i += 2) {
+        const batch = addresses.slice(i, i + 2);
+        const { results } = await getTokensByAddressPortfolio(
+          batch.map((a) => ({ address: a, chainIds: [ACTIVE_CHAIN_ID] })),
+          { withMetadata: true, withPrices: false, includeNativeTokens: false, includeErc20Tokens: true },
+        ).catch(() => ({ results: [] as Array<{ address: string; tokens: unknown[] }> }));
+        for (const r of results) {
+          const addrLower = r.address?.toLowerCase();
+          if (!addrLower) continue;
+          let usdc = 0;
+          let clrusd = 0;
+          for (const raw of r.tokens ?? []) {
+            const t = raw as { tokenAddress?: string; address?: string; tokenBalance?: string; balanceRaw?: string; tokenMetadata?: { decimals?: number }; decimals?: number };
+            const ta = (t.tokenAddress ?? t.address ?? '').toLowerCase();
+            const decimals = t.tokenMetadata?.decimals ?? t.decimals ?? 6;
+            const bal = Number(ethers.formatUnits(BigInt(t.tokenBalance ?? t.balanceRaw ?? '0'), decimals));
+            if (ta === usdcAddr) usdc += bal;
+            else if (ta === clrusdAddr) clrusd += bal;
+          }
+          out[addrLower] = { usdc, clrusd };
+        }
+      }
+      if (!cancelled) {
+        setBalances(out);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, enabled]);
+
+  return { balances, loading };
+}

--- a/app/src/lib/sendCalls.ts
+++ b/app/src/lib/sendCalls.ts
@@ -25,6 +25,7 @@ const paymasterUrl = (chainId: number) =>
 
 const ERC20_ABI = [
   { name: 'approve', type: 'function', stateMutability: 'nonpayable', inputs: [{ name: 'spender', type: 'address' }, { name: 'amount', type: 'uint256' }], outputs: [{ type: 'bool' }] },
+  { name: 'transfer', type: 'function', stateMutability: 'nonpayable', inputs: [{ name: 'to', type: 'address' }, { name: 'amount', type: 'uint256' }], outputs: [{ type: 'bool' }] },
 ] as const;
 const VAULT_ABI = [
   { name: 'deposit', type: 'function', stateMutability: 'nonpayable', inputs: [{ name: 'token', type: 'address' }, { name: 'amount', type: 'uint256' }, { name: 'receiver', type: 'address' }], outputs: [{ type: 'uint256' }] },
@@ -127,5 +128,24 @@ export async function scSendLock(args: {
   return runBatch(args.smartWalletClient, args.ownerWallet, args.chainId, [
     { to: c.usdc, data: encodeFunctionData({ abi: ERC20_ABI, functionName: 'approve', args: [c.claimEscrow, total] }) },
     { to: c.claimEscrow, data: encodeFunctionData({ abi: ESCROW_ABI, functionName: 'createTransfer', args: [args.transferId, principal, fee, expiry, args.recipientHintHash] }) },
+  ]);
+}
+
+/**
+ * Cash/Savings → a linked external wallet: ONE sponsored ERC-20 transfer from the smart wallet.
+ * `token` is the canonical USDC (Cash) or CLRUSD (Savings) address; both are 6-decimals. Gasless via
+ * the smart-wallet client. The reverse (linked → smart) can't be sponsored — the external EOA signs it.
+ */
+export async function scTransferToken(args: {
+  smartWalletClient?: unknown;
+  ownerWallet: string;
+  token: `0x${string}`;
+  to: `0x${string}`;
+  amount: string;
+  chainId: number;
+}): Promise<string> {
+  const amt = parseUnits(args.amount, 6);
+  return runBatch(args.smartWalletClient, args.ownerWallet, args.chainId, [
+    { to: args.token, data: encodeFunctionData({ abi: ERC20_ABI, functionName: 'transfer', args: [args.to, amt] }) },
   ]);
 }

--- a/app/src/pages/auth/PrivyLoginControls.tsx
+++ b/app/src/pages/auth/PrivyLoginControls.tsx
@@ -1,17 +1,16 @@
 import { useState } from 'react';
-import { ArrowRight, Loader2, Mail, Wallet } from 'lucide-react';
-import { useLoginWithEmail, useLoginWithOAuth, usePrivy } from '@privy-io/react-auth';
+import { ArrowRight, Loader2, Mail, Phone } from 'lucide-react';
+import { useLoginWithEmail, useLoginWithOAuth, useLoginWithSms } from '@privy-io/react-auth';
 
 /*
- * Custom Privy login. Email is a 2-step OTP (send code → verify) and socials redirect via initOAuth —
- * both fully our UI. External wallets use Privy's own wallet login `login({ loginMethods: ['wallet'] })`,
- * which handles connect + SIWE message + signature + session INTERNALLY (a manual generateSiweMessage +
- * personal_sign produced signatures Privy's /siwe/authenticate rejected as invalid). It opens a small
- * wallet-only Privy sheet; external wallets need their own extension popup anyway. On success Privy flips
- * `authenticated` → LoginPage navigates on. See [[clearpath-privy-migration]].
+ * Custom Privy login — identity only (email / phone / social). No wallet login: external wallets are
+ * LINKED in-app (Privy linked accounts), and the Privy smart wallet is the user's primary wallet.
+ * Email & phone are 2-step OTPs (send code → verify); socials redirect via initOAuth. All our own UI.
+ * On success Privy flips `authenticated` → LoginPage navigates onward. See [[clearpath-privy-migration]].
  */
 
 type OAuthProvider = 'google' | 'apple' | 'twitter' | 'discord' | 'github';
+type Method = 'email' | 'phone';
 
 const SOCIALS: { id: OAuthProvider; label: string }[] = [
   { id: 'apple', label: 'Apple' },
@@ -20,26 +19,39 @@ const SOCIALS: { id: OAuthProvider; label: string }[] = [
   { id: 'github', label: 'GitHub' },
 ];
 
-export default function PrivyLoginControls() {
-  const { sendCode, loginWithCode } = useLoginWithEmail();
-  const { initOAuth } = useLoginWithOAuth();
-  const { login } = usePrivy();
+// Privy wants E.164 (+15551234567). Strip spaces/dashes/parens; keep a single leading +.
+const normalizePhone = (raw: string) => '+' + raw.replace(/[^\d]/g, '');
+const isValidPhone = (raw: string) => /^\+[1-9]\d{6,14}$/.test(normalizePhone(raw));
 
-  const [step, setStep] = useState<'email' | 'code'>('email');
+export default function PrivyLoginControls() {
+  const { sendCode: sendEmailCode, loginWithCode: loginWithEmailCode } = useLoginWithEmail();
+  const { sendCode: sendSmsCode, loginWithCode: loginWithSmsCode } = useLoginWithSms();
+  const { initOAuth } = useLoginWithOAuth();
+
+  const [method, setMethod] = useState<Method>('email');
+  const [step, setStep] = useState<'enter' | 'code'>('enter');
   const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
   const [code, setCode] = useState('');
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const sendEmail = async () => {
-    if (!/^\S+@\S+\.\S+$/.test(email)) {
+  const destination = method === 'email' ? email : normalizePhone(phone);
+
+  const send = async () => {
+    if (method === 'email' && !/^\S+@\S+\.\S+$/.test(email)) {
       setError('Enter a valid email address.');
       return;
     }
-    setBusy('email');
+    if (method === 'phone' && !isValidPhone(phone)) {
+      setError('Enter a valid phone number (e.g. +1 555 123 4567).');
+      return;
+    }
+    setBusy('send');
     setError(null);
     try {
-      await sendCode({ email });
+      if (method === 'email') await sendEmailCode({ email });
+      else await sendSmsCode({ phoneNumber: normalizePhone(phone) });
       setStep('code');
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Could not send the code.');
@@ -52,7 +64,8 @@ export default function PrivyLoginControls() {
     setBusy('code');
     setError(null);
     try {
-      await loginWithCode({ code });
+      if (method === 'email') await loginWithEmailCode({ code });
+      else await loginWithSmsCode({ code });
       // On success Privy authenticates; LoginPage's effect navigates onward.
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Invalid or expired code.');
@@ -72,12 +85,6 @@ export default function PrivyLoginControls() {
     }
   };
 
-  const loginWithWallet = () => {
-    setError(null);
-    // Privy handles connect + SIWE + signature + session; on success `authenticated` flips → navigate.
-    login({ loginMethods: ['wallet'] });
-  };
-
   const inputCls =
     'w-full rounded-xl border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 focus:border-foreground/30 focus:outline-none';
   const socialBtn =
@@ -87,7 +94,7 @@ export default function PrivyLoginControls() {
     return (
       <div className="mt-6 space-y-3">
         <p className="text-sm text-muted-foreground">
-          Enter the 6-digit code we sent to <span className="font-medium text-foreground">{email}</span>.
+          Enter the 6-digit code we sent to <span className="font-medium text-foreground">{destination}</span>.
         </p>
         <input
           autoFocus
@@ -110,13 +117,13 @@ export default function PrivyLoginControls() {
         <button
           type="button"
           onClick={() => {
-            setStep('email');
+            setStep('enter');
             setCode('');
             setError(null);
           }}
           className="w-full text-center text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
         >
-          ← Use a different email
+          ← Use a different {method === 'email' ? 'email' : 'phone number'}
         </button>
       </div>
     );
@@ -124,27 +131,65 @@ export default function PrivyLoginControls() {
 
   return (
     <div className="mt-6 space-y-3">
-      {/* Email */}
+      {/* Email / Phone toggle */}
+      <div className="flex gap-1 rounded-xl bg-secondary/50 p-1">
+        {([
+          { id: 'email' as const, label: 'Email', icon: Mail },
+          { id: 'phone' as const, label: 'Phone', icon: Phone },
+        ]).map((m) => (
+          <button
+            key={m.id}
+            type="button"
+            onClick={() => {
+              setMethod(m.id);
+              setError(null);
+            }}
+            className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg py-2 text-xs font-medium transition-colors ${
+              method === m.id ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            <m.icon className="h-3.5 w-3.5" /> {m.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Email or phone input */}
       <div className="flex gap-2">
         <div className="relative flex-1">
-          <Mail className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && sendEmail()}
-            placeholder="you@email.com"
-            className={`${inputCls} pl-9`}
-          />
+          {method === 'email' ? (
+            <>
+              <Mail className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && send()}
+                placeholder="you@email.com"
+                className={`${inputCls} pl-9`}
+              />
+            </>
+          ) : (
+            <>
+              <Phone className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <input
+                type="tel"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && send()}
+                placeholder="+1 555 123 4567"
+                className={`${inputCls} pl-9`}
+              />
+            </>
+          )}
         </div>
         <button
           type="button"
-          disabled={busy === 'email'}
-          onClick={sendEmail}
-          aria-label="Continue with email"
+          disabled={busy === 'send'}
+          onClick={send}
+          aria-label={`Continue with ${method}`}
           className="flex w-12 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-transform active:scale-[0.97] disabled:opacity-40"
         >
-          {busy === 'email' ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
+          {busy === 'send' ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
         </button>
       </div>
 
@@ -173,15 +218,6 @@ export default function PrivyLoginControls() {
           </button>
         ))}
       </div>
-
-      {/* Wallet */}
-      <button
-        type="button"
-        onClick={loginWithWallet}
-        className="flex w-full items-center justify-center gap-2 rounded-xl border border-border py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-secondary"
-      >
-        <Wallet className="h-4 w-4" /> Connect a wallet
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
Bundles the post-#266 work:
- Login = email/phone/social only (no wallet login); phone OTP via useLoginWithSms
- Linked wallets are real (Privy link/unlink); Clear smart wallet = primary
- Linked-wallet balances via Alchemy tokens/by-address (one cheap call, modal-open only) + explorer txn links
- Transfer Cash/Savings → a linked wallet on-chain, gasless (scTransferToken)

Reverse linked→smart transfer deferred (#3b: external EOA must sign + pay gas). Phone account-identity capture + Settings account-vs-contact UI tracked under #4.