### PR TITLE
style(accounts): soften upcoming icon borders (foreground/20)

### DIFF
--- a/app/src/components/app-ui/UpcomingCalendar.tsx
+++ b/app/src/components/app-ui/UpcomingCalendar.tsx
@@ -139,13 +139,13 @@ export default function UpcomingCalendar({
                     const st = KIND_STYLE[classifyUpcoming(it)];
                     const Icon = st.icon;
                     return (
-                      <span key={it.id} className={cn('flex h-4 w-4 items-center justify-center rounded-lg border border-foreground/70', st.bg)}>
+                      <span key={it.id} className={cn('flex h-4 w-4 items-center justify-center rounded-lg border border-foreground/20', st.bg)}>
                         <Icon className={cn('h-2.5 w-2.5', st.fg)} />
                       </span>
                     );
                   })}
                   {overflow && (
-                    <span className="flex h-4 w-4 items-center justify-center rounded-lg border border-foreground/70 bg-secondary text-secondary-foreground">
+                    <span className="flex h-4 w-4 items-center justify-center rounded-lg border border-foreground/20 bg-secondary text-secondary-foreground">
                       <Plus className="h-2 w-2" />
                     </span>
                   )}
@@ -170,7 +170,7 @@ export default function UpcomingCalendar({
                       return (
                         <div key={it.id} className="flex items-center justify-between gap-3">
                           <span className="flex min-w-0 items-center gap-1.5">
-                            <span className={cn('flex h-4 w-4 shrink-0 items-center justify-center rounded-lg border border-foreground/70', st.bg)}>
+                            <span className={cn('flex h-4 w-4 shrink-0 items-center justify-center rounded-lg border border-foreground/20', st.bg)}>
                               <Icon className={cn('h-2.5 w-2.5', st.fg)} />
                             </span>
                             <span className="truncate text-[11px] text-muted-foreground">{it.name}</span>


### PR DESCRIPTION
Drops the upcoming-transaction icon outlines from `foreground/70` to `foreground/20` so the category color bleeds into the border instead of a hard black/white ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)