### PR TITLE
feat(privy): consolidate members by any verified identity (wallet/email/phone) + Standard/Accelerated tiers

### DIFF
--- a/app/server/src/middleware/auth.ts
+++ b/app/server/src/middleware/auth.ts
@@ -15,6 +15,7 @@ type AuthenticatedWallet = {
   email?: string;
   smartWallet?: string; // the Privy smart wallet — the CANONICAL primary (where funds live)
   addresses?: string[]; // ALL verified addresses for this user (primary + smart + linked), normalized
+  phone?: string; // the Privy account phone (login identity), if any
   token: string;
 };
 
@@ -30,7 +31,7 @@ function getPrivy(): PrivyClient | null {
 }
 
 // userId(DID) -> resolved wallets. Cached so we don't call getUser on every request (rate-limited).
-type UserWallets = { addresses: Set<string>; smartWallet?: string; email?: string; expiresAt: number };
+type UserWallets = { addresses: Set<string>; smartWallet?: string; email?: string; phone?: string; expiresAt: number };
 const userCache = new Map<string, UserWallets>();
 
 declare global {
@@ -71,6 +72,7 @@ type CollectedWallets = {
   addresses: Set<string>;
   smartWallet?: string;
   email?: string;
+  phone?: string;
   hasEmbeddedEoa: boolean;
   hasExternalWallet: boolean;
 };
@@ -79,11 +81,12 @@ function collectWallets(user: { linkedAccounts?: unknown[] }): CollectedWallets 
   const addresses = new Set<string>();
   let smartWallet: string | undefined;
   let email: string | undefined;
+  let phone: string | undefined;
   let hasEmbeddedEoa = false;
   let hasExternalWallet = false;
 
   for (const account of user.linkedAccounts ?? []) {
-    const acct = account as { type?: string; address?: string; chainType?: string; walletClientType?: string };
+    const acct = account as { type?: string; address?: string; number?: string; chainType?: string; walletClientType?: string };
     const isEvmWallet =
       (acct.type === 'wallet' || acct.type === 'smart_wallet') &&
       typeof acct.address === 'string' &&
@@ -98,9 +101,10 @@ function collectWallets(user: { linkedAccounts?: unknown[] }): CollectedWallets 
       }
     }
     if (acct.type === 'email' && typeof acct.address === 'string') email = acct.address;
+    if (acct.type === 'phone' && typeof acct.number === 'string') phone = acct.number;
   }
 
-  return { addresses, smartWallet, email, hasEmbeddedEoa, hasExternalWallet };
+  return { addresses, smartWallet, email, phone, hasEmbeddedEoa, hasExternalWallet };
 }
 
 async function loadUserWallets(privy: PrivyClient, userId: string): Promise<UserWallets> {
@@ -130,6 +134,7 @@ async function loadUserWallets(privy: PrivyClient, userId: string): Promise<User
     addresses: c.addresses,
     smartWallet: c.smartWallet,
     email: c.email,
+    phone: c.phone,
     expiresAt: Date.now() + AUTH_CACHE_TTL_MS,
   };
   userCache.set(userId, entry);
@@ -154,7 +159,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
     const claims = await privy.verifyAuthToken(token);
     const userId = claims.userId;
 
-    const { addresses, smartWallet, email } = await loadUserWallets(privy, userId);
+    const { addresses, smartWallet, email, phone } = await loadUserWallets(privy, userId);
 
     // Trust the frontend's active address only if it belongs to the verified user; else fall back to
     // the smart wallet (email/social funds) or the first linked wallet.
@@ -166,7 +171,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
       return sendUnauthorized(res, 'No wallet linked to this account', 'AUTH_NO_WALLET');
     }
 
-    req.auth = { walletAddress, profileUuid: userId, email, smartWallet, addresses: [...addresses], token };
+    req.auth = { walletAddress, profileUuid: userId, email, phone, smartWallet, addresses: [...addresses], token };
     return next();
   } catch (error) {
     console.error('Authentication error:', error);

--- a/app/server/src/middleware/memberCapabilities.ts
+++ b/app/server/src/middleware/memberCapabilities.ts
@@ -17,7 +17,9 @@ async function resolveMemberAuthSubject(req: Request): Promise<string> {
     authSubject: rawAuthSubject,
     profileUuid: req.auth?.profileUuid ?? null,
     walletAddress: req.auth?.walletAddress ?? null,
+    walletAddresses: req.auth?.addresses ?? null,
     email: req.auth?.email ?? null,
+    phone: req.auth?.phone ?? null,
   });
   return canonicalAuthSubject ?? rawAuthSubject;
 }

--- a/app/server/src/routes/members.ts
+++ b/app/server/src/routes/members.ts
@@ -36,7 +36,9 @@ function buildMemberAuthInput(req: Request) {
     authSubject: resolveRawAuthSubject(req),
     profileUuid: req.auth?.profileUuid ?? null,
     walletAddress: req.auth?.walletAddress ?? null,
+    walletAddresses: req.auth?.addresses ?? null,
     email: req.auth?.email ?? null,
+    phone: req.auth?.phone ?? null,
   };
 }
 
@@ -274,6 +276,8 @@ router.put('/me/bootstrap', async (req: Request, res: Response) => {
       primaryWallet: req.auth?.smartWallet ?? resolveWallet(req),
       reownProfileUuid: req.auth?.profileUuid ?? null,
       email: req.auth?.email ?? null,
+      phone: req.auth?.phone ?? null,
+      walletAddresses: req.auth?.addresses ?? null,
     });
 
     res.json({

--- a/app/server/src/services/memberStore.ts
+++ b/app/server/src/services/memberStore.ts
@@ -196,13 +196,17 @@ export interface BootstrapMemberInput {
   primaryWallet: string;
   reownProfileUuid?: string | null;
   email?: string | null;
+  phone?: string | null; // account phone (login identity), for identity matching
+  walletAddresses?: (string | null | undefined)[] | null; // ALL verified addresses, for identity matching
 }
 
 export interface ResolveMemberAuthInput {
   authSubject?: string | null;
   profileUuid?: string | null;
   walletAddress?: string | null;
+  walletAddresses?: (string | null | undefined)[] | null; // ALL verified addresses (smart + linked)
   email?: string | null;
+  phone?: string | null; // account phone (login identity)
 }
 
 export interface UpdateOnboardingInput {
@@ -982,12 +986,18 @@ export class MemberStore {
     const reownProfileUuid = normalizeOptionalString(input.reownProfileUuid ?? null, 255) ?? null;
     const email = normalizeOptionalEmail(input.email ?? null) ?? null;
     const reownEmailHash = email ? sha256Hex(email) : null;
+    const phone = normalizeOptionalPhone(input.phone ?? null) ?? null;
+    const reownPhoneHash = phone ? sha256Hex(phone) : null;
 
+    // Match an existing member by ANY verified identity (DID, any wallet, email, phone) so a pre-migration
+    // account is claimed instead of duplicated.
     const existingMember = await this.resolveMemberByAuthInput({
       authSubject,
       profileUuid: reownProfileUuid,
       walletAddress: primaryWallet,
+      walletAddresses: input.walletAddresses,
       email,
+      phone,
     });
 
     if (existingMember) {
@@ -1000,6 +1010,7 @@ export class MemberStore {
             auth_subject = $2,
             reown_profile_uuid = COALESCE($3, reown_profile_uuid),
             reown_email_hash = COALESCE($4, reown_email_hash),
+            reown_phone_hash = COALESCE($6, reown_phone_hash),
             -- Re-align the primary to the canonical (smart) wallet so members who joined via an external
             -- wallet pre-migration self-heal. syncPrimaryWallet then demotes the old primary in member_wallets.
             primary_wallet = COALESCE($5, primary_wallet),
@@ -1008,7 +1019,7 @@ export class MemberStore {
           WHERE id = $1
           RETURNING *
           `,
-          [existingMember.id, nextAuthSubject, reownProfileUuid, reownEmailHash, primaryWallet]
+          [existingMember.id, nextAuthSubject, reownProfileUuid, reownEmailHash, primaryWallet, reownPhoneHash]
         );
       });
 
@@ -1029,21 +1040,23 @@ export class MemberStore {
           primary_wallet,
           reown_profile_uuid,
           reown_email_hash,
+          reown_phone_hash,
           status,
           verification_status,
           membership_status,
           last_authenticated_at
-        ) VALUES ($1, $2, $3, $4, 'ONBOARDING', 'NOT_STARTED', 'NONE', NOW())
+        ) VALUES ($1, $2, $3, $4, $5, 'ONBOARDING', 'NOT_STARTED', 'NONE', NOW())
         ON CONFLICT (auth_subject)
         DO UPDATE SET
           primary_wallet = EXCLUDED.primary_wallet,
           reown_profile_uuid = COALESCE(EXCLUDED.reown_profile_uuid, ${TABLE_MEMBERS}.reown_profile_uuid),
           reown_email_hash = COALESCE(EXCLUDED.reown_email_hash, ${TABLE_MEMBERS}.reown_email_hash),
+          reown_phone_hash = COALESCE(EXCLUDED.reown_phone_hash, ${TABLE_MEMBERS}.reown_phone_hash),
           last_authenticated_at = NOW(),
           updated_at = NOW()
         RETURNING *
         `,
-        [authSubject, primaryWallet, reownProfileUuid, reownEmailHash]
+        [authSubject, primaryWallet, reownProfileUuid, reownEmailHash, reownPhoneHash]
       );
     });
 
@@ -2259,6 +2272,22 @@ export class MemberStore {
     return result.rows[0] ? mapMember(result.rows[0]) : null;
   }
 
+  private async loadMemberByReownPhone(phone: string): Promise<MemberRecord | null> {
+    const normalizedPhone = normalizeOptionalPhone(phone);
+    if (!normalizedPhone) {
+      return null;
+    }
+
+    const pool = this.mustPool();
+    const result = await withRetry(async () => {
+      return pool.query<MemberDbRow>(
+        `SELECT * FROM ${TABLE_MEMBERS} WHERE reown_phone_hash = $1 LIMIT 1`,
+        [sha256Hex(normalizedPhone)]
+      );
+    });
+    return result.rows[0] ? mapMember(result.rows[0]) : null;
+  }
+
   private async resolveMemberByAuthInput(input: ResolveMemberAuthInput): Promise<MemberRecord | null> {
     const authSubject = normalizeOptionalString(input.authSubject ?? null, 255) ?? null;
     if (authSubject) {
@@ -2276,14 +2305,21 @@ export class MemberStore {
       }
     }
 
-    const walletAddress = input.walletAddress ? normalizeWalletAddress(input.walletAddress) : null;
-    if (walletAddress) {
-      const byPrimaryWallet = await this.loadMemberByPrimaryWallet(walletAddress);
+    // Match against EVERY verified address (the primary smart wallet + any linked external wallet), so a
+    // pre-migration account keyed by a now-linked wallet is found instead of duplicated. Deterministic:
+    // the DID/auth_subject checks above always win first, so this only fires when there's no DID match.
+    const candidateWallets = [
+      input.walletAddress,
+      ...(input.walletAddresses ?? []),
+    ]
+      .filter((a): a is string => typeof a === 'string' && a.trim().length > 0)
+      .map((a) => normalizeWalletAddress(a));
+    for (const addr of new Set(candidateWallets)) {
+      const byPrimaryWallet = await this.loadMemberByPrimaryWallet(addr);
       if (byPrimaryWallet) {
         return byPrimaryWallet;
       }
-
-      const byLinkedWallet = await this.loadMemberByLinkedWallet(walletAddress);
+      const byLinkedWallet = await this.loadMemberByLinkedWallet(addr);
       if (byLinkedWallet) {
         return byLinkedWallet;
       }
@@ -2294,6 +2330,14 @@ export class MemberStore {
       const byEmail = await this.loadMemberByReownEmail(email);
       if (byEmail) {
         return byEmail;
+      }
+    }
+
+    const phone = normalizeOptionalPhone(input.phone ?? null) ?? null;
+    if (phone) {
+      const byPhone = await this.loadMemberByReownPhone(phone);
+      if (byPhone) {
+        return byPhone;
       }
     }
 
@@ -2891,6 +2935,7 @@ export class MemberStore {
           primary_wallet TEXT NOT NULL UNIQUE,
           reown_profile_uuid TEXT,
           reown_email_hash TEXT,
+          reown_phone_hash TEXT,
           status TEXT NOT NULL DEFAULT 'ONBOARDING',
           verification_status TEXT NOT NULL DEFAULT 'NOT_STARTED',
           membership_plan TEXT,
@@ -2907,6 +2952,9 @@ export class MemberStore {
           last_authenticated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
         )
       `);
+
+      // Account-phone hash for identity matching (older tables predate this column).
+      await pool.query(`ALTER TABLE ${TABLE_MEMBERS} ADD COLUMN IF NOT EXISTS reown_phone_hash TEXT;`);
 
       await pool.query(`
         CREATE TABLE IF NOT EXISTS ${TABLE_PROFILE_PUBLIC} (

--- a/app/src/context/GlobalModalsContext.tsx
+++ b/app/src/context/GlobalModalsContext.tsx
@@ -75,7 +75,8 @@ function formatShortAddress(address: string): string {
 
 function formatMembershipPlan(plan: MemberAccountCenterResponse['member']['membershipPlan']): string | null {
   if (!plan) return null;
-  return plan === 'LIFETIME' ? 'Lifetime' : 'Yearly';
+  // Display tiers: base (YEARLY) → Standard, premium (LIFETIME) → Accelerated. Stored enum unchanged.
+  return plan === 'LIFETIME' ? 'Accelerated' : 'Standard';
 }
 
 function buildMembershipLabel(


### PR DESCRIPTION
Member matching now consolidates by ANY verified identity (every verified wallet, email, phone) so returning/pre-migration users are claimed not duplicated; DID still wins first. Adds req.auth.phone + reown_phone_hash. Plan display renamed to Standard/Accelerated (label only).