### PR TITLE
fix(privy): smart wallet always primary + self-heal member primary_wallet

### DIFF
--- a/app/server/src/middleware/auth.ts
+++ b/app/server/src/middleware/auth.ts
@@ -13,6 +13,7 @@ type AuthenticatedWallet = {
   chainId?: string | number;
   profileUuid?: string;
   email?: string;
+  smartWallet?: string; // the Privy smart wallet — the CANONICAL primary (where funds live)
   token: string;
 };
 
@@ -164,7 +165,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
       return sendUnauthorized(res, 'No wallet linked to this account', 'AUTH_NO_WALLET');
     }
 
-    req.auth = { walletAddress, profileUuid: userId, email, token };
+    req.auth = { walletAddress, profileUuid: userId, email, smartWallet, token };
     return next();
   } catch (error) {
     console.error('Authentication error:', error);

--- a/app/server/src/routes/members.ts
+++ b/app/server/src/routes/members.ts
@@ -268,8 +268,10 @@ router.put('/me/bootstrap', async (req: Request, res: Response) => {
 
   try {
     const account = await memberStore.bootstrapMember({
+      // The Privy smart wallet is the CANONICAL primary (where funds live). Prefer it so a member who
+      // first joined via an external wallet (pre-migration) self-heals to the smart wallet as primary.
       authSubject: resolveRawAuthSubject(req),
-      primaryWallet: resolveWallet(req),
+      primaryWallet: req.auth?.smartWallet ?? resolveWallet(req),
       reownProfileUuid: req.auth?.profileUuid ?? null,
       email: req.auth?.email ?? null,
     });

--- a/app/server/src/services/memberStore.ts
+++ b/app/server/src/services/memberStore.ts
@@ -1000,12 +1000,15 @@ export class MemberStore {
             auth_subject = $2,
             reown_profile_uuid = COALESCE($3, reown_profile_uuid),
             reown_email_hash = COALESCE($4, reown_email_hash),
+            -- Re-align the primary to the canonical (smart) wallet so members who joined via an external
+            -- wallet pre-migration self-heal. syncPrimaryWallet then demotes the old primary in member_wallets.
+            primary_wallet = COALESCE($5, primary_wallet),
             last_authenticated_at = NOW(),
             updated_at = NOW()
           WHERE id = $1
           RETURNING *
           `,
-          [existingMember.id, nextAuthSubject, reownProfileUuid, reownEmailHash]
+          [existingMember.id, nextAuthSubject, reownProfileUuid, reownEmailHash, primaryWallet]
         );
       });
 

--- a/app/src/lib/walletCompat.ts
+++ b/app/src/lib/walletCompat.ts
@@ -38,10 +38,13 @@ export function useAppKitAccount() {
   const externalAddress = (externalWallet?.address ?? linkedExternal?.address ?? undefined) as
     | `0x${string}`
     | undefined;
-  const isEmbedded = !externalAddress;
+  // The Privy SMART WALLET is ALWAYS the primary account (where funds live), even when an external
+  // wallet (MetaMask) is LINKED — linked wallets are for viewing/transfers, not the active account, so a
+  // linked EOA must never hijack `address`. Only a user with genuinely NO smart wallet (legacy external
+  // login) falls through to the EOA path. Login is identity-only now + the server guarantees a smart
+  // wallet, so email/social users always resolve to their smart wallet here.
+  const isEmbedded = !!smartWalletAddress || !externalAddress;
 
-  // External login → that wallet's OWN address (same across providers → reclaims the member, tier-2/3).
-  // Email/social → the smart wallet address (tier 1, where funds live).
   const address = (
     isEmbedded
       ? (smartWalletAddress ?? embeddedWallet?.address ?? wagmiAddress ?? user?.wallet?.address)


### PR DESCRIPTION
Linked external wallet was hijacking the primary address (couldn't see the smart wallet). Frontend: smart wallet is always primary. Backend: bootstrap re-aligns members.primary_wallet to the smart wallet on login (auto-heals pre-migration external-wallet members; syncPrimaryWallet demotes the old primary). No manual DB migration.