### PR TITLE
fix(plaid): Plaid Link clickable inside dialogs

### DIFF
--- a/app/src/components/portfolio/DepositModal.tsx
+++ b/app/src/components/portfolio/DepositModal.tsx
@@ -13,9 +13,10 @@ declare global {
       create: (config: {
         token: string;
         receivedRedirectUri?: string;
+        onLoad?: () => void;
         onSuccess: (public_token: string, metadata?: unknown) => void;
         onExit?: (err: unknown, metadata: unknown) => void;
-      }) => { open: () => void };
+      }) => { open: () => void; destroy?: () => void };
     };
   }
 }
@@ -467,10 +468,22 @@ const DepositModal = ({ isOpen, onClose, initialOption = null }: DepositModalPro
 
       await loadPlaidScript();
       if (!window.Plaid) throw new Error('Plaid Link is not available');
+      // Radix/modal libs put `pointer-events: none` on <body> while a dialog is open; the Plaid iframe
+      // (appended to <body>) inherits it and renders visible-but-unclickable. Force the body interactive
+      // while Plaid is open, restore on close.
+      const prevBodyPE = document.body.style.getPropertyValue('pointer-events');
+      const prevBodyPEPriority = document.body.style.getPropertyPriority('pointer-events');
+      const makeBodyInteractive = () => document.body.style.setProperty('pointer-events', 'auto', 'important');
+      const restoreBody = () => {
+        if (prevBodyPE) document.body.style.setProperty('pointer-events', prevBodyPE, prevBodyPEPriority);
+        else document.body.style.removeProperty('pointer-events');
+      };
       const handler = window.Plaid.create({
         token: linkToken,
         ...(useReceivedRedirectUri ? { receivedRedirectUri: window.location.href } : {}),
+        onLoad: () => makeBodyInteractive(),
         onSuccess: async (public_token: string) => {
+          restoreBody();
           plaidSuccessFiredRef.current = true;
           clearPlaidOAuthSession();
           const exchanged = await exchangePlaidToken(address, public_token);
@@ -489,6 +502,7 @@ const DepositModal = ({ isOpen, onClose, initialOption = null }: DepositModalPro
           }
         },
         onExit: (err) => {
+          restoreBody();
           if (plaidSuccessFiredRef.current) return;
           if (useReceivedRedirectUri) {
             clearPlaidOAuthSession();
@@ -521,6 +535,7 @@ const DepositModal = ({ isOpen, onClose, initialOption = null }: DepositModalPro
         },
       });
       handler.open();
+      makeBodyInteractive();
     } catch (e) {
       setBankError(e instanceof Error ? e.message : 'Failed to open Plaid Link');
     } finally {

--- a/app/src/lib/plaidLink.ts
+++ b/app/src/lib/plaidLink.ts
@@ -40,11 +40,29 @@ export async function runPlaidLink(walletAddress: string): Promise<boolean> {
   return new Promise<boolean>((resolve, reject) => {
     let fired = false;
     let handler: { open: () => void; destroy?: () => void };
+
+    // Radix (and similar modal libs) set `pointer-events: none` on <body> while a dialog is open.
+    // Plaid Link appends its iframe to <body>, so when launched from inside a dialog (e.g. the External
+    // Accounts modal) it inherits that and renders visible-but-unclickable. Force the body interactive
+    // while Plaid is open, and restore the prior value on teardown so the dialog's modal lock resumes.
+    const prevBodyPE = document.body.style.getPropertyValue('pointer-events');
+    const prevBodyPEPriority = document.body.style.getPropertyPriority('pointer-events');
+    const makeBodyInteractive = () => document.body.style.setProperty('pointer-events', 'auto', 'important');
+    const restoreBody = () => {
+      if (prevBodyPE) document.body.style.setProperty('pointer-events', prevBodyPE, prevBodyPEPriority);
+      else document.body.style.removeProperty('pointer-events');
+    };
+
     // Tear down the Plaid iframe/overlay; without this the modal sticks around until a page refresh.
     // Deferred so it runs after Plaid finishes its own exit transition.
-    const cleanup = () => setTimeout(() => { try { handler?.destroy?.(); } catch { /* noop */ } }, 0);
+    const cleanup = () => setTimeout(() => {
+      restoreBody();
+      try { handler?.destroy?.(); } catch { /* noop */ }
+    }, 0);
     handler = window.Plaid!.create({
       token: res.link_token,
+      // Re-assert once Plaid's UI is mounted, in case the modal lib set the lock after we did.
+      onLoad: () => makeBodyInteractive(),
       onSuccess: async (public_token: string) => {
         fired = true;
         try {
@@ -62,5 +80,6 @@ export async function runPlaidLink(walletAddress: string): Promise<boolean> {
       },
     });
     handler.open();
+    makeBodyInteractive();
   });
 }


### PR DESCRIPTION
Radix modals put `pointer-events: none` on `<body>`; Plaid Link's iframe (appended to `<body>`) inherits it, so the Plaid modal rendered visible but unclickable — you couldn't click or close it without refreshing.

Forces `<body>` interactive (`pointer-events: auto !important`) while Plaid Link is open (set on open + reasserted `onLoad`) and restores the prior value on teardown so the underlying dialog's modal lock resumes. Applied to `lib/plaidLink.ts` (External Accounts) and `DepositModal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)