### PR TITLE
fix(accounts): controlled balance animation, reliable chips, colored upcoming icons

### DIFF
--- a/app/src/components/app-ui/StatBar.tsx
+++ b/app/src/components/app-ui/StatBar.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ArrowUpRight, ArrowDownRight, type LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { PriceWheel } from '@/components/PriceWheel';
 
 export interface Stat {
-  /** Number → rolls/animates (green/red on change); string → rendered as-is (already formatted). */
+  /** Number → shows exact value, rolls/flashes only on a real change; string → rendered as-is. */
   value: number | string;
   label: string;
   change?: string;
@@ -13,25 +12,64 @@ export interface Stat {
 }
 
 const fmtUsd = (v: number) => `$${v.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const CHANGE_EPS = 0.01; // ignore sub-cent poll jitter
+
+// Last value shown per stat, kept at module scope so it survives unmount/remount. This is why
+// navigating away and back does NOT re-animate: on remount the value already matches what's stored.
+const lastShown = new Map<string, number>();
 
 /**
- * A single stat value that rolls smoothly to its new figure (and briefly flashes green/red on the
- * direction of change) instead of snapping — the old brokerage "price wheel", reused. Tracking the
- * previous value here means background balance polls animate rather than flicker.
+ * Shows the exact balance, and only PLAYS the rolling/flash animation when the value actually changes
+ * by a meaningful amount (a deposit/withdraw/transfer, or a poll detecting a real balance change) —
+ * not on every re-render, navigation, or sub-cent jitter. It always settles on the precise figure.
  */
-function AnimatedStatValue({ value }: { value: number }) {
-  const prevRef = useRef(value);
+function AnimatedStatValue({ value, statKey }: { value: number; statKey: string }) {
+  const [display, setDisplay] = useState(value);
+  const [flash, setFlash] = useState<'up' | 'down' | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
-    prevRef.current = value;
-  }, [value]);
+    const prev = lastShown.has(statKey) ? (lastShown.get(statKey) as number) : value;
+    lastShown.set(statKey, value);
+    const delta = value - prev;
+
+    // No meaningful change (first mount, navigation to the same value, or micro-jitter) → snap.
+    if (Math.abs(delta) < CHANGE_EPS) {
+      setDisplay(value);
+      return;
+    }
+
+    // Real change → roll from the previous value to the new one and flash the direction.
+    setFlash(delta > 0 ? 'up' : 'down');
+    const from = prev;
+    const to = value;
+    const start = performance.now();
+    const duration = 600;
+    const tick = (now: number) => {
+      const p = Math.min((now - start) / duration, 1);
+      const eased = 1 - Math.pow(1 - p, 3);
+      setDisplay(from + (to - from) * eased);
+      if (p < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        setDisplay(to); // settle on the exact figure
+        if (flashTimer.current) clearTimeout(flashTimer.current);
+        flashTimer.current = setTimeout(() => setFlash(null), 1500);
+      }
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [value, statKey]);
+
+  useEffect(() => () => { if (flashTimer.current) clearTimeout(flashTimer.current); }, []);
+
   return (
-    <PriceWheel
-      value={value}
-      previousValue={prevRef.current}
-      formatter={fmtUsd}
-      duration={600}
-      className="font-display text-2xl tracking-tight text-foreground tabular-nums"
-    />
+    <span className={cn('transition-colors duration-300', flash === 'up' && 'text-emerald-500', flash === 'down' && 'text-rose-500')}>
+      {fmtUsd(display)}
+    </span>
   );
 }
 
@@ -56,7 +94,7 @@ export default function StatBar({ stats, loading, className }: { stats: Stat[]; 
                 {loading ? (
                   <span className="text-muted-foreground">—</span>
                 ) : typeof s.value === 'number' ? (
-                  <AnimatedStatValue value={s.value} />
+                  <AnimatedStatValue value={s.value} statKey={s.label} />
                 ) : (
                   s.value
                 )}

--- a/app/src/components/app-ui/UpcomingCalendar.tsx
+++ b/app/src/components/app-ui/UpcomingCalendar.tsx
@@ -1,5 +1,8 @@
 import { useState } from 'react';
-import { TrendingUp, Calendar, Bell, DollarSign, Plus, type LucideIcon } from 'lucide-react';
+import {
+  TrendingUp, Calendar, Bell, DollarSign, Plus, Home, Zap, CreditCard, Music, Clapperboard,
+  Smartphone, Dumbbell, ShieldCheck, Receipt, type LucideIcon,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export interface UpcomingItem {
@@ -14,6 +17,37 @@ const weekDays = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
 const headerIcons: LucideIcon[] = [TrendingUp, Calendar, Bell];
 const formatAmount = (a: number) => (a >= 1000 ? `$${(a / 1000).toFixed(1)}k` : `$${Math.round(a)}`);
 const fmtMoney = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+// Each upcoming item gets a colored icon by kind. Classes are written out in full so Tailwind keeps them.
+type UpcomingKind = 'income' | 'rent' | 'utility' | 'phone' | 'video' | 'music' | 'card' | 'insurance' | 'fitness' | 'bill';
+const KIND_STYLE: Record<UpcomingKind, { icon: LucideIcon; bg: string; fg: string; label: string }> = {
+  income:    { icon: DollarSign,   bg: 'bg-emerald-500/15', fg: 'text-emerald-500', label: 'Income' },
+  rent:      { icon: Home,         bg: 'bg-amber-500/15',   fg: 'text-amber-500',   label: 'Rent' },
+  utility:   { icon: Zap,          bg: 'bg-sky-500/15',     fg: 'text-sky-500',     label: 'Utilities' },
+  phone:     { icon: Smartphone,   bg: 'bg-cyan-500/15',    fg: 'text-cyan-500',    label: 'Phone' },
+  video:     { icon: Clapperboard, bg: 'bg-violet-500/15',  fg: 'text-violet-500',  label: 'Streaming' },
+  music:     { icon: Music,        bg: 'bg-pink-500/15',    fg: 'text-pink-500',    label: 'Music' },
+  card:      { icon: CreditCard,   bg: 'bg-rose-500/15',    fg: 'text-rose-500',    label: 'Card / loan' },
+  insurance: { icon: ShieldCheck,  bg: 'bg-teal-500/15',    fg: 'text-teal-500',    label: 'Insurance' },
+  fitness:   { icon: Dumbbell,     bg: 'bg-orange-500/15',  fg: 'text-orange-500',  label: 'Fitness' },
+  bill:      { icon: Receipt,      bg: 'bg-secondary',      fg: 'text-muted-foreground', label: 'Bill' },
+};
+
+/** Classify an upcoming item into a kind (for its icon/color) from its direction + merchant name. */
+function classifyUpcoming(item: UpcomingItem): UpcomingKind {
+  if (item.direction === 'in') return 'income';
+  const n = item.name.toLowerCase();
+  const has = (...keys: string[]) => keys.some((k) => n.includes(k));
+  if (has('netflix', 'hulu', 'disney', 'hbo', ' max', 'youtube', 'prime video', 'paramount', 'peacock', 'apple tv', 'sling', 'fubo')) return 'video';
+  if (has('spotify', 'apple music', 'tidal', 'pandora', 'soundcloud', 'amazon music', 'deezer', 'audible')) return 'music';
+  if (has('rent', 'apartment', 'landlord', 'mortgage', 'lease', 'realty', 'property')) return 'rent';
+  if (has('verizon', 'at&t', 't-mobile', 'mint mobile', 'sprint', 'cricket', 'boost mobile')) return 'phone';
+  if (has('electric', 'water', 'energy', 'utility', 'pg&e', 'con ed', 'duke', 'sewer', 'waste', 'internet', 'comcast', 'xfinity', 'spectrum', 'fiber', 'broadband')) return 'utility';
+  if (has('insurance', 'geico', 'allstate', 'state farm', 'progressive', 'nationwide', 'liberty mutual')) return 'insurance';
+  if (has('credit card', 'card payment', 'visa', 'mastercard', 'amex', 'american express', 'loan', 'financing', 'affirm', 'klarna', 'afterpay', 'synchrony', 'capital one', 'discover')) return 'card';
+  if (has('gym', 'fitness', 'peloton', 'crunch', 'equinox', 'anytime')) return 'fitness';
+  return 'bill';
+}
 
 /**
  * Upcoming recurring bills/income calendar — the old portfolio UpcomingTransactions
@@ -101,17 +135,15 @@ export default function UpcomingCalendar({
               </span>
               {hasItems ? (
                 <div className="flex items-center -space-x-1">
-                  {shown.map((it) => (
-                    <span
-                      key={it.id}
-                      className={cn(
-                        'flex h-4 w-4 items-center justify-center rounded-lg border border-card',
-                        it.direction === 'in' ? 'bg-background ring-1 ring-foreground/50' : 'bg-foreground',
-                      )}
-                    >
-                      {it.direction === 'in' && <DollarSign className="h-2 w-2 text-foreground" />}
-                    </span>
-                  ))}
+                  {shown.map((it) => {
+                    const st = KIND_STYLE[classifyUpcoming(it)];
+                    const Icon = st.icon;
+                    return (
+                      <span key={it.id} className={cn('flex h-4 w-4 items-center justify-center rounded-lg border border-card', st.bg)}>
+                        <Icon className={cn('h-2.5 w-2.5', st.fg)} />
+                      </span>
+                    );
+                  })}
                   {overflow && (
                     <span className="flex h-4 w-4 items-center justify-center rounded-lg border border-card bg-secondary text-secondary-foreground">
                       <Plus className="h-2 w-2" />
@@ -131,15 +163,24 @@ export default function UpcomingCalendar({
                   onClick={(e) => e.stopPropagation()}
                 >
                   <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">{monthName} {day}</div>
-                  <div className="space-y-1">
-                    {dayItems.map((it) => (
-                      <div key={it.id} className="flex items-center justify-between gap-3">
-                        <span className="truncate text-[11px] text-muted-foreground">{it.name}</span>
-                        <span className={cn('shrink-0 text-[11px] font-medium tabular-nums', it.direction === 'in' ? 'text-positive' : 'text-foreground')}>
-                          {it.direction === 'in' ? '+' : '−'}{fmtMoney(it.amount)}
-                        </span>
-                      </div>
-                    ))}
+                  <div className="space-y-1.5">
+                    {dayItems.map((it) => {
+                      const st = KIND_STYLE[classifyUpcoming(it)];
+                      const Icon = st.icon;
+                      return (
+                        <div key={it.id} className="flex items-center justify-between gap-3">
+                          <span className="flex min-w-0 items-center gap-1.5">
+                            <span className={cn('flex h-4 w-4 shrink-0 items-center justify-center rounded-lg', st.bg)}>
+                              <Icon className={cn('h-2.5 w-2.5', st.fg)} />
+                            </span>
+                            <span className="truncate text-[11px] text-muted-foreground">{it.name}</span>
+                          </span>
+                          <span className={cn('shrink-0 text-[11px] font-medium tabular-nums', it.direction === 'in' ? 'text-positive' : 'text-foreground')}>
+                            {it.direction === 'in' ? '+' : '−'}{fmtMoney(it.amount)}
+                          </span>
+                        </div>
+                      );
+                    })}
                   </div>
                 </div>
               )}

--- a/app/src/pages/app/AccountsPage.tsx
+++ b/app/src/pages/app/AccountsPage.tsx
@@ -37,24 +37,43 @@ export default function AccountsPage() {
   const upcoming = useUpcoming();
   const { firstName } = useMemberProfile();
 
-  // Real trailing-7-day change for a metric, from the backend balance-history series (returns nothing
-  // until there's enough history to compare). Cash/Savings share the on-chain series — we snapshot the
-  // combined on-chain total, not each token, so both reflect the same on-chain trend.
-  const weekChange = (field: 'totalUsd' | 'onchainUsd' | 'bankUsd'): { change?: string; changePositive?: boolean } => {
+  // Real trailing-7-day change for a metric. Prefers the backend balance-history series (exact, and
+  // it includes external); falls back to net 7-day transaction flow when history isn't backfilled yet
+  // — for stablecoins there's no price movement, so net flow == the balance change. Cash/Savings share
+  // the on-chain figure (we snapshot the combined on-chain total, not each token).
+  const fmtPct = (pct: number) => ({ change: `${Math.abs(pct).toFixed(1)}% this week`, changePositive: pct >= 0 });
+  const weekChange = (
+    field: 'totalUsd' | 'onchainUsd' | 'bankUsd',
+    current: number,
+  ): { change?: string; changePositive?: boolean } => {
     const pts = history.points;
-    if (pts.length < 2) return {};
-    const last = pts[pts.length - 1];
-    const target = new Date(last.date);
-    target.setDate(target.getDate() - 7);
-    let past = pts[0][field];
-    for (const p of pts) {
-      if (new Date(p.date).getTime() <= target.getTime()) past = p[field];
-      else break;
+    if (pts.length >= 2) {
+      const last = pts[pts.length - 1];
+      const target = new Date(last.date);
+      target.setDate(target.getDate() - 7);
+      let past = pts[0][field];
+      for (const p of pts) {
+        if (new Date(p.date).getTime() <= target.getTime()) past = p[field];
+        else break;
+      }
+      if (Math.abs(past) >= 0.01) {
+        const pct = ((last[field] - past) / Math.abs(past)) * 100;
+        if (Number.isFinite(pct)) return fmtPct(pct);
+      }
     }
-    if (!past) return {};
-    const pct = ((last[field] - past) / Math.abs(past)) * 100;
-    if (!Number.isFinite(pct) || Math.abs(pct) < 0.05) return {};
-    return { change: `${Math.abs(pct).toFixed(1)}% this week`, changePositive: pct >= 0 };
+    // Fallback: net signed flow over the last 7 days, scoped to the metric's accounts.
+    const cutoff = Date.now() - 7 * 86_400_000;
+    let net = 0;
+    for (const it of items) {
+      if (it.ts < cutoff) continue;
+      const isBank = it.source === 'bank';
+      const include = field === 'totalUsd' ? true : field === 'bankUsd' ? isBank : !isBank;
+      if (include) net += it.amount;
+    }
+    const past = current - net;
+    if (Math.abs(past) < 0.01) return {};
+    const pct = (net / Math.abs(past)) * 100;
+    return Number.isFinite(pct) ? fmtPct(pct) : {};
   };
 
   // Cash/Savings = the Clear (smart) wallet PLUS every linked wallet, aggregated. (This is a holdings
@@ -125,10 +144,10 @@ export default function AccountsPage() {
       <StatBar
         loading={bal.loading}
         stats={[
-          { label: 'Total balance', value: cash + savings + ext.totalBalance, icon: Wallet, ...weekChange('totalUsd') },
-          { label: 'Cash · USDC', value: cash, icon: Banknote, ...weekChange('onchainUsd') },
-          { label: 'Savings · CLRUSD', value: savings, icon: PiggyBank, ...weekChange('onchainUsd') },
-          { label: 'External · Plaid', value: ext.totalBalance, icon: Landmark, ...weekChange('bankUsd') },
+          { label: 'Total balance', value: cash + savings + ext.totalBalance, icon: Wallet, ...weekChange('totalUsd', cash + savings + ext.totalBalance) },
+          { label: 'Cash · USDC', value: cash, icon: Banknote, ...weekChange('onchainUsd', cash + savings) },
+          { label: 'Savings · CLRUSD', value: savings, icon: PiggyBank, ...weekChange('onchainUsd', cash + savings) },
+          { label: 'External · Plaid', value: ext.totalBalance, icon: Landmark, ...weekChange('bankUsd', ext.totalBalance) },
         ]}
       />
 


### PR DESCRIPTION
Follow-up fixes to the account-page UI.

- **Balance animation is no longer stock-chart-y.** The value shows exactly and only rolls + flashes green/red on a *real* change (≥ $0.01) — a deposit/withdraw/transfer or a poll detecting a balance change. The last value is persisted at module scope so navigating between pages does **not** re-animate, sub-cent poll jitter snaps instead of rolling, and it always settles on the precise figure (fixes "switches on every page change / inaccurate after change"). Removed the PriceWheel from StatBar in favor of this controlled component.
- **Change chips restored + reliable.** They were gated on the backend balance-history series, which is often empty → chips vanished. Now: history first (exact, includes external), falling back to net 7-day transaction flow (for stablecoins, net flow == the balance change).
- **Colored category icons on upcoming transactions.** Income = green $, plus rent, utilities, phone, streaming video, music, card/loan, insurance, fitness, and a default bill — in both the day-cell dots and the day tooltip, classified from merchant name + direction.

Verified via typecheck + production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)