### PR TITLE
fix(plaid): gate Investments so Link loads before approval

### DIFF
--- a/app/server/src/routes/plaid.ts
+++ b/app/server/src/routes/plaid.ts
@@ -283,6 +283,14 @@ router.post('/link-token', async (req: Request, res: Response) => {
     if (!plaidScope) return;
 
     const redirectUri = process.env.PLAID_REDIRECT_URI?.trim();
+    // In Plaid production, EVERY product listed (required or optional) must be enabled on the account
+    // — an unenabled one fails the whole Link with INVALID_PRODUCT. Investments requires separate Plaid
+    // approval, so gate it behind a flag (default off) and flip PLAID_ENABLE_INVESTMENTS=true once
+    // approved. Sandbox enables all products, so the demo can set the flag on. Liabilities stays on
+    // unless explicitly disabled.
+    const optionalProducts: Products[] = [];
+    if (process.env.PLAID_ENABLE_INVESTMENTS === 'true') optionalProducts.push(Products.Investments);
+    if (process.env.PLAID_ENABLE_LIABILITIES !== 'false') optionalProducts.push(Products.Liabilities);
     const baseRequest: LinkTokenCreateRequest = {
       client_name: 'Protocol Contracts',
       language: 'en',
@@ -290,8 +298,8 @@ router.post('/link-token', async (req: Request, res: Response) => {
       user: { client_user_id: walletAddress.toLowerCase() },
       // Transactions (spend insights) + Auth (account/routing for ACH bill pay & bank↔bank transfers).
       products: [Products.Transactions, Products.Auth],
-      // Optional: brokerage/investment + liabilities (credit/loans) when institution supports them
-      optional_products: [Products.Investments, Products.Liabilities],
+      // Optional: brokerage/investment + liabilities (credit/loans) when institution + account support them
+      ...(optionalProducts.length ? { optional_products: optionalProducts } : {}),
     };
     const requestWithRedirect: LinkTokenCreateRequest = redirectUri
       ? { ...baseRequest, redirect_uri: redirectUri }


### PR DESCRIPTION
Production Plaid requires every product in the Link token (required or optional) to be enabled on the account. Investments isn't approved yet, so listing it fails the whole Link with `INVALID_PRODUCT` on the live app (sandbox/demo enables all products, so it worked there).

Gates Investments behind `PLAID_ENABLE_INVESTMENTS` (default **off**) so Link loads immediately; flip to `true` once Plaid approves the account. Liabilities stays on unless `PLAID_ENABLE_LIABILITIES=false`. The investments data endpoints already no-op on `PRODUCT_NOT_READY`, so they return empty cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)