### PR TITLE
fix(privy): bootstrap member on auth so Plaid/Bridge capability gates pass

### DIFF
--- a/app/src/hooks/useMemberProfile.ts
+++ b/app/src/hooks/useMemberProfile.ts
@@ -1,6 +1,6 @@
 import { createContext, createElement, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
 import { useAppKitAccount } from '@/lib/walletCompat';
-import { getMemberAccountCenter, type MemberProfileViewResponse } from '@/utils/apiClient';
+import { getMemberAccountCenter, bootstrapMemberAccount, type MemberProfileViewResponse } from '@/utils/apiClient';
 import { getStoredAvatar, setStoredAvatar } from '@/lib/avatarStore';
 
 /**
@@ -72,6 +72,10 @@ export function MemberProfileProvider({ children }: { children: ReactNode }) {
     }
     setLoading(true);
     try {
+      // Ensure a member record exists for this Privy DID (idempotent upsert) BEFORE reading it, so
+      // capability-gated features (Plaid, Bridge) work for users who came straight in without the
+      // onboarding flow. Without this, the capability check finds no member and 403s.
+      await bootstrapMemberAccount().catch(() => {});
       const r = await getMemberAccountCenter();
       setRaw(r?.profile ?? null);
     } catch {


### PR DESCRIPTION
Users who skipped onboarding had no member record → requireMemberCapability returned null → 403 on Plaid/Bridge. MemberProfileProvider now bootstraps (idempotent) before reading the account center, so every authenticated user has a DID-keyed member. Fixes the Plaid link-token 403.