### PR TITLE
feat(accounts): real chips, animated balances, tracker tooltips + flicker fix

### DIFF
--- a/app/src/components/app-ui/SpendHeatmap.tsx
+++ b/app/src/components/app-ui/SpendHeatmap.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { TrendingDown, Calendar, Sparkles, type LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -8,19 +9,29 @@ const formatAmount = (amount: number): string => {
   if (amount >= 1000) return `$${(amount / 1000).toFixed(1)}k`;
   return amount > 0 ? `$${Math.round(amount)}` : '-';
 };
+const fmtMoney = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 const getIntensity = (amount: number, max: number) => (amount <= 0 || max <= 0 ? 0 : Math.min(amount / max, 1));
+
+export interface SpendDetail {
+  category: string;
+  amount: number;
+}
 
 /**
  * Spend-intensity calendar — the old portfolio SpendTracker layout (day + amount
- * per cell, Less/More legend), reskinned to neutral / Space Grotesk. Presentational.
+ * per cell, Less/More legend), reskinned to neutral / Space Grotesk. Hover or tap a
+ * day to see that day's spend broken down by category.
  */
 export default function SpendHeatmap({
   spendingByDay,
+  detailByDay,
   className,
 }: {
   spendingByDay: Record<number, number>;
+  detailByDay?: Record<number, SpendDetail[]>;
   className?: string;
 }) {
+  const [activeDay, setActiveDay] = useState<number | null>(null);
   const today = new Date();
   const year = today.getFullYear();
   const month = today.getMonth();
@@ -69,13 +80,24 @@ export default function SpendHeatmap({
           const isToday = day === currentDay;
           const intensity = getIntensity(amount, maxDaySpend);
           const inverted = isPast && intensity > 0.5;
+          const hasSpend = amount > 0;
+          const detail = detailByDay?.[day] ?? [];
+          const isActive = activeDay === day && hasSpend;
           return (
             <div
               key={day}
+              role={hasSpend ? 'button' : undefined}
+              tabIndex={hasSpend ? 0 : undefined}
+              onMouseEnter={() => hasSpend && setActiveDay(day)}
+              onMouseLeave={() => setActiveDay((d) => (d === day ? null : d))}
+              onFocus={() => hasSpend && setActiveDay(day)}
+              onBlur={() => setActiveDay((d) => (d === day ? null : d))}
+              onClick={() => hasSpend && setActiveDay((d) => (d === day ? null : day))}
               className={cn(
-                'relative flex min-h-14 min-w-0 flex-col items-start justify-between rounded-[6px] border p-1.5',
+                'relative flex min-h-14 min-w-0 flex-col items-start justify-between rounded-[6px] border p-1.5 outline-none',
                 isPast ? 'border-border' : 'border-border/50',
                 isToday && 'ring-1 ring-foreground/40',
+                hasSpend && 'cursor-pointer focus-visible:ring-1 focus-visible:ring-foreground/60',
               )}
             >
               <div className="pointer-events-none absolute inset-0 rounded-[6px] bg-foreground" style={{ opacity: isPast ? intensity : 0 }} aria-hidden />
@@ -83,6 +105,30 @@ export default function SpendHeatmap({
               <span className={cn('relative z-10 w-full truncate text-[10px] font-medium', inverted ? 'text-background/90' : 'text-muted-foreground')}>
                 {isPast ? formatAmount(amount) : '-'}
               </span>
+
+              {isActive && (
+                <div
+                  className="absolute bottom-full left-1/2 z-30 mb-1.5 w-44 -translate-x-1/2 rounded-lg border border-border bg-card p-2.5 text-left shadow-xl"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <div className="mb-1.5 flex items-center justify-between gap-2 border-b border-border pb-1.5">
+                    <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">{monthName} {day}</span>
+                    <span className="text-[11px] font-semibold tabular-nums text-foreground">{fmtMoney(amount)}</span>
+                  </div>
+                  {detail.length > 0 ? (
+                    <div className="space-y-1">
+                      {detail.map((c) => (
+                        <div key={c.category} className="flex items-center justify-between gap-3">
+                          <span className="truncate text-[11px] text-muted-foreground">{c.category}</span>
+                          <span className="shrink-0 text-[11px] tabular-nums text-foreground">{fmtMoney(c.amount)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="text-[11px] text-muted-foreground">Spent {fmtMoney(amount)}</div>
+                  )}
+                </div>
+              )}
             </div>
           );
         })}

--- a/app/src/components/app-ui/StatBar.tsx
+++ b/app/src/components/app-ui/StatBar.tsx
@@ -1,19 +1,45 @@
+import { useEffect, useRef } from 'react';
 import { ArrowUpRight, ArrowDownRight, type LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { PriceWheel } from '@/components/PriceWheel';
 
 export interface Stat {
+  /** Number → rolls/animates (green/red on change); string → rendered as-is (already formatted). */
+  value: number | string;
   label: string;
-  value: string;
   change?: string;
   changePositive?: boolean;
   icon?: LucideIcon;
+}
+
+const fmtUsd = (v: number) => `$${v.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+/**
+ * A single stat value that rolls smoothly to its new figure (and briefly flashes green/red on the
+ * direction of change) instead of snapping — the old brokerage "price wheel", reused. Tracking the
+ * previous value here means background balance polls animate rather than flicker.
+ */
+function AnimatedStatValue({ value }: { value: number }) {
+  const prevRef = useRef(value);
+  useEffect(() => {
+    prevRef.current = value;
+  }, [value]);
+  return (
+    <PriceWheel
+      value={value}
+      previousValue={prevRef.current}
+      formatter={fmtUsd}
+      duration={600}
+      className="font-display text-2xl tracking-tight text-foreground tabular-nums"
+    />
+  );
 }
 
 /**
  * A single stat container divided by faint grid lines (gap-px over bg-border),
  * instead of N separate cards. One strategic highlight container, hairline-divided.
  */
-export default function StatBar({ stats, className }: { stats: Stat[]; className?: string }) {
+export default function StatBar({ stats, loading, className }: { stats: Stat[]; loading?: boolean; className?: string }) {
   return (
     <div className={cn('overflow-hidden rounded-xl border border-border bg-border', className)}>
       <div className="grid grid-cols-2 gap-px bg-border lg:grid-cols-4">
@@ -26,7 +52,15 @@ export default function StatBar({ stats, className }: { stats: Stat[]; className
                 <span className="text-xs font-medium text-muted-foreground">{s.label}</span>
                 {Icon && <Icon className="h-4 w-4 text-muted-foreground" />}
               </div>
-              <div className="mt-2 font-display text-2xl tracking-tight text-foreground tabular-nums">{s.value}</div>
+              <div className="mt-2 font-display text-2xl tracking-tight text-foreground tabular-nums">
+                {loading ? (
+                  <span className="text-muted-foreground">—</span>
+                ) : typeof s.value === 'number' ? (
+                  <AnimatedStatValue value={s.value} />
+                ) : (
+                  s.value
+                )}
+              </div>
               {s.change && (
                 <div
                   className={cn(

--- a/app/src/components/app-ui/UpcomingCalendar.tsx
+++ b/app/src/components/app-ui/UpcomingCalendar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { TrendingUp, Calendar, Bell, DollarSign, Plus, type LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -12,11 +13,13 @@ export interface UpcomingItem {
 const weekDays = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
 const headerIcons: LucideIcon[] = [TrendingUp, Calendar, Bell];
 const formatAmount = (a: number) => (a >= 1000 ? `$${(a / 1000).toFixed(1)}k` : `$${Math.round(a)}`);
+const fmtMoney = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
 /**
  * Upcoming recurring bills/income calendar — the old portfolio UpcomingTransactions
  * layout (day cells with dot clusters + day totals), reskinned to neutral. A solid dot
- * is a bill, a hollow $ dot is income, "+" marks overflow. Presentational.
+ * is a bill, a hollow $ dot is income, "+" marks overflow. Hover or tap a day to see
+ * the transactions and amounts scheduled for it.
  */
 export default function UpcomingCalendar({
   items,
@@ -25,6 +28,7 @@ export default function UpcomingCalendar({
   items: UpcomingItem[];
   className?: string;
 }) {
+  const [activeDay, setActiveDay] = useState<number | null>(null);
   const today = new Date();
   const year = today.getFullYear();
   const month = today.getMonth();
@@ -73,19 +77,29 @@ export default function UpcomingCalendar({
           const dayOut = dayItems.filter((i) => i.direction === 'out').reduce((s, i) => s + i.amount, 0);
           const overflow = dayItems.length > 3;
           const shown = overflow ? dayItems.slice(0, 2) : dayItems.slice(0, 3);
+          const hasItems = dayItems.length > 0;
+          const isActive = activeDay === day && hasItems;
           return (
             <div
               key={day}
+              role={hasItems ? 'button' : undefined}
+              tabIndex={hasItems ? 0 : undefined}
+              onMouseEnter={() => hasItems && setActiveDay(day)}
+              onMouseLeave={() => setActiveDay((d) => (d === day ? null : d))}
+              onFocus={() => hasItems && setActiveDay(day)}
+              onBlur={() => setActiveDay((d) => (d === day ? null : d))}
+              onClick={() => hasItems && setActiveDay((d) => (d === day ? null : day))}
               className={cn(
-                'flex min-h-14 min-w-0 flex-col items-center justify-between rounded-[6px] border p-1',
+                'relative flex min-h-14 min-w-0 flex-col items-center justify-between rounded-[6px] border p-1 outline-none',
                 isPast ? 'border-border/50 opacity-60' : 'border-border',
                 isToday && 'bg-secondary/40 ring-1 ring-foreground/40',
+                hasItems && 'cursor-pointer focus-visible:ring-1 focus-visible:ring-foreground/60',
               )}
             >
               <span className={cn('text-[10px] font-medium', isToday ? 'flex h-4 w-4 items-center justify-center rounded-lg bg-foreground text-[9px] text-background' : 'text-foreground')}>
                 {day}
               </span>
-              {dayItems.length > 0 ? (
+              {hasItems ? (
                 <div className="flex items-center -space-x-1">
                   {shown.map((it) => (
                     <span
@@ -110,6 +124,25 @@ export default function UpcomingCalendar({
               <span className="w-full truncate text-center text-[9px] font-medium text-muted-foreground">
                 {dayOut > 0 ? formatAmount(dayOut) : ' '}
               </span>
+
+              {isActive && (
+                <div
+                  className="absolute bottom-full left-1/2 z-30 mb-1.5 w-48 -translate-x-1/2 rounded-lg border border-border bg-card p-2.5 text-left shadow-xl"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">{monthName} {day}</div>
+                  <div className="space-y-1">
+                    {dayItems.map((it) => (
+                      <div key={it.id} className="flex items-center justify-between gap-3">
+                        <span className="truncate text-[11px] text-muted-foreground">{it.name}</span>
+                        <span className={cn('shrink-0 text-[11px] font-medium tabular-nums', it.direction === 'in' ? 'text-positive' : 'text-foreground')}>
+                          {it.direction === 'in' ? '+' : '−'}{fmtMoney(it.amount)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           );
         })}

--- a/app/src/hooks/useClearBalances.ts
+++ b/app/src/hooks/useClearBalances.ts
@@ -1,4 +1,4 @@
-import { createContext, createElement, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { createContext, createElement, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useMultichainBalances } from '@/hooks/useMultichainBalances';
 import { COMMON_TOKENS } from '@/config/tokens';
 import { includeChainBalance, ACTIVE_CHAIN_ID } from '@/lib/clearNetwork';
@@ -73,6 +73,17 @@ export function ClearBalancesProvider({ children }: { children: ReactNode }) {
   const { tokens, tokensLoading, refreshTokens } = useMultichainBalances({ chainIds: CLEAR_CHAIN_IDS });
   const [pending, setPending] = useState<Pending | null>(null);
 
+  // `tokensLoading` flips true on every background poll, but `tokens` (and the derived balance) are
+  // retained across polls — so treating every poll as "loading" made consumers blank the value to a
+  // dash and flicker. Track whether the FIRST fetch has completed and only report `loading` until
+  // then; after that, background refreshes update the value in place with no loading flash.
+  const [everLoaded, setEverLoaded] = useState(false);
+  const prevLoadingRef = useRef(false);
+  useEffect(() => {
+    if (prevLoadingRef.current && !tokensLoading) setEverLoaded(true);
+    prevLoadingRef.current = tokensLoading;
+  }, [tokensLoading]);
+
   // Authoritative (on-chain) balances derived from fetched tokens.
   const fetched = useMemo(() => {
     const sumByKeys = (keys: Set<string>) =>
@@ -139,11 +150,11 @@ export function ClearBalancesProvider({ children }: { children: ReactNode }) {
       cash,
       savings,
       total: cash + savings,
-      loading: tokensLoading,
+      loading: tokensLoading && !everLoaded,
       refresh: () => void refreshTokens(true),
       applyOptimistic,
     };
-  }, [pending, fetched, tokensLoading, refreshTokens, applyOptimistic]);
+  }, [pending, fetched, tokensLoading, everLoaded, refreshTokens, applyOptimistic]);
 
   return createElement(Ctx.Provider, { value }, children);
 }

--- a/app/src/pages/app/AccountsPage.tsx
+++ b/app/src/pages/app/AccountsPage.tsx
@@ -7,6 +7,7 @@ import { useClearBalances } from '@/hooks/useClearBalances';
 import { useLinkedWallets } from '@/context/LinkedWalletsContext';
 import { useLinkedWalletBalances } from '@/hooks/useLinkedWalletBalances';
 import { useClearTransactions } from '@/hooks/useClearTransactions';
+import { useClearPortfolioHistory } from '@/hooks/useClearPortfolioHistory';
 import { useUpcoming } from '@/hooks/useUpcoming';
 import { useMemberProfile } from '@/hooks/useMemberProfile';
 import QuickActions from '@/components/app-ui/QuickActions';
@@ -20,10 +21,8 @@ import ClearDeedCard from '@/components/app-ui/ClearDeedCard';
 /**
  * Accounts — the dashboard. Stat row (Total / Cash / Savings / External), a big
  * balance-analytics chart, quick actions, recent activity, Clear Deed progress,
- * and the upcoming/spend calendars. Scaffold: placeholder figures.
+ * and the upcoming/spend calendars.
  */
-const fmtUsd = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-
 export default function AccountsPage() {
   const { verified, openKyc } = useKyc();
   const bal = useClearBalances();
@@ -33,10 +32,30 @@ export default function AccountsPage() {
     externalWallets.map((w) => w.address),
     externalWallets.length > 0,
   );
-  const { flows } = useClearTransactions();
+  const { items } = useClearTransactions();
+  const history = useClearPortfolioHistory();
   const upcoming = useUpcoming();
   const { firstName } = useMemberProfile();
-  const dash = (v: number) => (bal.loading ? '—' : fmtUsd(v));
+
+  // Real trailing-7-day change for a metric, from the backend balance-history series (returns nothing
+  // until there's enough history to compare). Cash/Savings share the on-chain series — we snapshot the
+  // combined on-chain total, not each token, so both reflect the same on-chain trend.
+  const weekChange = (field: 'totalUsd' | 'onchainUsd' | 'bankUsd'): { change?: string; changePositive?: boolean } => {
+    const pts = history.points;
+    if (pts.length < 2) return {};
+    const last = pts[pts.length - 1];
+    const target = new Date(last.date);
+    target.setDate(target.getDate() - 7);
+    let past = pts[0][field];
+    for (const p of pts) {
+      if (new Date(p.date).getTime() <= target.getTime()) past = p[field];
+      else break;
+    }
+    if (!past) return {};
+    const pct = ((last[field] - past) / Math.abs(past)) * 100;
+    if (!Number.isFinite(pct) || Math.abs(pct) < 0.05) return {};
+    return { change: `${Math.abs(pct).toFixed(1)}% this week`, changePositive: pct >= 0 };
+  };
 
   // Cash/Savings = the Clear (smart) wallet PLUS every linked wallet, aggregated. (This is a holdings
   // view; movable Cash in the Transfer/Send flows stays the smart wallet only — linked funds need their
@@ -56,18 +75,29 @@ export default function AccountsPage() {
   const cash = bal.cash + linkedTotals.usdc;
   const savings = bal.savings + linkedTotals.clrusd;
 
-  // This month's outflows grouped by day-of-month (for the spend heatmap).
-  const spendByDay = useMemo(() => {
+  // This month's outflows grouped by day-of-month — total per day (heatmap intensity) plus a
+  // by-category breakdown per day (for the hover/press tooltip).
+  const { spendByDay, spendDetailByDay } = useMemo(() => {
     const now = new Date();
-    const out: Record<number, number> = {};
-    for (const f of flows) {
-      if (f.usd >= 0) continue;
-      const d = new Date(f.ts);
+    const totals: Record<number, number> = {};
+    const byCat: Record<number, Record<string, number>> = {};
+    for (const it of items) {
+      if (it.amount >= 0) continue;
+      const d = new Date(it.ts);
       if (d.getMonth() !== now.getMonth() || d.getFullYear() !== now.getFullYear()) continue;
-      out[d.getDate()] = (out[d.getDate()] || 0) + Math.abs(f.usd);
+      const day = d.getDate();
+      const amt = Math.abs(it.amount);
+      totals[day] = (totals[day] || 0) + amt;
+      (byCat[day] ||= {})[it.category] = (byCat[day][it.category] || 0) + amt;
     }
-    return out;
-  }, [flows]);
+    const detail: Record<number, { category: string; amount: number }[]> = {};
+    for (const [day, cats] of Object.entries(byCat)) {
+      detail[Number(day)] = Object.entries(cats)
+        .map(([category, amount]) => ({ category, amount }))
+        .sort((a, b) => b.amount - a.amount);
+    }
+    return { spendByDay: totals, spendDetailByDay: detail };
+  }, [items]);
   return (
     <div className="animate-fade-in space-y-5">
       <div>
@@ -93,11 +123,12 @@ export default function AccountsPage() {
       )}
 
       <StatBar
+        loading={bal.loading}
         stats={[
-          { label: 'Total balance', value: dash(cash + savings + ext.totalBalance), change: '2.1% this week', icon: Wallet },
-          { label: 'Cash · USDC', value: dash(cash), change: '0.4%', icon: Banknote },
-          { label: 'Savings · CLRUSD', value: dash(savings), change: '1.8%', icon: PiggyBank },
-          { label: 'External · Plaid', value: fmtUsd(ext.totalBalance), change: '0.6%', changePositive: false, icon: Landmark },
+          { label: 'Total balance', value: cash + savings + ext.totalBalance, icon: Wallet, ...weekChange('totalUsd') },
+          { label: 'Cash · USDC', value: cash, icon: Banknote, ...weekChange('onchainUsd') },
+          { label: 'Savings · CLRUSD', value: savings, icon: PiggyBank, ...weekChange('onchainUsd') },
+          { label: 'External · Plaid', value: ext.totalBalance, icon: Landmark, ...weekChange('bankUsd') },
         ]}
       />
 
@@ -111,7 +142,7 @@ export default function AccountsPage() {
 
       <div className="grid gap-5 lg:grid-cols-3">
         <UpcomingCalendar items={upcoming} />
-        <SpendHeatmap spendingByDay={spendByDay} />
+        <SpendHeatmap spendingByDay={spendByDay} detailByDay={spendDetailByDay} />
         <ClearDeedCard />
       </div>
 


### PR DESCRIPTION
Small account-page UI improvements.

- **Animated balances (no flicker):** top-metric values now use the old brokerage `PriceWheel` — they roll smoothly to new figures and flash green/red on the direction of change. `useClearBalances` now only reports `loading` until the *first* fetch completes (the value is retained across polls), so the 30s poll no longer blanks the value to a dash — that was the flicker.
- **Real change chips:** replaced the hardcoded `2.1% this week` placeholders with the real trailing-7-day % from the balance-history series (Total = totalUsd, Cash/Savings = onchainUsd, External = bankUsd). Chips hide until there's enough history rather than showing fake numbers.
- **Upcoming transactions tooltip:** hover or tap a day → the transactions + amounts (in/out) scheduled for it.
- **Spend tracker tooltip:** hover or tap a day → that day's spend broken down by category (new `detailByDay`, built from categorized transactions).

`StatBar` now accepts a number (animated) or string (static), so the other pages using it are unaffected.

Verified via typecheck + production build. The authed account dashboard can't be exercised in the sandbox preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)