### PR TITLE
fix(charts): proper leader-line label layout for spending donut

### DIFF
--- a/app/src/components/app-ui/charts/CategoryRadial.tsx
+++ b/app/src/components/app-ui/charts/CategoryRadial.tsx
@@ -1,6 +1,4 @@
 import { useMemo, useState } from 'react';
-import { Cell, Label, Pie, PieChart, type PieLabelRenderProps } from 'recharts';
-import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from '@/components/ui/chart';
 import { useClearTransactions } from '@/hooks/useClearTransactions';
 import type { Category } from '@/components/app-ui/TransactionFilterModal';
 import { cn } from '@/lib/utils';
@@ -24,42 +22,64 @@ const CATEGORY_COLORS: Record<Category, string> = {
   Payroll: '#22c55e',
 };
 
-const config = {} satisfies ChartConfig;
 const fmtTotal = (n: number) => (n >= 10000 ? `$${(n / 1000).toFixed(1)}k` : `$${Math.round(n).toLocaleString()}`);
 
-const LABEL_GUTTER = 6; // px inset from the chart's horizontal edge
+// Fixed drawing space — the SVG scales responsively via viewBox, so coordinates never depend on the
+// container width and labels can be laid out (and kept in-bounds) deterministically.
+const VB_W = 540;
+const VB_H = 340;
+const CX = 270;
+const CY = 168;
+const R_OUT = 112;
+const R_IN = 74;
+const LABEL_TOP = 20;
+const LABEL_BOTTOM = 316;
+const LABEL_GAP = 24; // min vertical spacing between labels on a side
+const COL_R = CX + R_OUT + 22; // right-side label column x
+const COL_L = CX - R_OUT - 22; // left-side label column x
 
-/**
- * Leader-line geometry that keeps labels on-chart: slice edge → short radial leg → a diagonal knee →
- * a horizontal run to a fixed side gutter (up to 3 angled segments). The label is then anchored at the
- * gutter and grows INWARD (textAnchor end on the right, start on the left), so the words can never run
- * off the edge regardless of length. `cx*2 ≈ chart width` because the PieChart margins are symmetric.
- */
-function leader(cx: number, cy: number, midAngle: number, outerRadius: number) {
-  const RADIAN = Math.PI / 180;
-  const cos = Math.cos(-midAngle * RADIAN);
-  const sin = Math.sin(-midAngle * RADIAN);
-  const dir = cos >= 0 ? 1 : -1;
-  const edge = { x: cx + outerRadius * cos, y: cy + outerRadius * sin };
-  const bend = { x: cx + (outerRadius + 14) * cos, y: cy + (outerRadius + 14) * sin };
-  const knee = { x: bend.x + dir * 14, y: bend.y }; // short diagonal step before the horizontal run
-  const gutterX = dir > 0 ? cx * 2 - LABEL_GUTTER : LABEL_GUTTER;
-  const end = { x: gutterX, y: bend.y };
-  return {
-    edge,
-    bend,
-    knee,
-    end,
-    dir,
-    textX: gutterX + (dir > 0 ? -2 : 2),
-    anchor: (dir > 0 ? 'end' : 'start') as 'end' | 'start',
-  };
+const polar = (r: number, deg: number) => {
+  const a = (deg * Math.PI) / 180;
+  return { x: CX + r * Math.cos(a), y: CY + r * Math.sin(a) };
+};
+
+/** Annular-sector (donut slice) path between two angles (degrees, screen coords). */
+function slicePath(rOut: number, rIn: number, startDeg: number, endDeg: number) {
+  const large = endDeg - startDeg > 180 ? 1 : 0;
+  const o0 = polar(rOut, startDeg);
+  const o1 = polar(rOut, endDeg);
+  const i1 = polar(rIn, endDeg);
+  const i0 = polar(rIn, startDeg);
+  return `M ${o0.x} ${o0.y} A ${rOut} ${rOut} 0 ${large} 1 ${o1.x} ${o1.y} L ${i1.x} ${i1.y} A ${rIn} ${rIn} 0 ${large} 0 ${i0.x} ${i0.y} Z`;
+}
+
+/** Spread labels down a side so they don't overlap, keeping within [top, bottom]. */
+function distribute<T extends { yNat: number }>(items: T[], top: number, bottom: number, gap: number): (T & { y: number })[] {
+  const sorted = [...items].sort((a, b) => a.yNat - b.yNat) as (T & { y: number })[];
+  let cursor = top;
+  for (const it of sorted) {
+    it.y = Math.max(it.yNat, cursor);
+    cursor = it.y + gap;
+  }
+  // If we ran past the bottom, push the whole stack up, then re-clamp to the top.
+  const overflow = cursor - gap - bottom;
+  if (overflow > 0) {
+    for (const it of sorted) it.y -= overflow;
+    let up = top;
+    for (const it of sorted) {
+      it.y = Math.max(it.y, up);
+      up = it.y + gap;
+    }
+  }
+  return sorted;
 }
 
 /**
  * Spending-by-category donut from real transaction history (useClearTransactions). Sums outflows by
- * category over the selected window, with the period total in the middle and leader-line labels
- * (name + %) pointing from each slice. Week/Month/Year switcher in the footer.
+ * category over the selected window, with the period total in the middle. Labels are laid out with
+ * proper leader lines: each is nudged up/down into a side column so they never overlap or clip, and an
+ * angled 3-segment line (radial → diagonal → nub) connects each slice to its label. Week/Month/Year
+ * switcher in the footer.
  */
 export default function CategoryRadial({ className }: { className?: string }) {
   const [range, setRange] = useState<Range>('month');
@@ -80,89 +100,96 @@ export default function CategoryRadial({ className }: { className?: string }) {
 
   const total = data.reduce((s, d) => s + d.value, 0);
   const isEmpty = data.length === 0 || total <= 0;
-  // A single muted ring stands in for the donut when there's nothing to show.
-  const chartData = isEmpty ? [{ name: 'none', value: 1, fill: 'rgb(var(--muted))' }] : data;
+
+  // Build slice geometry + leader-line label layout.
+  const { slices, labels } = useMemo(() => {
+    if (isEmpty) return { slices: [], labels: [] };
+    let acc = -90; // start at top
+    const raw = data.map((d) => {
+      const frac = d.value / total;
+      const start = acc;
+      const end = acc + frac * 360;
+      const mid = (start + end) / 2;
+      acc = end;
+      const midRad = (mid * Math.PI) / 180;
+      const side: 'left' | 'right' = Math.cos(midRad) >= 0 ? 'right' : 'left';
+      return {
+        name: d.name,
+        fill: d.fill,
+        value: d.value,
+        pct: Math.round(frac * 100),
+        d: slicePath(R_OUT, R_IN, start, Math.max(end, start + 0.5)),
+        mid,
+        side,
+        edge: polar(R_OUT, mid),
+        elbow: polar(R_OUT + 12, mid),
+        yNat: CY + (R_OUT + 12) * Math.sin(midRad),
+      };
+    });
+
+    const laid = [
+      ...distribute(raw.filter((r) => r.side === 'left'), LABEL_TOP, LABEL_BOTTOM, LABEL_GAP),
+      ...distribute(raw.filter((r) => r.side === 'right'), LABEL_TOP, LABEL_BOTTOM, LABEL_GAP),
+    ].map((r) => {
+      const dir = r.side === 'right' ? 1 : -1;
+      const col = r.side === 'right' ? COL_R : COL_L;
+      return {
+        key: r.name,
+        fill: r.fill,
+        text: `${r.name} ${r.pct}%`,
+        points: `${r.edge.x},${r.edge.y} ${r.elbow.x},${r.elbow.y} ${col},${r.y} ${col + dir * 8},${r.y}`,
+        textX: col + dir * 12,
+        textY: r.y,
+        anchor: (dir > 0 ? 'start' : 'end') as 'start' | 'end',
+      };
+    });
+
+    return { slices: raw, labels: laid };
+  }, [data, total, isEmpty]);
 
   return (
     <div className={cn('flex flex-col rounded-xl border border-border bg-card p-5', className)}>
       <h3 className="text-xs font-medium text-muted-foreground">Spending by category</h3>
 
       <div className="flex flex-1 items-center justify-center">
-        <ChartContainer config={config} height={360} className="mx-auto w-full max-w-[520px]">
-          <PieChart margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
-            {!isEmpty && (
-              <ChartTooltip content={<ChartTooltipContent hideLabel formatter={(v) => `$${Number(v).toLocaleString()}`} />} />
-            )}
-            <Pie
-              data={chartData}
-              dataKey="value"
-              nameKey="name"
-              innerRadius="46%"
-              outerRadius="64%"
-              paddingAngle={isEmpty ? 0 : 2}
-              strokeWidth={2}
-              stroke="rgb(var(--card))"
-              isAnimationActive={!isEmpty}
-              labelLine={
-                isEmpty
-                  ? false
-                  : (p) => {
-                      const { edge, bend, knee, end } = leader(Number(p.cx ?? 0), Number(p.cy ?? 0), Number(p.midAngle ?? 0), Number(p.outerRadius ?? 0));
-                      return (
-                        <polyline
-                          points={`${edge.x},${edge.y} ${bend.x},${bend.y} ${knee.x},${knee.y} ${end.x},${end.y}`}
-                          stroke="rgb(var(--border))"
-                          strokeWidth={1}
-                          fill="none"
-                        />
-                      );
-                    }
-              }
-              label={
-                isEmpty
-                  ? false
-                  : (p: PieLabelRenderProps) => {
-                      const { textX, end, anchor } = leader(Number(p.cx ?? 0), Number(p.cy ?? 0), Number(p.midAngle ?? 0), Number(p.outerRadius ?? 0));
-                      return (
-                        <text
-                          x={textX}
-                          y={end.y}
-                          textAnchor={anchor}
-                          dominantBaseline="central"
-                          className="fill-foreground"
-                          fontSize={11}
-                          fontWeight={500}
-                        >
-                          {`${p.payload?.name ?? ''} ${Math.round((p.percent ?? 0) * 100)}%`}
-                        </text>
-                      );
-                    }
-              }
-            >
-              {chartData.map((d) => (
-                <Cell key={d.name} fill={d.fill} />
+        <svg viewBox={`0 0 ${VB_W} ${VB_H}`} className="mx-auto w-full max-w-[560px]" role="img" aria-label="Spending by category">
+          {isEmpty ? (
+            <path d={slicePath(R_OUT, R_IN, -90, 269.5)} fill="rgb(var(--muted))" />
+          ) : (
+            <>
+              {slices.map((s) => (
+                <path key={s.name} d={s.d} fill={s.fill} stroke="rgb(var(--card))" strokeWidth={2}>
+                  <title>{`${s.name}: $${s.value.toLocaleString()}`}</title>
+                </path>
               ))}
-              <Label
-                content={({ viewBox }) => {
-                  if (viewBox && 'cx' in viewBox && typeof viewBox.cx === 'number' && typeof viewBox.cy === 'number') {
-                    const { cx, cy } = viewBox;
-                    return (
-                      <text x={cx} y={cy} textAnchor="middle" dominantBaseline="central">
-                        <tspan x={cx} y={cy - 10} className="fill-foreground font-display" style={{ fontSize: 30, fontWeight: 600 }}>
-                          {fmtTotal(isEmpty ? 0 : total)}
-                        </tspan>
-                        <tspan x={cx} y={cy + 17} className="fill-muted-foreground" style={{ fontSize: 12 }}>
-                          {loading && isEmpty ? 'loading…' : `spent ${SUB[range]}`}
-                        </tspan>
-                      </text>
-                    );
-                  }
-                  return null;
-                }}
-              />
-            </Pie>
-          </PieChart>
-        </ChartContainer>
+              {labels.map((l) => (
+                <g key={l.key}>
+                  <polyline points={l.points} stroke="rgb(var(--border))" strokeWidth={1} fill="none" />
+                  <text
+                    x={l.textX}
+                    y={l.textY}
+                    textAnchor={l.anchor}
+                    dominantBaseline="central"
+                    className="fill-foreground"
+                    fontSize={12}
+                    fontWeight={500}
+                  >
+                    {l.text}
+                  </text>
+                </g>
+              ))}
+            </>
+          )}
+
+          <text x={CX} y={CY} textAnchor="middle">
+            <tspan x={CX} y={CY - 8} className="fill-foreground font-display" style={{ fontSize: 30, fontWeight: 600 }}>
+              {fmtTotal(isEmpty ? 0 : total)}
+            </tspan>
+            <tspan x={CX} y={CY + 18} className="fill-muted-foreground" style={{ fontSize: 12 }}>
+              {loading && isEmpty ? 'loading…' : `spent ${SUB[range]}`}
+            </tspan>
+          </text>
+        </svg>
       </div>
 
       {isEmpty && <p className="-mt-1 text-center text-xs text-muted-foreground">No spending {SUB[range]}.</p>}


### PR DESCRIPTION
The category labels were sitting flat on the lines and couldn't use the vertical space, because Recharts' per-label callback can't see sibling labels (so no decluttering/staggering).

Replaced the Recharts pie with a hand-rolled fixed-`viewBox` SVG donut so the whole label layout is under our control:
- Labels are **distributed vertically** into left/right columns — nudged up/down so they never overlap, and kept within the viewBox so they never clip (the SVG scales responsively).
- Each slice connects to its label via an **angled 3-segment leader line** (radial leg → diagonal to the label's row → short nub), with the **text set beside the line end**, not lying on it.
- Kept the Week/Month/Year switcher, empty state, center total, and per-slice hover (shows `$amount` via `<title>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)