### PR TITLE
fix(accounts): calendar tooltips above chrome + edge-aware positioning

### DIFF
--- a/app/src/components/app-ui/SpendHeatmap.tsx
+++ b/app/src/components/app-ui/SpendHeatmap.tsx
@@ -49,6 +49,15 @@ export default function SpendHeatmap({
     ...Array.from({ length: daysInMonth }, (_, i) => i + 1),
   ];
 
+  // Anchor the tooltip to the cell edge on outer columns so it stays within the card (a centered
+  // tooltip on the leftmost column slid under the fixed sidebar).
+  const tipPos = (day: number) => {
+    const col = (startDow + day - 1) % 7;
+    if (col <= 1) return 'left-0';
+    if (col >= 5) return 'right-0';
+    return 'left-1/2 -translate-x-1/2';
+  };
+
   return (
     <div className={cn('flex flex-col rounded-xl border border-border bg-card p-5', className)}>
       <div className="mb-4 flex items-center justify-between">
@@ -108,7 +117,7 @@ export default function SpendHeatmap({
 
               {isActive && (
                 <div
-                  className="absolute bottom-full left-1/2 z-30 mb-1.5 w-44 -translate-x-1/2 rounded-lg border border-border bg-card p-2.5 text-left shadow-xl"
+                  className={cn('absolute bottom-full z-50 mb-1.5 w-44 rounded-lg border border-border bg-card p-2.5 text-left shadow-xl', tipPos(day))}
                   onClick={(e) => e.stopPropagation()}
                 >
                   <div className="mb-1.5 flex items-center justify-between gap-2 border-b border-border pb-1.5">

--- a/app/src/components/app-ui/UpcomingCalendar.tsx
+++ b/app/src/components/app-ui/UpcomingCalendar.tsx
@@ -79,6 +79,15 @@ export default function UpcomingCalendar({
     ...Array.from({ length: daysInMonth }, (_, i) => i + 1),
   ];
 
+  // Anchor the day tooltip to the cell edge for the outer columns so it never overflows the card
+  // (a centered tooltip on the leftmost column slid under the fixed sidebar).
+  const tipPos = (day: number) => {
+    const col = (startDow + day - 1) % 7;
+    if (col <= 1) return 'left-0';
+    if (col >= 5) return 'right-0';
+    return 'left-1/2 -translate-x-1/2';
+  };
+
   return (
     <div className={cn('flex flex-col rounded-xl border border-border bg-card p-5', className)}>
       <div className="mb-4 flex items-center justify-between">
@@ -159,7 +168,7 @@ export default function UpcomingCalendar({
 
               {isActive && (
                 <div
-                  className="absolute bottom-full left-1/2 z-30 mb-1.5 w-48 -translate-x-1/2 rounded-lg border border-border bg-card p-2.5 text-left shadow-xl"
+                  className={cn('absolute bottom-full z-50 mb-1.5 w-48 rounded-lg border border-border bg-card p-2.5 text-left shadow-xl', tipPos(day))}
                   onClick={(e) => e.stopPropagation()}
                 >
                   <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">{monthName} {day}</div>


### PR DESCRIPTION
Day tooltips were `z-30` while the fixed desktop sidebar is `z-40`, so a leftmost-column tooltip (centered with `-translate-x-1/2`) slid **under** the sidebar. Fix: bump tooltips to `z-50` and make them edge-aware — anchor to the cell's left edge on the first two columns (Sun/Mon), the right edge on the last two (Fri/Sat), centered otherwise — so they stay within the card and never overlap the chrome. Applied to both the Upcoming Transactions and Spend This Month calendars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)