### PR TITLE
feat(privy): gasless linked-wallet → Clear transfer via EIP-3009 (#3b)

### DIFF
--- a/app/server/src/middleware/auth.ts
+++ b/app/server/src/middleware/auth.ts
@@ -14,6 +14,7 @@ type AuthenticatedWallet = {
   profileUuid?: string;
   email?: string;
   smartWallet?: string; // the Privy smart wallet — the CANONICAL primary (where funds live)
+  addresses?: string[]; // ALL verified addresses for this user (primary + smart + linked), normalized
   token: string;
 };
 
@@ -165,7 +166,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
       return sendUnauthorized(res, 'No wallet linked to this account', 'AUTH_NO_WALLET');
     }
 
-    req.auth = { walletAddress, profileUuid: userId, email, smartWallet, token };
+    req.auth = { walletAddress, profileUuid: userId, email, smartWallet, addresses: [...addresses], token };
     return next();
   } catch (error) {
     console.error('Authentication error:', error);
@@ -191,6 +192,42 @@ export function requireWalletMatch(
 
   if (normalizeAddress(walletAddress) !== req.auth.walletAddress) {
     res.status(403).json({ error: 'Forbidden', message: `${fieldName} does not match authenticated wallet` });
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Like requireWalletMatch, but accepts ANY of the user's VERIFIED addresses (primary smart wallet OR a
+ * linked external wallet from Privy linkedAccounts) — not only the primary. Use for actions that operate
+ * on a specific wallet the user owns (e.g. moving USDC FROM a linked wallet). Still strictly scoped to
+ * the authenticated user's own addresses, so a relayer can never be steered at a stranger's wallet.
+ */
+export function requireVerifiedWallet(
+  req: Request,
+  res: Response,
+  walletAddress: unknown,
+  fieldName: string = 'walletAddress',
+): walletAddress is string {
+  if (typeof walletAddress !== 'string' || walletAddress.trim().length === 0) {
+    res.status(400).json({ error: `Invalid ${fieldName}`, message: `${fieldName} must be a non-empty string` });
+    return false;
+  }
+
+  // Compatibility mode for routes that don't enforce requireAuth middleware.
+  if (!req.auth?.walletAddress) {
+    return true;
+  }
+
+  const addr = normalizeAddress(walletAddress);
+  const verified = new Set<string>([
+    req.auth.walletAddress,
+    ...(req.auth.smartWallet ? [normalizeAddress(req.auth.smartWallet)] : []),
+    ...((req.auth.addresses ?? []).map((a) => normalizeAddress(a))),
+  ]);
+  if (!verified.has(addr)) {
+    res.status(403).json({ error: 'Forbidden', message: `${fieldName} is not a verified wallet on this account` });
     return false;
   }
 

--- a/app/server/src/routes/savings.ts
+++ b/app/server/src/routes/savings.ts
@@ -1,6 +1,6 @@
 import { Router, type Request, type Response } from 'express';
 import { ethers } from 'ethers';
-import { requireWalletMatch } from '../middleware/auth.js';
+import { requireWalletMatch, requireVerifiedWallet } from '../middleware/auth.js';
 import { savingsIntentService } from '../services/savingsIntentService.js';
 import { savingsRelayerService } from '../services/savingsRelayerService.js';
 import { savingsGaslessService } from '../services/savingsGaslessService.js';
@@ -327,6 +327,105 @@ savingsRouter.post('/gasless/submit', async (req: Request, res: Response) => {
   } catch (error) {
     res.status(500).json({
       error: 'Failed to submit gasless savings transfer',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+/**
+ * Gasless move of USDC FROM a linked external wallet → the user's Clear smart wallet (the reverse of a
+ * Cash→linked transfer, and the first leg of gasless move-then-withdraw). The linked EOA signs an EIP-3009
+ * TransferWithAuthorization; the relayer submits it + pays gas. Source must be a VERIFIED wallet of the
+ * user (linked), destination is server-pinned to their smart wallet, token pinned to USDC.
+ */
+savingsRouter.post('/gasless/wallet-transfer/prepare', async (req: Request, res: Response) => {
+  try {
+    const body = req.body as { fromWallet?: unknown; amount?: unknown; chainId?: unknown };
+    if (typeof body.fromWallet !== 'string' || !ethers.isAddress(body.fromWallet)) {
+      res.status(400).json({ error: 'Invalid fromWallet', message: 'fromWallet must be a valid EVM address' });
+      return;
+    }
+    // The source must be one of THIS user's verified wallets (a linked external wallet).
+    if (!requireVerifiedWallet(req, res, body.fromWallet, 'fromWallet')) return;
+    // Destination is ALWAYS the user's own smart wallet — server-pinned, never client-chosen.
+    const toWallet = req.auth?.smartWallet;
+    if (!toWallet || !ethers.isAddress(toWallet)) {
+      res.status(400).json({ error: 'No smart wallet', message: 'Your Clear account is still setting up. Try again shortly.' });
+      return;
+    }
+    if (ethers.getAddress(body.fromWallet) === ethers.getAddress(toWallet)) {
+      res.status(400).json({ error: 'Same wallet', message: 'Source and destination are the same wallet.' });
+      return;
+    }
+    if (typeof body.amount !== 'string' || body.amount.trim().length === 0) {
+      res.status(400).json({ error: 'Invalid amount', message: 'amount is required' });
+      return;
+    }
+    const prepared = await savingsGaslessService.buildWalletTransferTypedData({
+      chainId: parseChainId(body.chainId),
+      fromWallet: body.fromWallet,
+      toWallet,
+      amount: body.amount,
+    });
+    res.json(prepared);
+  } catch (error) {
+    res.status(500).json({
+      error: 'Failed to prepare wallet transfer',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+savingsRouter.post('/gasless/wallet-transfer/submit', async (req: Request, res: Response) => {
+  try {
+    const body = req.body as { chainId?: unknown; signature?: unknown; submit?: Record<string, unknown> };
+    if (typeof body.signature !== 'string' || !/^0x[a-fA-F0-9]{130}$/.test(body.signature.trim())) {
+      res.status(400).json({ error: 'Invalid signature', message: 'signature must be a 65-byte hex signature' });
+      return;
+    }
+    const submit = body.submit;
+    if (!submit || typeof submit !== 'object') {
+      res.status(400).json({ error: 'Invalid submit', message: 'submit params are required' });
+      return;
+    }
+    const from = submit.from;
+    if (typeof from !== 'string' || !ethers.isAddress(from)) {
+      res.status(400).json({ error: 'Invalid from', message: 'submit.from must be a valid address' });
+      return;
+    }
+    if (!requireVerifiedWallet(req, res, from, 'from')) return;
+
+    // Pin destination to the user's smart wallet + token to the configured USDC — never trust the client.
+    const config = savingsGaslessService.resolveConfig(parseChainId(body.chainId));
+    const toWallet = req.auth?.smartWallet;
+    if (!toWallet || typeof submit.to !== 'string' || ethers.getAddress(String(submit.to)) !== ethers.getAddress(toWallet)) {
+      res.status(400).json({ error: 'Invalid to', message: 'Destination must be your Clear account.' });
+      return;
+    }
+    if (typeof submit.token !== 'string' || ethers.getAddress(submit.token) !== config.usdcAddress) {
+      res.status(400).json({ error: 'Invalid token', message: 'token must be the configured USDC for this chain' });
+      return;
+    }
+    const value = BigInt(String(submit.value));
+    if (value <= 0n) throw new Error('value must be greater than zero');
+    const sig = ethers.Signature.from(body.signature.trim());
+
+    const txHash = await savingsRelayerService.transferWithAuthorization(config.chainId, config.usdcAddress, {
+      from: ethers.getAddress(from),
+      to: ethers.getAddress(toWallet),
+      value,
+      validAfter: BigInt(String(submit.validAfter ?? '0')),
+      validBefore: BigInt(String(submit.validBefore)),
+      nonce: String(submit.authNonce),
+      v: sig.v,
+      r: sig.r,
+      s: sig.s,
+    });
+
+    res.json({ success: true, action: 'wallet-transfer', chainId: config.chainId, txHash, status: 'SUBMITTED' });
+  } catch (error) {
+    res.status(500).json({
+      error: 'Failed to submit wallet transfer',
       message: error instanceof Error ? error.message : 'Unknown error',
     });
   }

--- a/app/server/src/services/savingsGaslessService.ts
+++ b/app/server/src/services/savingsGaslessService.ts
@@ -193,6 +193,57 @@ class SavingsGaslessService {
     };
   }
 
+  /**
+   * Move USDC FROM a linked external wallet TO the user's Clear smart wallet. EIP-3009
+   * TransferWithAuthorization (anyone may submit, so the relayer pays gas) — the linked EOA only signs.
+   * `from` = the linked wallet (validated as a verified address by the route); `to` = the smart wallet
+   * (server-pinned). Used for the reverse transfer + gasless move-then-withdraw.
+   */
+  async buildWalletTransferTypedData(input: { chainId?: number; fromWallet: string; toWallet: string; amount: string }) {
+    const config = this.resolveConfig(input.chainId);
+    const from = ethers.getAddress(input.fromWallet);
+    const to = ethers.getAddress(input.toWallet);
+    const amount = savingsIntentService.parseAmountToMicros(input.amount);
+    const provider = new ethers.JsonRpcProvider(config.rpcUrl);
+
+    const now = Math.floor(Date.now() / 1000);
+    const validAfter = '0';
+    const validBefore = String(now + this.ttlSeconds());
+    const authNonce = `0x${crypto.randomBytes(32).toString('hex')}`;
+    const domain = await this.resolveTokenDomain(provider, config.usdcAddress, config.chainId);
+
+    return {
+      chainId: config.chainId,
+      action: 'wallet-transfer' as const,
+      token: config.usdcAddress,
+      amountMicros: amount.toString(),
+      typedData: {
+        domain,
+        primaryType: 'TransferWithAuthorization',
+        types: {
+          TransferWithAuthorization: [
+            { name: 'from', type: 'address' },
+            { name: 'to', type: 'address' },
+            { name: 'value', type: 'uint256' },
+            { name: 'validAfter', type: 'uint256' },
+            { name: 'validBefore', type: 'uint256' },
+            { name: 'nonce', type: 'bytes32' },
+          ],
+        },
+        message: { from, to, value: amount.toString(), validAfter, validBefore, nonce: authNonce },
+      },
+      submit: {
+        from,
+        to,
+        token: config.usdcAddress,
+        value: amount.toString(),
+        validAfter,
+        validBefore,
+        authNonce,
+      },
+    };
+  }
+
   /** Redeem: CLRUSD → USDC. Returns the vault EIP-712 `Redeem` typed data + the one-time approve target. */
   async buildRedeemTypedData(input: { chainId?: number; ownerWallet: string; amount: string }) {
     const config = this.resolveConfig(input.chainId);

--- a/app/server/src/services/savingsRelayerService.ts
+++ b/app/server/src/services/savingsRelayerService.ts
@@ -413,6 +413,42 @@ class SavingsRelayerService {
     const data = iface.encodeFunctionData('permit', [a.owner, a.spender, a.value, a.deadline, a.v, a.r, a.s]);
     return this.submit(chainId, ethers.getAddress(tokenAddress), data);
   }
+
+  /**
+   * Move USDC linked→smart: relayer submits the linked EOA's EIP-3009 TransferWithAuthorization directly
+   * on the USDC token (relayer pays gas). USDC goes from→to with no allowance/approval needed.
+   */
+  async transferWithAuthorization(
+    chainId: number,
+    tokenAddress: string,
+    a: {
+      from: string;
+      to: string;
+      value: bigint;
+      validAfter: bigint;
+      validBefore: bigint;
+      nonce: string;
+      v: number;
+      r: string;
+      s: string;
+    },
+  ): Promise<string> {
+    const iface = new ethers.Interface([
+      'function transferWithAuthorization(address from, address to, uint256 value, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s)',
+    ]);
+    const data = iface.encodeFunctionData('transferWithAuthorization', [
+      a.from,
+      a.to,
+      a.value,
+      a.validAfter,
+      a.validBefore,
+      a.nonce,
+      a.v,
+      a.r,
+      a.s,
+    ]);
+    return this.submit(chainId, ethers.getAddress(tokenAddress), data);
+  }
 }
 
 export const savingsRelayerService = new SavingsRelayerService();

--- a/app/src/components/app-ui/TransferModal.tsx
+++ b/app/src/components/app-ui/TransferModal.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { useWallets } from '@privy-io/react-auth';
+import { createWalletClient, custom } from 'viem';
 import { useAppKitAccount } from '@/lib/walletCompat';
 import { useSmartWallets } from '@privy-io/react-auth/smart-wallets';
 import { ACTIVE_CHAIN_ID, clearContracts } from '@/lib/clearNetwork';
@@ -8,8 +10,10 @@ import { useExternalAccounts } from '@/context/ExternalAccountsContext';
 import { useLinkedWallets } from '@/context/LinkedWalletsContext';
 import { useKyc } from '@/context/KycContext';
 import { useClearBalances } from '@/hooks/useClearBalances';
-import { gaslessDeposit, gaslessRedeem } from '@/lib/gaslessMoney';
+import { useLinkedWalletBalances } from '@/hooks/useLinkedWalletBalances';
+import { gaslessDeposit, gaslessRedeem, gaslessWalletTransfer } from '@/lib/gaslessMoney';
 import { scDeposit, scRedeem, scTransferToken } from '@/lib/sendCalls';
+import type { Eip712TypedData } from '@/utils/apiClient';
 import { cn } from '@/lib/utils';
 
 /*
@@ -45,8 +49,10 @@ const INSTANT_FEE = 0.015;
 export default function TransferModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
   const { accounts: external, openManager } = useExternalAccounts();
   const { externalWallets } = useLinkedWallets();
+  const { wallets: connectedWallets } = useWallets();
   const { verified, openKyc } = useKyc();
   const bal = useClearBalances();
+  const { balances: linkedBal } = useLinkedWalletBalances(externalWallets.map((w) => w.address), open);
   const { address, embeddedWalletInfo } = useAppKitAccount();
   const { getClientForChain } = useSmartWallets();
   const isSmartAccount = embeddedWalletInfo?.accountType === 'smartAccount';
@@ -55,8 +61,24 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
     { id: 'cash', name: 'Cash', detail: 'USDC', scope: 'internal', balance: bal.cash, icon: Wallet },
     { id: 'savings', name: 'Savings', detail: 'CLRUSD', scope: 'internal', balance: bal.savings, icon: PiggyBank },
     ...external.map((a) => ({ id: a.id, name: a.name, detail: `${a.type} ••${a.mask}`, scope: 'external' as Scope, icon: Landmark })),
-    ...externalWallets.map((w) => ({ id: w.id, name: w.label, detail: shorten(w.address), scope: 'wallet' as Scope, address: w.address, icon: Wallet })),
+    ...externalWallets.map((w) => ({ id: w.id, name: w.label, detail: shorten(w.address), scope: 'wallet' as Scope, address: w.address, balance: linkedBal[w.address.toLowerCase()]?.usdc, icon: Wallet })),
   ];
+
+  // Sign an EIP-3009 authorization with a SPECIFIC linked wallet's own provider (not the active wallet),
+  // so the relayer can move that wallet's USDC. The wallet must be connected in the browser.
+  const signWithLinkedWallet = async (fromAddr: string, typedData: Eip712TypedData): Promise<string> => {
+    const w = connectedWallets.find((x) => x.address.toLowerCase() === fromAddr.toLowerCase());
+    if (!w) throw new Error('Open and reconnect that wallet in your browser to move funds from it.');
+    const provider = await w.getEthereumProvider();
+    const walletClient = createWalletClient({ account: fromAddr as `0x${string}`, transport: custom(provider as Parameters<typeof custom>[0]) });
+    return walletClient.signTypedData({
+      account: fromAddr as `0x${string}`,
+      domain: typedData.domain,
+      types: typedData.types,
+      primaryType: typedData.primaryType,
+      message: typedData.message,
+    } as Parameters<typeof walletClient.signTypedData>[0]);
+  };
 
   const [step, setStep] = useState<'compose' | 'review' | 'status'>('compose');
   const [fromId, setFromId] = useState('cash');
@@ -101,29 +123,42 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
         const isDeposit = fromId === 'cash' && toId === 'savings';
         const isRedeem = fromId === 'savings' && toId === 'cash';
         const isOnchainOut = (fromId === 'cash' || fromId === 'savings') && to?.scope === 'wallet';
-        if (!isDeposit && !isRedeem && !isOnchainOut) throw new Error('Unsupported transfer.');
-        // Bind the smart-wallet client to THIS chain (default client sits on Privy's defaultChain, not
-        // necessarily ACTIVE_CHAIN_ID) so the UserOp lands on-chain.
-        const chainClient = isSmartAccount ? await getClientForChain({ id: chainId }) : undefined;
+        const isOnchainIn = from?.scope === 'wallet' && toId === 'cash';
+        if (!isDeposit && !isRedeem && !isOnchainOut && !isOnchainIn) throw new Error('Unsupported transfer.');
         let hash: string;
-        if (isOnchainOut) {
-          // Cash (USDC) or Savings (CLRUSD) → linked external wallet: one sponsored ERC-20 transfer.
-          if (!chainClient) throw new Error('Your wallet is still setting up — try again in a moment.');
-          const c = clearContracts(chainId);
-          if (!c) throw new Error('On-chain transfers are unavailable on this network.');
-          const token = fromId === 'cash' ? c.usdc : c.clrusd;
-          hash = await scTransferToken({ smartWalletClient: chainClient, ownerWallet: address, token, to: to!.address as `0x${string}`, amount: amountStr, chainId });
+        if (isOnchainIn) {
+          // Linked wallet → Cash: gasless EIP-3009 USDC move to the smart wallet. The LINKED wallet signs
+          // an off-chain authorization (no gas, no ETH needed); the relayer submits it + pays gas.
+          if (!from?.address) throw new Error('Select a linked wallet.');
+          hash = await gaslessWalletTransfer({
+            fromWallet: from.address,
+            amount: amountStr,
+            chainId,
+            signTypedData: (td) => signWithLinkedWallet(from.address as string, td),
+          });
         } else {
-          // Smart accounts use the sponsored UserOp; EOAs use the EIP-3009 relayer (gasless) as fallback.
-          const scRun = isDeposit ? scDeposit : scRedeem;
-          const relayerRun = isDeposit ? gaslessDeposit : gaslessRedeem;
-          if (isSmartAccount && chainClient) {
-            hash = await scRun({ smartWalletClient: chainClient, ownerWallet: address, amount: amountStr, chainId });
+          // Bind the smart-wallet client to THIS chain (default client sits on Privy's defaultChain, not
+          // necessarily ACTIVE_CHAIN_ID) so the UserOp lands on-chain.
+          const chainClient = isSmartAccount ? await getClientForChain({ id: chainId }) : undefined;
+          if (isOnchainOut) {
+            // Cash (USDC) or Savings (CLRUSD) → linked external wallet: one sponsored ERC-20 transfer.
+            if (!chainClient) throw new Error('Your wallet is still setting up — try again in a moment.');
+            const c = clearContracts(chainId);
+            if (!c) throw new Error('On-chain transfers are unavailable on this network.');
+            const token = fromId === 'cash' ? c.usdc : c.clrusd;
+            hash = await scTransferToken({ smartWalletClient: chainClient, ownerWallet: address, token, to: to!.address as `0x${string}`, amount: amountStr, chainId });
           } else {
-            try {
-              hash = await scRun({ ownerWallet: address, amount: amountStr, chainId });
-            } catch {
-              hash = await relayerRun({ ownerWallet: address, amount: amountStr, chainId });
+            // Smart accounts use the sponsored UserOp; EOAs use the EIP-3009 relayer (gasless) as fallback.
+            const scRun = isDeposit ? scDeposit : scRedeem;
+            const relayerRun = isDeposit ? gaslessDeposit : gaslessRedeem;
+            if (isSmartAccount && chainClient) {
+              hash = await scRun({ smartWalletClient: chainClient, ownerWallet: address, amount: amountStr, chainId });
+            } else {
+              try {
+                hash = await scRun({ ownerWallet: address, amount: amountStr, chainId });
+              } catch {
+                hash = await relayerRun({ ownerWallet: address, amount: amountStr, chainId });
+              }
             }
           }
         }
@@ -134,8 +169,8 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
         const amt = Number(amountStr) || 0;
         if (isDeposit) bal.applyOptimistic(-amt, amt);
         else if (isRedeem) bal.applyOptimistic(amt, -amt);
-        else if (fromId === 'cash') bal.applyOptimistic(-amt, 0); // on-chain out from Cash
-        else bal.applyOptimistic(0, -amt); // on-chain out from Savings
+        else if (isOnchainOut) bal.applyOptimistic(fromId === 'cash' ? -amt : 0, fromId === 'savings' ? -amt : 0);
+        else if (isOnchainIn) bal.applyOptimistic(amt, 0); // linked → Cash: Cash up
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : 'Transfer failed.');
       }
@@ -147,14 +182,16 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
   }, [step]);
 
   const from = accounts.find((a) => a.id === fromId) ?? accounts[0];
-  const toOptions = accounts.filter((a) => toScopesFor(from?.scope).includes(a.scope) && a.id !== fromId);
-  const to = accounts.find((a) => a.id === toId && toScopesFor(from?.scope).includes(a.scope)) ?? toOptions[0];
+  // From a linked wallet the only destination is Cash (gasless USDC move IN); otherwise use scope rules.
+  const allowedTo = (a: Acct) => (from?.scope === 'wallet' ? a.id === 'cash' : toScopesFor(from?.scope).includes(a.scope));
+  const toOptions = accounts.filter((a) => allowedTo(a) && a.id !== fromId);
+  const to = accounts.find((a) => a.id === toId && allowedTo(a)) ?? toOptions[0];
   const isExternal = from?.scope === 'external';
 
   // keep `to` valid when `from` (and thus scope) changes
   useEffect(() => {
-    if (!to || to.id === fromId) {
-      const next = accounts.find((a) => a.scope === from?.scope && a.id !== fromId);
+    if (!to || to.id === fromId || !allowedTo(to)) {
+      const next = toOptions[0];
       if (next) setToId(next.id);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -273,7 +310,7 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
 
             {/* from → swap → to */}
             <div className="relative mt-5 space-y-2">
-              <Picker label="From" acct={from} isOpen={fromOpen} setOpen={(o) => { setFromOpen(o); setToOpen(false); }} options={accounts.filter((a) => a.scope !== 'wallet')} />
+              <Picker label="From" acct={from} isOpen={fromOpen} setOpen={(o) => { setFromOpen(o); setToOpen(false); }} options={accounts} />
               <div className="flex justify-center">
                 <button
                   type="button"

--- a/app/src/lib/gaslessMoney.ts
+++ b/app/src/lib/gaslessMoney.ts
@@ -11,6 +11,8 @@ import {
   submitGaslessSavings,
   prepareSendLockAuthorization,
   submitSendLockAuthorization,
+  prepareWalletTransfer,
+  submitWalletTransfer,
   type Eip712TypedData,
 } from '@/utils/apiClient';
 import type { SendTransferSummary } from '@/types/send';
@@ -111,6 +113,24 @@ export async function gaslessRedeem(args: { ownerWallet: string; amount: string;
     signature,
     submit: prepared.submit,
   });
+  return result.txHash;
+}
+
+/**
+ * Move USDC FROM a linked external wallet → the Clear smart wallet, gasless. The LINKED wallet signs an
+ * EIP-3009 TransferWithAuthorization (via `signTypedData`, which must use that wallet's own provider —
+ * not the active one), and the relayer submits it + pays gas. Returns the tx hash. CLRUSD isn't supported
+ * here (no permit/3009 by A3) — that path needs a plain transfer (pay gas) or 7702.
+ */
+export async function gaslessWalletTransfer(args: {
+  fromWallet: string;
+  amount: string;
+  chainId: number;
+  signTypedData: (typedData: Eip712TypedData) => Promise<string>;
+}): Promise<string> {
+  const prepared = await prepareWalletTransfer({ fromWallet: args.fromWallet, amount: args.amount, chainId: args.chainId });
+  const signature = await args.signTypedData(prepared.typedData);
+  const result = await submitWalletTransfer({ chainId: prepared.chainId, signature, submit: prepared.submit });
   return result.txHash;
 }
 

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -1382,6 +1382,38 @@ export async function submitGaslessSavings(payload: {
   return response.data;
 }
 
+/** Move USDC from a linked external wallet → the Clear smart wallet (gasless, EIP-3009). Prepare the
+ *  TransferWithAuthorization the linked wallet signs; the relayer submits it. */
+export async function prepareWalletTransfer(payload: {
+  fromWallet: string;
+  amount: string;
+  chainId?: number;
+}): Promise<{ chainId: number; token: string; amountMicros: string; typedData: Eip712TypedData; submit: Record<string, string> }> {
+  const response = await apiRequest<{ chainId: number; token: string; amountMicros: string; typedData: Eip712TypedData; submit: Record<string, string> }>(
+    '/api/savings/gasless/wallet-transfer/prepare',
+    { method: 'POST', body: JSON.stringify(payload) },
+  );
+  if (response.error || !response.data) {
+    throw new Error(response.error || 'Failed to prepare wallet transfer.');
+  }
+  return response.data;
+}
+
+export async function submitWalletTransfer(payload: {
+  chainId?: number;
+  signature: string;
+  submit: Record<string, string>;
+}): Promise<{ success: boolean; txHash: string; chainId: number }> {
+  const response = await apiRequest<{ success: boolean; txHash: string; chainId: number }>(
+    '/api/savings/gasless/wallet-transfer/submit',
+    { method: 'POST', body: JSON.stringify(payload), timeout: 120000 },
+  );
+  if (response.error || !response.data) {
+    throw new Error(response.error || 'Failed to complete wallet transfer.');
+  }
+  return response.data;
+}
+
 /** Record equity credits for an AA-submitted (client-side) savings deposit/redeem, by tx hash. */
 export async function recordGaslessSavings(p: {
   action: 'deposit' | 'redeem';


### PR DESCRIPTION
Move USDC from a linked external wallet to the Clear smart wallet — linked EOA signs an off-chain EIP-3009 TransferWithAuthorization, relayer pays gas. Auth gains requireVerifiedWallet (accepts any of the user's wallets). Backend prepare/submit pin destination=smart wallet, token=USDC. TransferModal exposes linked wallet as From→Cash. Unlocks reverse transfer + gasless move-then-withdraw. CLRUSD unsupported (no 3009 by A3).