### PR TITLE
feat(privy): linked wallets first-class (dashboard balances, txns, source filter)

### DIFF
--- a/app/src/components/app-ui/LinkedWalletsCard.tsx
+++ b/app/src/components/app-ui/LinkedWalletsCard.tsx
@@ -1,0 +1,73 @@
+import { ExternalLink, Wallet } from 'lucide-react';
+import { useLinkedWallets } from '@/context/LinkedWalletsContext';
+import { useLinkedWalletBalances } from '@/hooks/useLinkedWalletBalances';
+import { ACTIVE_CHAIN_ID } from '@/lib/clearNetwork';
+import { cn } from '@/lib/utils';
+
+const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const shorten = (a: string) => (a.length > 12 ? `${a.slice(0, 6)}…${a.slice(-4)}` : a);
+const explorerBase = ACTIVE_CHAIN_ID === 84532 ? 'https://sepolia.basescan.org' : 'https://basescan.org';
+
+/**
+ * Linked external wallets + their USDC/CLRUSD balances, surfaced on the dashboard (not just the Wallets
+ * modal). Balances via Alchemy tokens/by-address (one cheap batched call, fetched once on mount — no
+ * idle polling). Renders nothing when no wallets are linked. See [[clearpath-alchemy-cu]].
+ */
+export default function LinkedWalletsCard({ className }: { className?: string }) {
+  const { externalWallets, openManager } = useLinkedWallets();
+  const { balances, loading } = useLinkedWalletBalances(
+    externalWallets.map((w) => w.address),
+    externalWallets.length > 0,
+  );
+
+  if (externalWallets.length === 0) return null;
+
+  return (
+    <div className={cn('rounded-xl border border-border bg-card p-5', className)}>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-medium text-foreground">Linked wallets</h3>
+        <button
+          type="button"
+          onClick={openManager}
+          className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Manage
+        </button>
+      </div>
+
+      <div className="space-y-2">
+        {externalWallets.map((w) => {
+          const b = balances[w.address.toLowerCase()];
+          return (
+            <div key={w.id} className="flex items-center gap-3 rounded-xl border border-border p-3">
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
+                <Wallet className="h-[18px] w-[18px]" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium text-foreground">{w.label}</div>
+                <a
+                  href={`${explorerBase}/address/${w.address}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-0.5 text-xs tabular-nums text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {shorten(w.address)} <ExternalLink className="h-3 w-3" />
+                </a>
+              </div>
+              <div className="shrink-0 text-right">
+                <div className="text-sm font-medium tabular-nums text-foreground">
+                  {b ? fmt(b.usdc + b.clrusd) : loading ? '—' : fmt(0)}
+                </div>
+                {b && (b.usdc > 0 || b.clrusd > 0) && (
+                  <div className="text-[11px] tabular-nums text-muted-foreground">
+                    {fmt(b.usdc)} USDC · {fmt(b.clrusd)} CLRUSD
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/app-ui/RecentActivity.tsx
+++ b/app/src/components/app-ui/RecentActivity.tsx
@@ -3,7 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import { Search, SlidersHorizontal, ArrowLeftRight, ArrowDownLeft, Briefcase, Receipt, CreditCard, Repeat, type LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useClearTransactions, type ActivityStatus as Status } from '@/hooks/useClearTransactions';
-import TransactionFilterModal, { type Category, type AdvFilters, DEFAULT_ADV, advCount } from './TransactionFilterModal';
+import { useAppKitAccount } from '@/lib/walletCompat';
+import { useLinkedWallets } from '@/context/LinkedWalletsContext';
+import TransactionFilterModal, { type Category, type AdvFilters, type SourceOption, DEFAULT_ADV, advCount } from './TransactionFilterModal';
 
 const CATEGORY: Record<Category, { icon: LucideIcon; tint: string }> = {
   Transfer: { icon: ArrowLeftRight, tint: 'bg-info/10 text-info' },
@@ -35,6 +37,8 @@ function money(n: number) {
  */
 export default function RecentActivity({ className, limit }: { className?: string; limit?: number }) {
   const { items, loading } = useClearTransactions();
+  const { address } = useAppKitAccount();
+  const { externalWallets } = useLinkedWallets();
   const navigate = useNavigate();
   const compact = typeof limit === 'number';
   const [query, setQuery] = useState('');
@@ -42,6 +46,14 @@ export default function RecentActivity({ className, limit }: { className?: strin
   const [adv, setAdv] = useState<AdvFilters>(DEFAULT_ADV);
   const [modalOpen, setModalOpen] = useState(false);
   const activeAdv = advCount(adv);
+
+  // Source filter options: All, Clear account (primary smart wallet), each linked wallet, external bank.
+  const sources: SourceOption[] = [
+    { value: '', label: 'All sources' },
+    { value: (address ?? '').toLowerCase(), label: 'Clear account' },
+    ...externalWallets.map((w) => ({ value: w.address.toLowerCase(), label: w.label })),
+    { value: 'bank', label: 'External bank' },
+  ];
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -53,6 +65,7 @@ export default function RecentActivity({ className, limit }: { className?: strin
       if (filter === 'Transfers' && it.category !== 'Transfer') return false;
       if (filter === 'Pending' && it.status !== 'pending') return false;
       // advanced
+      if (adv.source && it.source !== adv.source) return false;
       if (!adv.categories[it.category]) return false;
       if (adv.status !== 'all' && it.status !== adv.status) return false;
       if (adv.direction === 'in' && it.amount <= 0) return false;
@@ -175,7 +188,7 @@ export default function RecentActivity({ className, limit }: { className?: strin
         )}
       </div>
 
-      <TransactionFilterModal open={modalOpen} onOpenChange={setModalOpen} value={adv} onApply={setAdv} />
+      <TransactionFilterModal open={modalOpen} onOpenChange={setModalOpen} value={adv} onApply={setAdv} sources={sources} />
     </div>
   );
 }

--- a/app/src/components/app-ui/TransactionFilterModal.tsx
+++ b/app/src/components/app-ui/TransactionFilterModal.tsx
@@ -10,11 +10,17 @@ export type Category = 'Transfer' | 'Deposit' | 'Payroll' | 'Bill' | 'Card' | 'S
 export type StatusFilter = 'all' | 'completed' | 'pending' | 'failed';
 export type DirectionFilter = 'all' | 'in' | 'out';
 
+export interface SourceOption {
+  value: string; // '' = all, a lowercased wallet address, or 'bank'
+  label: string;
+}
+
 export interface AdvFilters {
   categories: Record<Category, boolean>;
   status: StatusFilter;
   direction: DirectionFilter;
   amount: [number, number];
+  source: string; // '' = all sources
 }
 
 export const ALL_CATEGORIES: Category[] = ['Transfer', 'Deposit', 'Payroll', 'Bill', 'Card', 'Subscription'];
@@ -26,6 +32,7 @@ export const DEFAULT_ADV: AdvFilters = {
   status: 'all',
   direction: 'all',
   amount: [AMOUNT_MIN, AMOUNT_MAX],
+  source: '',
 };
 
 /** How many advanced filter groups differ from the defaults (for the button badge). */
@@ -35,6 +42,7 @@ export function advCount(a: AdvFilters): number {
   if (a.status !== 'all') n++;
   if (a.direction !== 'all') n++;
   if (a.amount[0] !== AMOUNT_MIN || a.amount[1] !== AMOUNT_MAX) n++;
+  if (a.source) n++;
   return n;
 }
 
@@ -56,11 +64,13 @@ export default function TransactionFilterModal({
   onOpenChange,
   value,
   onApply,
+  sources = [],
 }: {
   open: boolean;
   onOpenChange: (o: boolean) => void;
   value: AdvFilters;
   onApply: (v: AdvFilters) => void;
+  sources?: SourceOption[];
 }) {
   const [draft, setDraft] = useState<AdvFilters>(value);
   useEffect(() => {
@@ -77,6 +87,25 @@ export default function TransactionFilterModal({
         </DialogHeader>
 
         <div className="space-y-5 py-1">
+          {/* source — Clear account, a linked wallet, or external bank */}
+          {sources.length > 1 && (
+            <div>
+              <div className="mb-2 text-xs font-medium text-muted-foreground">Source</div>
+              <Select value={draft.source || 'all'} onValueChange={(v) => setDraft((s) => ({ ...s, source: v === 'all' ? '' : v }))}>
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {sources.map((o) => (
+                    <SelectItem key={o.value || 'all'} value={o.value || 'all'}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
           {/* direction */}
           <div>
             <div className="mb-2 text-xs font-medium text-muted-foreground">Direction</div>

--- a/app/src/components/shell/AppShell.tsx
+++ b/app/src/components/shell/AppShell.tsx
@@ -50,8 +50,8 @@ export default function AppShell() {
       <BridgeProvider>
       <MemberProfileProvider>
       <ClearBalancesProvider>
-      <ClearTransactionsProvider>
       <LinkedWalletsProvider>
+      <ClearTransactionsProvider>
       <ExternalAccountsProvider>
       <ContactsProvider>
       <PayProvider>
@@ -76,8 +76,8 @@ export default function AppShell() {
       </PayProvider>
       </ContactsProvider>
       </ExternalAccountsProvider>
-      </LinkedWalletsProvider>
       </ClearTransactionsProvider>
+      </LinkedWalletsProvider>
       </ClearBalancesProvider>
       </MemberProfileProvider>
       </BridgeProvider>

--- a/app/src/hooks/useClearTransactions.ts
+++ b/app/src/hooks/useClearTransactions.ts
@@ -1,5 +1,6 @@
 import { createContext, createElement, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
 import { useAppKitAccount } from '@/lib/walletCompat';
+import { useLinkedWallets } from '@/context/LinkedWalletsContext';
 import { getTransactionsBatch, getPlaidRecentTransactions, type PlaidRecentTransaction } from '@/utils/apiClient';
 import { ACTIVE_CHAIN_ID } from '@/lib/clearNetwork';
 import type { Category } from '@/components/app-ui/TransactionFilterModal';
@@ -21,6 +22,7 @@ export interface ActivityItem {
   ts: number; // ms epoch, for range filtering/grouping
   amount: number; // signed: + in, - out
   status: ActivityStatus;
+  source: string; // lowercased wallet address (primary or a linked wallet), or 'bank'
 }
 
 export interface CashFlow {
@@ -67,7 +69,7 @@ function formatDate(iso?: string): string {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
-function toActivity(tx: RawTx): ActivityItem {
+function toActivity(tx: RawTx, source: string): ActivityItem {
   const inbound = /deposit|receiv|incoming|claim/i.test(tx.type || '');
   const usd = typeof tx.amountUsd === 'number' && tx.amountUsd > 0 ? tx.amountUsd : Number(tx.amount) || 0;
   const amount = inbound ? Math.abs(usd) : -Math.abs(usd);
@@ -78,13 +80,14 @@ function toActivity(tx: RawTx): ActivityItem {
       : 'completed';
   const sym = cleanSymbol(tx.assetSymbol) || 'tokens';
   return {
-    id: tx.id,
+    id: `${source}:${tx.id}`,
     name: `${inbound ? 'Received' : 'Sent'} ${sym}`,
     category: inbound ? 'Deposit' : 'Transfer',
     date: formatDate(tx.date),
     ts: Date.parse(tx.date || '') || 0,
     amount,
     status,
+    source,
   };
 }
 
@@ -106,11 +109,15 @@ function plaidToActivity(t: PlaidRecentTransaction): ActivityItem {
     ts: Date.parse(t.date || '') || 0,
     amount: inbound ? amt : -amt,
     status: t.pending ? 'pending' : 'completed',
+    source: 'bank',
   };
 }
 
 export function ClearTransactionsProvider({ children }: { children: ReactNode }) {
   const { address, isConnected } = useAppKitAccount();
+  const { externalWallets } = useLinkedWallets();
+  // Stable string key of linked addresses so the fetch re-runs when wallets are linked/unlinked.
+  const linkedKey = externalWallets.map((w) => w.address.toLowerCase()).sort().join(',');
   const [items, setItems] = useState<ActivityItem[]>([]);
   const [flows, setFlows] = useState<CashFlow[]>([]);
   const [loading, setLoading] = useState(false);
@@ -123,27 +130,35 @@ export function ClearTransactionsProvider({ children }: { children: ReactNode })
     }
     setLoading(true);
     try {
-      // On-chain (the Clear chain only — Cash/Savings/Send live on Base / Base Sepolia) + Plaid,
-      // merged newest-first. Scoped to ACTIVE_CHAIN_ID so we don't poll Gnosis/Ethereum (huge CU cut).
-      const requests = [{ chainId: ACTIVE_CHAIN_ID, address, limit: 15 }];
+      // On-chain activity for the PRIMARY (smart) wallet + every LINKED wallet (one batched request,
+      // scoped to ACTIVE_CHAIN_ID so we don't poll Gnosis/Ethereum), plus Plaid bank — merged newest-first
+      // and tagged by source so the Transactions filter can narrow to a specific wallet or bank.
+      const primaryLower = address.toLowerCase();
+      const linked = linkedKey ? linkedKey.split(',').filter((a) => a && a !== primaryLower) : [];
+      const requests = [address, ...linked].map((a) => ({ chainId: ACTIVE_CHAIN_ID, address: a, limit: 15 }));
       const [chainResults, plaid] = await Promise.all([
         getTransactionsBatch(requests).catch(() => []),
         getPlaidRecentTransactions(address).catch(() => null),
       ]);
-      const onchain = (chainResults || [])
-        .flatMap((r) => (r.transactions as RawTx[]) || [])
-        .map(toActivity);
+      const onchain = (chainResults || []).flatMap((r) =>
+        ((r.transactions as RawTx[]) || []).map((tx) => toActivity(tx, (r.address || '').toLowerCase())),
+      );
       const bank = (plaid?.transactions || []).map(plaidToActivity);
       const merged = [...onchain, ...bank].sort((a, b) => b.ts - a.ts);
-      setItems(merged.slice(0, 50));
-      setFlows(merged.filter((x) => x.ts > 0).map((x) => ({ ts: x.ts, usd: x.amount })));
+      setItems(merged.slice(0, 80));
+      // Charts reflect the user's CLEAR cashflow (primary wallet + bank), not linked external wallets.
+      setFlows(
+        merged
+          .filter((x) => x.ts > 0 && (x.source === primaryLower || x.source === 'bank'))
+          .map((x) => ({ ts: x.ts, usd: x.amount })),
+      );
     } catch {
       setItems([]);
       setFlows([]);
     } finally {
       setLoading(false);
     }
-  }, [address, isConnected]);
+  }, [address, isConnected, linkedKey]);
 
   useEffect(() => {
     void load();

--- a/app/src/pages/app/AccountsPage.tsx
+++ b/app/src/pages/app/AccountsPage.tsx
@@ -10,6 +10,7 @@ import { useMemberProfile } from '@/hooks/useMemberProfile';
 import QuickActions from '@/components/app-ui/QuickActions';
 import CtaStack from '@/components/app-ui/CtaStack';
 import RecentActivity from '@/components/app-ui/RecentActivity';
+import LinkedWalletsCard from '@/components/app-ui/LinkedWalletsCard';
 import SpendHeatmap from '@/components/app-ui/SpendHeatmap';
 import UpcomingCalendar from '@/components/app-ui/UpcomingCalendar';
 import BalanceAnalyticsChart from '@/components/app-ui/charts/BalanceAnalyticsChart';
@@ -83,6 +84,8 @@ export default function AccountsPage() {
           <QuickActions />
         </div>
       </div>
+
+      <LinkedWalletsCard />
 
       <div className="grid gap-5 lg:grid-cols-3">
         <UpcomingCalendar items={upcoming} />


### PR DESCRIPTION
Linked-wallet balances on the Accounts dashboard (LinkedWalletsCard), linked-wallet transactions merged into the activity feed (tagged by source; charts stay Clear-scoped), and a Source filter (Clear account / each linked wallet / external bank) in the transactions filter modal.