### PR TITLE
feat(privy): gasless move-then-withdraw + CLRUSD-from-linked (7702 → plain fallback)

### DIFF
--- a/app/src/components/app-ui/TransferModal.tsx
+++ b/app/src/components/app-ui/TransferModal.tsx
@@ -12,6 +12,7 @@ import { useKyc } from '@/context/KycContext';
 import { useClearBalances } from '@/hooks/useClearBalances';
 import { useLinkedWalletBalances } from '@/hooks/useLinkedWalletBalances';
 import { gaslessDeposit, gaslessRedeem, gaslessWalletTransfer } from '@/lib/gaslessMoney';
+import { linkedWalletTokenTransfer } from '@/lib/linkedWalletTransfer';
 import { scDeposit, scRedeem, scTransferToken } from '@/lib/sendCalls';
 import type { Eip712TypedData } from '@/utils/apiClient';
 import { cn } from '@/lib/utils';
@@ -80,6 +81,13 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
     } as Parameters<typeof walletClient.signTypedData>[0]);
   };
 
+  // The linked wallet's raw EIP-1193 provider (for the CLRUSD path, which submits from that wallet).
+  const getLinkedProvider = async (fromAddr: string): Promise<unknown> => {
+    const w = connectedWallets.find((x) => x.address.toLowerCase() === fromAddr.toLowerCase());
+    if (!w) throw new Error('Open and reconnect that wallet in your browser to move funds from it.');
+    return w.getEthereumProvider();
+  };
+
   const [step, setStep] = useState<'compose' | 'review' | 'status'>('compose');
   const [fromId, setFromId] = useState('cash');
   const [toId, setToId] = useState('savings');
@@ -123,10 +131,11 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
         const isDeposit = fromId === 'cash' && toId === 'savings';
         const isRedeem = fromId === 'savings' && toId === 'cash';
         const isOnchainOut = (fromId === 'cash' || fromId === 'savings') && to?.scope === 'wallet';
-        const isOnchainIn = from?.scope === 'wallet' && toId === 'cash';
-        if (!isDeposit && !isRedeem && !isOnchainOut && !isOnchainIn) throw new Error('Unsupported transfer.');
+        const isOnchainInCash = from?.scope === 'wallet' && toId === 'cash';
+        const isOnchainInSavings = from?.scope === 'wallet' && toId === 'savings';
+        if (!isDeposit && !isRedeem && !isOnchainOut && !isOnchainInCash && !isOnchainInSavings) throw new Error('Unsupported transfer.');
         let hash: string;
-        if (isOnchainIn) {
+        if (isOnchainInCash) {
           // Linked wallet → Cash: gasless EIP-3009 USDC move to the smart wallet. The LINKED wallet signs
           // an off-chain authorization (no gas, no ETH needed); the relayer submits it + pays gas.
           if (!from?.address) throw new Error('Select a linked wallet.');
@@ -135,6 +144,21 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
             amount: amountStr,
             chainId,
             signTypedData: (td) => signWithLinkedWallet(from.address as string, td),
+          });
+        } else if (isOnchainInSavings) {
+          // Linked wallet → Savings: move CLRUSD to the smart wallet. CLRUSD has no EIP-3009 (A3), so the
+          // linked wallet submits it — gasless via 7702/paymaster when supported, else it pays its own gas.
+          if (!from?.address) throw new Error('Select a linked wallet.');
+          const c = clearContracts(chainId);
+          if (!c) throw new Error('On-chain transfers are unavailable on this network.');
+          const provider = await getLinkedProvider(from.address);
+          hash = await linkedWalletTokenTransfer({
+            provider,
+            from: from.address as `0x${string}`,
+            token: c.clrusd,
+            to: address as `0x${string}`,
+            amount: amountStr,
+            chainId,
           });
         } else {
           // Bind the smart-wallet client to THIS chain (default client sits on Privy's defaultChain, not
@@ -170,7 +194,8 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
         if (isDeposit) bal.applyOptimistic(-amt, amt);
         else if (isRedeem) bal.applyOptimistic(amt, -amt);
         else if (isOnchainOut) bal.applyOptimistic(fromId === 'cash' ? -amt : 0, fromId === 'savings' ? -amt : 0);
-        else if (isOnchainIn) bal.applyOptimistic(amt, 0); // linked → Cash: Cash up
+        else if (isOnchainInCash) bal.applyOptimistic(amt, 0); // linked → Cash: Cash up
+        else if (isOnchainInSavings) bal.applyOptimistic(0, amt); // linked → Savings: Savings up
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : 'Transfer failed.');
       }
@@ -182,8 +207,9 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
   }, [step]);
 
   const from = accounts.find((a) => a.id === fromId) ?? accounts[0];
-  // From a linked wallet the only destination is Cash (gasless USDC move IN); otherwise use scope rules.
-  const allowedTo = (a: Acct) => (from?.scope === 'wallet' ? a.id === 'cash' : toScopesFor(from?.scope).includes(a.scope));
+  // From a linked wallet you can move into Cash (USDC, gasless via 3009) or Savings (CLRUSD, 7702/plain);
+  // otherwise use the scope rules.
+  const allowedTo = (a: Acct) => (from?.scope === 'wallet' ? a.id === 'cash' || a.id === 'savings' : toScopesFor(from?.scope).includes(a.scope));
   const toOptions = accounts.filter((a) => allowedTo(a) && a.id !== fromId);
   const to = accounts.find((a) => a.id === toId && allowedTo(a)) ?? toOptions[0];
   const isExternal = from?.scope === 'external';
@@ -199,7 +225,9 @@ export default function TransferModal({ open, onOpenChange }: { open: boolean; o
 
   const amount = Number(amountStr) || 0;
   const fee = isExternal && method === 'instant' ? amount * INSTANT_FEE : 0;
-  const overBalance = from?.balance != null && amount > from.balance;
+  // No balance guard for a linked source: its single balance is USDC, but it can also send CLRUSD — the
+  // on-chain move fails clearly if the wallet is short. Internal/bank sources keep the guard.
+  const overBalance = from?.scope !== 'wallet' && from?.balance != null && amount > from.balance;
   const valid = amount >= 1 && !!to && !overBalance;
   const timing = !isExternal ? 'Instant' : method === 'instant' ? 'In minutes' : '1–3 business days';
 

--- a/app/src/components/app-ui/WithdrawModal.tsx
+++ b/app/src/components/app-ui/WithdrawModal.tsx
@@ -6,8 +6,12 @@ import { useExternalAccounts } from '@/context/ExternalAccountsContext';
 import { useKyc } from '@/context/KycContext';
 import { useMemberProfile } from '@/hooks/useMemberProfile';
 import { useClearBalances } from '@/hooks/useClearBalances';
-import { useAccount } from 'wagmi';
-import { withdrawToBank, getOnramperSellQuotes, createOnramperSellCheckout } from '@/utils/apiClient';
+import { useWallets } from '@privy-io/react-auth';
+import { createWalletClient, custom } from 'viem';
+import { useAppKitAccount } from '@/lib/walletCompat';
+import { ACTIVE_CHAIN_ID } from '@/lib/clearNetwork';
+import { gaslessWalletTransfer } from '@/lib/gaslessMoney';
+import { withdrawToBank, getOnramperSellQuotes, createOnramperSellCheckout, type Eip712TypedData } from '@/utils/apiClient';
 import { cn } from '@/lib/utils';
 
 /*
@@ -72,17 +76,31 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
   const [bankOpen, setBankOpen] = useState(false);
   const [done, setDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { wallets: allWallets, primaryId, openManager } = useLinkedWallets();
-  // Withdrawals off-ramp the Clear (smart) wallet via Bridge. Linked external wallets can't be withdrawn
-  // from yet — that needs the external wallet to sign / move funds first (like the linked→smart transfer,
-  // tier-2 EIP-5792/7702 territory), so the source is the Clear account only for now.
-  const wallets = allWallets.filter((w) => w.id === primaryId);
+  // Source can be the Clear account OR a linked wallet. Withdrawing from a linked wallet first moves its
+  // USDC into the smart wallet (gasless, EIP-3009), then Bridge off-ramps the smart wallet (below).
+  const { wallets, primaryId, openManager } = useLinkedWallets();
+  const { wallets: connectedWallets } = useWallets();
   const { accounts, openManager: openAccounts } = useExternalAccounts();
   const banks = accounts.map((a) => ({ id: a.id, label: `${a.name} ••${a.mask}` }));
   const { verified, openKyc } = useKyc();
   const { email } = useMemberProfile();
-  const { address } = useAccount();
+  const { address } = useAppKitAccount();
   const bal = useClearBalances();
+
+  // Sign an EIP-3009 authorization with a SPECIFIC linked wallet's own provider (for move-then-withdraw).
+  const signWithLinkedWallet = async (fromAddr: string, typedData: Eip712TypedData): Promise<string> => {
+    const w = connectedWallets.find((x) => x.address.toLowerCase() === fromAddr.toLowerCase());
+    if (!w) throw new Error('Open and reconnect that wallet in your browser to withdraw from it.');
+    const provider = await w.getEthereumProvider();
+    const walletClient = createWalletClient({ account: fromAddr as `0x${string}`, transport: custom(provider as Parameters<typeof custom>[0]) });
+    return walletClient.signTypedData({
+      account: fromAddr as `0x${string}`,
+      domain: typedData.domain,
+      types: typedData.types,
+      primaryType: typedData.primaryType,
+      message: typedData.message,
+    } as Parameters<typeof walletClient.signTypedData>[0]);
+  };
   const proceed = () => {
     if (BANK_METHODS.has(methodId) && !verified) openKyc(() => setStep('status'));
     else setStep('status');
@@ -111,6 +129,19 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
     (async () => {
       try {
         if (!address) throw new Error('Connect your wallet to withdraw.');
+
+        // Withdrawing FROM a linked wallet? First move its USDC into the Clear smart wallet (gasless,
+        // EIP-3009 — the linked wallet signs, relayer pays), then off-ramp from the smart wallet below.
+        const sourceWallet = wallets.find((w) => w.id === walletId);
+        if (sourceWallet?.external && sourceWallet.address) {
+          await gaslessWalletTransfer({
+            fromWallet: sourceWallet.address,
+            amount: amountStr,
+            chainId: ACTIVE_CHAIN_ID,
+            signTypedData: (td) => signWithLinkedWallet(sourceWallet.address as string, td),
+          });
+          if (cancelled) return;
+        }
 
         if (methodId === 'instant') {
           // Instant-to-debit → Onramper sell: pick the best off-ramp, open its hosted cash-out (it
@@ -146,8 +177,9 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
         if (cancelled) return;
         if (!res.success) throw new Error(res.message || 'Withdrawal failed.');
         setDone(true);
-        // Optimistic: USDC leaves Cash now; reconciles when the off-ramp debit indexes.
-        bal.applyOptimistic(-amount, 0);
+        // Optimistic: USDC leaves Cash now; reconciles when the off-ramp debit indexes. A linked-wallet
+        // withdraw just passed THROUGH Cash (move in, off-ramp out ≈ net 0), so skip the overlay there.
+        if (!sourceWallet?.external) bal.applyOptimistic(-amount, 0);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : 'Withdrawal failed.');
       }

--- a/app/src/lib/linkedWalletTransfer.ts
+++ b/app/src/lib/linkedWalletTransfer.ts
@@ -1,0 +1,73 @@
+import { createWalletClient, custom, encodeFunctionData, parseUnits } from 'viem';
+
+/*
+ * Move an ERC-20 (e.g. CLRUSD, which has NO EIP-3009/permit by decision A3) FROM a linked external wallet
+ * TO the Clear smart wallet, using the LINKED wallet's own provider. Two tiers:
+ *   1. EIP-5792 wallet_sendCalls + the ZeroDev paymaster — the wallet uses EIP-7702 to batch + sponsor at
+ *      its own address → GASLESS, when the wallet supports it.
+ *   2. Plain ERC-20 transfer — the linked wallet pays its own (small, Base) gas. Universal fallback.
+ * USDC has a better path (the EIP-3009 relayer, see gaslessMoney) — this is for tokens without 3009.
+ * See [[clearpath-account-abstraction]] / the 3-tier note in [[clearpath-privy-migration]].
+ */
+
+const ERC20_TRANSFER = [
+  { name: 'transfer', type: 'function', stateMutability: 'nonpayable', inputs: [{ name: 'to', type: 'address' }, { name: 'amount', type: 'uint256' }], outputs: [{ type: 'bool' }] },
+] as const;
+
+const ZERODEV_PROJECT_ID = (import.meta.env.VITE_ZERODEV_PROJECT_ID as string | undefined)?.trim();
+const paymasterUrl = (chainId: number) => `https://rpc.zerodev.app/api/v3/${ZERODEV_PROJECT_ID}/chain/${chainId}?selfFunded=true`;
+
+type Eip1193Provider = { request: (args: { method: string; params?: unknown[] }) => Promise<unknown> };
+
+export async function linkedWalletTokenTransfer(args: {
+  provider: unknown; // the linked wallet's EIP-1193 provider (Privy getEthereumProvider)
+  from: `0x${string}`;
+  token: `0x${string}`;
+  to: `0x${string}`; // the Clear smart wallet
+  amount: string; // decimal; CLRUSD is 6-decimals (matches USDC)
+  chainId: number;
+}): Promise<string> {
+  const provider = args.provider as Eip1193Provider;
+  const value = parseUnits(args.amount, 6);
+  const data = encodeFunctionData({ abi: ERC20_TRANSFER, functionName: 'transfer', args: [args.to, value] });
+
+  // Tier 1 — 7702/EIP-5792: ask the wallet to sponsor via the paymaster. Any failure → plain transfer.
+  if (ZERODEV_PROJECT_ID) {
+    try {
+      const sendRes = await provider.request({
+        method: 'wallet_sendCalls',
+        params: [
+          {
+            version: '2.0.0',
+            from: args.from,
+            chainId: `0x${args.chainId.toString(16)}`,
+            atomicRequired: true,
+            calls: [{ to: args.token, data }],
+            capabilities: { paymasterService: { url: paymasterUrl(args.chainId) } },
+          },
+        ],
+      });
+      const id = typeof sendRes === 'string' ? sendRes : (sendRes as { id?: string })?.id;
+      if (id) {
+        for (let i = 0; i < 30; i++) {
+          const st = (await provider.request({ method: 'wallet_getCallsStatus', params: [id] })) as {
+            status?: number | string;
+            receipts?: Array<{ transactionHash?: string }>;
+          };
+          const receipts = st?.receipts ?? [];
+          const hash = receipts[receipts.length - 1]?.transactionHash;
+          if (hash && (st?.status === 200 || st?.status === 'CONFIRMED' || receipts.length > 0)) return hash;
+          if (st?.status === 500 || st?.status === 'FAILED') throw new Error('Sponsored call failed.');
+          await new Promise((r) => setTimeout(r, 2000));
+        }
+      }
+      throw new Error('Sponsored call did not confirm.');
+    } catch {
+      /* fall through to the plain transfer */
+    }
+  }
+
+  // Tier 2 — plain transfer (linked wallet pays gas).
+  const walletClient = createWalletClient({ account: args.from, transport: custom(provider as Parameters<typeof custom>[0]) });
+  return walletClient.sendTransaction({ account: args.from, to: args.token, data, chain: null } as Parameters<typeof walletClient.sendTransaction>[0]);
+}


### PR DESCRIPTION
Withdraw can source a linked wallet (gasless EIP-3009 move → Bridge off-ramp; withdraw now uses the smart-wallet address). Transfer adds linked → Savings: CLRUSD has no 3009 (A3), so linkedWalletTransfer tries wallet_sendCalls+paymaster (EIP-7702, gasless if supported) and falls back to a plain transfer (pay gas). Completes linked-wallet money movement in both directions for both assets.