### PR TITLE
feat(notifications): true backend notifications — persistent, realtime, push, + messages

### DIFF
--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -25,7 +25,8 @@
         "plaid": "^41.1.0",
         "redis": "^4.6.12",
         "socket.io": "^4.8.3",
-        "viem": "^2.53.1"
+        "viem": "^2.53.1",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "@types/bun": "^1.3.6",
@@ -33,6 +34,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/node": "^20.10.6",
+        "@types/web-push": "^3.6.4",
         "@typescript-eslint/eslint-plugin": "^6.17.0",
         "@typescript-eslint/parser": "^6.17.0",
         "eslint": "^8.56.0",
@@ -566,6 +568,14 @@
       "resolved": "https://registry.npmjs.org/@simplewebauthn/types/-/types-9.0.1.tgz",
       "integrity": "sha512-tGSRP1QvsAvsJmnOlRQyw/mvK9gnPtjEc5fg2+m8n+QUa+D7rvrKkOYyfpy42GTs90X3RDOnqJgfHt+qO67/+w==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
+    },
+    "node_modules/@simplewebauthn/typescript-types": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/typescript-types/-/typescript-types-8.3.4.tgz",
+      "integrity": "sha512-38xtca0OqfRVNloKBrFB5LEM6PN5vzFbJG6rAutPVrtGHFYxPdiV3btYWq0eAZAZmP+dqFPYJxJWeJrGfmYHng==",
+      "deprecated": "This package has been renamed to @simplewebauthn/types. Please install @simplewebauthn/types instead to ensure you receive future updates.",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
@@ -1844,6 +1854,16 @@
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "license": "MIT"
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "7.4.7",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
@@ -2096,6 +2116,68 @@
         "viem": "^2.28.0"
       }
     },
+    "node_modules/@zerodev/webauthn-key": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@zerodev/webauthn-key/-/webauthn-key-5.5.0.tgz",
+      "integrity": "sha512-AbD2d/qrsX7AWxJMEfwxnLbp1TjiUjc1V4ne3Q40UJxKe+lW64Td+y8OD0qSFMqgN6rQxJZ0aOAXmat8H6xluA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@simplewebauthn/browser": "^8.3.4",
+        "@simplewebauthn/types": "^12.0.0"
+      },
+      "peerDependencies": {
+        "viem": "^2.28.0"
+      }
+    },
+    "node_modules/@zerodev/webauthn-key/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@zerodev/webauthn-key/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@zerodev/webauthn-key/node_modules/@simplewebauthn/browser": {
+      "version": "8.3.7",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-8.3.7.tgz",
+      "integrity": "sha512-ZtRf+pUEgOCvjrYsbMsJfiHOdKcrSZt2zrAnIIpfmA06r0FxBovFYq0rJ171soZbe13KmWzAoLKjSxVW7KxCdQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@simplewebauthn/typescript-types": "^8.3.4"
+      }
+    },
+    "node_modules/@zerodev/webauthn-key/node_modules/@simplewebauthn/types": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-q6y8MkoV8V8jB4zzp18Uyj2I7oFp2/ONL8c3j8uT06AOWu3cIChc1au71QYHrP2b+xDapkGTiv+9lX7xkTlAsA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/abitype": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
@@ -2157,6 +2239,15 @@
     "node_modules/aes-js": {
       "version": "4.0.0-beta.5",
       "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
@@ -2223,6 +2314,24 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.4.tgz",
+      "integrity": "sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g==",
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2395,6 +2504,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-reverse": {
       "version": "1.0.1",
@@ -2763,6 +2878,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -3658,6 +3782,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "license": "MIT",
@@ -3674,6 +3807,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/humanize-ms": {
@@ -3957,6 +4103,27 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "license": "ISC"
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "dev": true,
@@ -4113,6 +4280,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -5190,7 +5372,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -5362,6 +5543,25 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/web3-utils": {

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -32,7 +32,8 @@
     "plaid": "^41.1.0",
     "redis": "^4.6.12",
     "socket.io": "^4.8.3",
-    "viem": "^2.53.1"
+    "viem": "^2.53.1",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@types/bun": "^1.3.6",
@@ -40,6 +41,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^20.10.6",
+    "@types/web-push": "^3.6.4",
     "@typescript-eslint/eslint-plugin": "^6.17.0",
     "@typescript-eslint/parser": "^6.17.0",
     "eslint": "^8.56.0",

--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -33,6 +33,7 @@ import onramperWebhookRouter from './routes/onramperWebhook.js';
 import { startPriceUpdater } from './jobs/priceUpdater.js';
 import { startPortfolioSnapshotter } from './jobs/portfolioSnapshotter.js';
 import { startAutopayRunner } from './jobs/autopayRunner.js';
+import { startDueBillNotifier } from './jobs/dueBillNotifier.js';
 import { websocketService } from './services/websocketService.js';
 import { eventListenerService } from './services/eventListenerService.js';
 
@@ -247,6 +248,9 @@ async function startServer() {
     });
     startAutopayRunner().catch((error) => {
       console.error('⚠️ Autopay runner failed to start:', error);
+    });
+    startDueBillNotifier().catch((error) => {
+      console.error('⚠️ Due-bill notifier failed to start:', error);
     });
 
     // Start HTTP server (Express + WebSocket)

--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -27,6 +27,7 @@ import payRouter from './routes/pay.js';
 import withdrawRouter from './routes/withdraw.js';
 import autopayRouter from './routes/autopay.js';
 import contactsRouter from './routes/contacts.js';
+import notificationsRouter from './routes/notifications.js';
 import onramperRouter from './routes/onramper.js';
 import onramperWebhookRouter from './routes/onramperWebhook.js';
 import { startPriceUpdater } from './jobs/priceUpdater.js';
@@ -194,6 +195,7 @@ async function startServer() {
     app.use('/api/withdraw', requireAuth, withdrawRouter);
     app.use('/api/autopay', requireAuth, autopayRouter);
     app.use('/api/contacts', requireAuth, contactsRouter);
+    app.use('/api/notifications', requireAuth, notificationsRouter);
     app.use('/api/onramper', requireAuth, onramperRouter);
 
     console.log('✅ API routes registered:');

--- a/app/server/src/jobs/dueBillNotifier.ts
+++ b/app/server/src/jobs/dueBillNotifier.ts
@@ -1,0 +1,63 @@
+import { getPayPool } from '../config/postgres.js';
+import { notificationStore } from '../services/notificationStore.js';
+
+/*
+ * Daily-ish scheduled producer: emits "bill due soon" notifications for billers due within 3 days that
+ * haven't been paid this period. Idempotent per biller+period via the notification dedupe key, so it's
+ * safe to run repeatedly. See services/payLedgerStore.ts (pay_billers / pay_payments).
+ */
+const CHECK_MS = 12 * 60 * 60 * 1000; // twice a day
+const DUE_WINDOW_DAYS = 3;
+
+interface DueBillRow {
+  id: string;
+  wallet: string;
+  name: string;
+  type: string;
+  due_day: number;
+  default_amount: string | null;
+}
+
+async function run(): Promise<void> {
+  const pool = getPayPool();
+  if (!pool) return;
+  const now = new Date();
+  const period = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  const today = now.getDate();
+  try {
+    const { rows } = await pool.query<DueBillRow>(
+      `SELECT b.id, b.wallet, b.name, b.type, b.due_day, b.default_amount
+         FROM pay_billers b
+        WHERE b.archived_at IS NULL AND b.due_day IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM pay_payments p
+             WHERE p.wallet = b.wallet AND p.biller_id = b.id AND p.period = $1
+          )`,
+      [period],
+    );
+    for (const b of rows) {
+      const diff = Number(b.due_day) - today;
+      if (diff < 0 || diff > DUE_WINDOW_DAYS) continue;
+      const amt = b.default_amount
+        ? `$${Number(b.default_amount).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+        : '';
+      await notificationStore
+        .emit({
+          wallet: b.wallet,
+          kind: 'due',
+          title: b.type === 'rent' ? 'Rent due soon' : 'Bill due soon',
+          body: `${b.name}${amt ? ` · ${amt}` : ''} · ${diff === 0 ? 'due today' : `due in ${diff}d`}`,
+          data: { billerId: b.id, href: '/pay' },
+          dedupeKey: `due:${b.id}:${period}`,
+        })
+        .catch(() => {});
+    }
+  } catch (e) {
+    console.error('[dueBillNotifier] error', e);
+  }
+}
+
+export async function startDueBillNotifier(): Promise<void> {
+  await run();
+  setInterval(() => void run(), CHECK_MS);
+}

--- a/app/server/src/routes/notifications.ts
+++ b/app/server/src/routes/notifications.ts
@@ -36,6 +36,17 @@ router.post('/:wallet/:id/read', requireWalletMatch, async (req, res) => {
   res.json({ ok: true });
 });
 
+// POST /api/notifications/:wallet/subscribe — register a Web Push subscription
+router.post('/:wallet/subscribe', requireWalletMatch, async (req, res) => {
+  const { subscription } = (req.body ?? {}) as { subscription?: { endpoint?: string } & Record<string, unknown> };
+  if (!subscription?.endpoint) {
+    res.status(400).json({ error: 'Missing subscription' });
+    return;
+  }
+  await notificationStore.saveSubscription(wallet(req), subscription);
+  res.json({ ok: true });
+});
+
 // POST /api/notifications/:wallet/:id/archive
 router.post('/:wallet/:id/archive', requireWalletMatch, async (req, res) => {
   await notificationStore.archive(wallet(req), String(req.params.id));

--- a/app/server/src/routes/notifications.ts
+++ b/app/server/src/routes/notifications.ts
@@ -1,0 +1,45 @@
+import { Router, type Request, type Response } from 'express';
+import { requireWalletMatch } from '../middleware/auth.js';
+import { notificationStore } from '../services/notificationStore.js';
+
+/*
+ * In-app notifications, wallet-scoped (requireWalletMatch) under requireAuth. Read model only — rows are
+ * created server-side by producers (transfers, equity credits, cron). See services/notificationStore.ts.
+ */
+const router = Router();
+const wallet = (req: Request) => String(req.params.wallet || '').toLowerCase();
+
+function ensureReady(res: Response): boolean {
+  if (!notificationStore.isConfigured()) {
+    res.json({ notifications: [], unreadCount: 0 });
+    return false;
+  }
+  return true;
+}
+
+// GET /api/notifications/:wallet → { notifications, unreadCount }
+router.get('/:wallet', requireWalletMatch, async (req, res) => {
+  if (!ensureReady(res)) return;
+  const data = await notificationStore.list(wallet(req));
+  res.json(data);
+});
+
+// POST /api/notifications/:wallet/read-all
+router.post('/:wallet/read-all', requireWalletMatch, async (req, res) => {
+  await notificationStore.markAllRead(wallet(req));
+  res.json({ ok: true });
+});
+
+// POST /api/notifications/:wallet/:id/read
+router.post('/:wallet/:id/read', requireWalletMatch, async (req, res) => {
+  await notificationStore.markRead(wallet(req), String(req.params.id));
+  res.json({ ok: true });
+});
+
+// POST /api/notifications/:wallet/:id/archive
+router.post('/:wallet/:id/archive', requireWalletMatch, async (req, res) => {
+  await notificationStore.archive(wallet(req), String(req.params.id));
+  res.json({ ok: true });
+});
+
+export default router;

--- a/app/server/src/services/notificationStore.ts
+++ b/app/server/src/services/notificationStore.ts
@@ -1,0 +1,151 @@
+import crypto from 'crypto';
+import { getPostgresPool } from '../config/postgres.js';
+import { websocketService } from './websocketService.js';
+
+/*
+ * Persistent in-app notifications, scoped by owner wallet (same scoping as contacts / pay_credits, and
+ * matches how producers + the WebSocket already target addresses). Producers call `emit()` with a
+ * stable `dedupeKey` so the same event can't create duplicates; new rows are pushed live over the
+ * WebSocket as `notification:new`. The client fetches, marks read, and archives via /api/notifications.
+ */
+const TABLE = 'notifications';
+let ensured = false;
+
+export type NotificationKind =
+  | 'received' | 'sent' | 'card' | 'pending' | 'credit' | 'milestone' | 'due' | 'kyc' | 'system';
+
+export interface NotificationRow {
+  id: string;
+  kind: NotificationKind;
+  title: string;
+  body: string;
+  data: Record<string, unknown> | null;
+  read: boolean;
+  createdAt: string;
+}
+
+interface DbRow {
+  id: string;
+  kind: NotificationKind;
+  title: string;
+  body: string;
+  data: Record<string, unknown> | null;
+  read_at: string | null;
+  created_at: string;
+}
+
+const normalizeWallet = (w: string) => w.trim().toLowerCase();
+
+async function ensureTables(): Promise<void> {
+  const pool = getPostgresPool();
+  if (!pool || ensured) return;
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS ${TABLE} (
+      id TEXT PRIMARY KEY,
+      owner_wallet TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      title TEXT NOT NULL,
+      body TEXT NOT NULL,
+      data JSONB,
+      dedupe_key TEXT NOT NULL,
+      read_at TIMESTAMPTZ,
+      archived_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS notifications_dedupe_idx ON ${TABLE} (owner_wallet, dedupe_key);
+    CREATE INDEX IF NOT EXISTS notifications_owner_created_idx ON ${TABLE} (owner_wallet, created_at DESC);
+  `);
+  ensured = true;
+}
+
+const toRow = (r: DbRow): NotificationRow => ({
+  id: r.id,
+  kind: r.kind,
+  title: r.title,
+  body: r.body,
+  data: r.data,
+  read: r.read_at != null,
+  createdAt: r.created_at,
+});
+
+export interface EmitInput {
+  wallet: string;
+  kind: NotificationKind;
+  title: string;
+  body: string;
+  data?: Record<string, unknown> | null;
+  /** Stable key so the same event never duplicates (e.g. `tx:0xabc`, `credit:2026-06`). */
+  dedupeKey: string;
+}
+
+export const notificationStore = {
+  isConfigured(): boolean {
+    return !!getPostgresPool();
+  },
+
+  /** Create a notification (idempotent by dedupeKey) and push it live over the WebSocket if new. */
+  async emit(input: EmitInput): Promise<NotificationRow | null> {
+    const pool = getPostgresPool();
+    if (!pool) return null;
+    await ensureTables();
+    const wallet = normalizeWallet(input.wallet);
+    const id = crypto.randomUUID();
+    const result = await pool.query<DbRow>(
+      `INSERT INTO ${TABLE} (id, owner_wallet, kind, title, body, data, dedupe_key)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (owner_wallet, dedupe_key) DO NOTHING
+       RETURNING id, kind, title, body, data, read_at, created_at`,
+      [id, wallet, input.kind, input.title, input.body, input.data ?? null, input.dedupeKey],
+    );
+    const row = result.rows[0];
+    if (!row) return null; // deduped — already existed
+    const notif = toRow(row);
+    try {
+      await websocketService.broadcastToAddress(wallet, 'notification:new', notif);
+    } catch {
+      /* realtime is best-effort */
+    }
+    return notif;
+  },
+
+  async list(wallet: string, limit = 40): Promise<{ notifications: NotificationRow[]; unreadCount: number }> {
+    const pool = getPostgresPool();
+    if (!pool) return { notifications: [], unreadCount: 0 };
+    await ensureTables();
+    const w = normalizeWallet(wallet);
+    const [rows, counts] = await Promise.all([
+      pool.query<DbRow>(
+        `SELECT id, kind, title, body, data, read_at, created_at FROM ${TABLE}
+           WHERE owner_wallet = $1 AND archived_at IS NULL
+           ORDER BY created_at DESC LIMIT $2`,
+        [w, Math.min(Math.max(limit, 1), 100)],
+      ),
+      pool.query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM ${TABLE} WHERE owner_wallet = $1 AND archived_at IS NULL AND read_at IS NULL`,
+        [w],
+      ),
+    ]);
+    return { notifications: rows.rows.map(toRow), unreadCount: Number(counts.rows[0]?.count ?? 0) };
+  },
+
+  async markRead(wallet: string, id: string): Promise<void> {
+    const pool = getPostgresPool();
+    if (!pool) return;
+    await ensureTables();
+    await pool.query(`UPDATE ${TABLE} SET read_at = now() WHERE owner_wallet = $1 AND id = $2 AND read_at IS NULL`, [normalizeWallet(wallet), id]);
+  },
+
+  async markAllRead(wallet: string): Promise<void> {
+    const pool = getPostgresPool();
+    if (!pool) return;
+    await ensureTables();
+    await pool.query(`UPDATE ${TABLE} SET read_at = now() WHERE owner_wallet = $1 AND read_at IS NULL`, [normalizeWallet(wallet)]);
+  },
+
+  async archive(wallet: string, id: string): Promise<void> {
+    const pool = getPostgresPool();
+    if (!pool) return;
+    await ensureTables();
+    await pool.query(`UPDATE ${TABLE} SET archived_at = now() WHERE owner_wallet = $1 AND id = $2`, [normalizeWallet(wallet), id]);
+  },
+};

--- a/app/server/src/services/notificationStore.ts
+++ b/app/server/src/services/notificationStore.ts
@@ -1,6 +1,10 @@
 import crypto from 'crypto';
 import { getPostgresPool } from '../config/postgres.js';
 import { websocketService } from './websocketService.js';
+import { pushService } from './pushService.js';
+
+// Kinds worth a Web Push (arrive when the app is closed); noisy/low-value ones stay in-app only.
+const PUSH_KINDS = new Set<NotificationKind>(['received', 'credit', 'milestone', 'due', 'kyc']);
 
 /*
  * Persistent in-app notifications, scoped by owner wallet (same scoping as contacts / pay_credits, and
@@ -54,6 +58,13 @@ async function ensureTables(): Promise<void> {
     );
     CREATE UNIQUE INDEX IF NOT EXISTS notifications_dedupe_idx ON ${TABLE} (owner_wallet, dedupe_key);
     CREATE INDEX IF NOT EXISTS notifications_owner_created_idx ON ${TABLE} (owner_wallet, created_at DESC);
+    CREATE TABLE IF NOT EXISTS push_subscriptions (
+      endpoint TEXT PRIMARY KEY,
+      owner_wallet TEXT NOT NULL,
+      subscription JSONB NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    CREATE INDEX IF NOT EXISTS push_subs_wallet_idx ON push_subscriptions (owner_wallet);
   `);
   ensured = true;
 }
@@ -105,7 +116,24 @@ export const notificationStore = {
     } catch {
       /* realtime is best-effort */
     }
+    // Web Push for important kinds so it lands even when the app is closed (best-effort).
+    if (PUSH_KINDS.has(notif.kind)) {
+      void pushService.sendToWallet(wallet, { title: notif.title, body: notif.body, data: notif.data, tag: notif.id }).catch(() => {});
+    }
     return notif;
+  },
+
+  /** Register/refresh a Web Push subscription for a wallet (keyed by endpoint). */
+  async saveSubscription(wallet: string, subscription: { endpoint?: string } & Record<string, unknown>): Promise<void> {
+    const pool = getPostgresPool();
+    if (!pool || !subscription?.endpoint) return;
+    await ensureTables();
+    await pool.query(
+      `INSERT INTO push_subscriptions (endpoint, owner_wallet, subscription)
+         VALUES ($1, $2, $3)
+       ON CONFLICT (endpoint) DO UPDATE SET owner_wallet = EXCLUDED.owner_wallet, subscription = EXCLUDED.subscription`,
+      [subscription.endpoint, normalizeWallet(wallet), subscription],
+    );
   },
 
   async list(wallet: string, limit = 40): Promise<{ notifications: NotificationRow[]; unreadCount: number }> {

--- a/app/server/src/services/payLedgerStore.ts
+++ b/app/server/src/services/payLedgerStore.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import { getPayPool } from '../config/postgres.js';
 import { encryptSendContact, decryptSendContact } from '../utils/sendEncryption.js';
+import { notificationStore } from './notificationStore.js';
 
 /*
  * Clear Pay rent/bill → equity-credit ledger (off-chain, Railway Postgres). Append-only credit rows
@@ -378,6 +379,16 @@ export const payLedgerStore = {
        VALUES ($1,$2,$3,$4,$5,$6,$7,'pending',$8,$9) ON CONFLICT (payment_id) DO NOTHING`,
       [crypto.randomUUID(), input.wallet, paymentId, amount, input.type === 'rent' ? 'rent_on_time' : 'bill_on_time', input.source, streak, vestUntil, input.network ?? 'mainnet'],
     );
+    if (amount > 0) {
+      void notificationStore.emit({
+        wallet: input.wallet,
+        kind: 'credit',
+        title: 'Equity credits earned',
+        body: `+${amount} credits for on-time ${input.type === 'rent' ? 'rent' : input.name}`,
+        data: { amount, reason: input.type, href: '/' },
+        dedupeKey: `credit:${paymentId}`,
+      }).catch(() => {});
+    }
     return { creditAwarded: amount, onTime, duplicate: false };
   },
 
@@ -419,6 +430,14 @@ export const payLedgerStore = {
       [crypto.randomUUID(), input.wallet, `deposit:${input.txRef}`, award, vestUntil, input.network],
     );
     if (ins.rowCount === 0) return { creditAwarded: 0, duplicate: true };
+    void notificationStore.emit({
+      wallet: input.wallet,
+      kind: 'credit',
+      title: '1:1 match applied',
+      body: `+${award} equity credits matched on your savings deposit`,
+      data: { amount: award, reason: 'deposit_match', href: '/' },
+      dedupeKey: `credit:deposit:${input.txRef}`,
+    }).catch(() => {});
     return { creditAwarded: award, duplicate: false };
   },
 

--- a/app/server/src/services/pushService.ts
+++ b/app/server/src/services/pushService.ts
@@ -1,0 +1,57 @@
+import webpush from 'web-push';
+import { getPostgresPool } from '../config/postgres.js';
+
+/*
+ * Web Push (VAPID) delivery for notifications — lets important notifications arrive when the app is
+ * closed (PWA). Subscriptions live in push_subscriptions (see notificationStore.ensureTables). Set
+ * VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY / VAPID_SUBJECT in the server env; if unset, this no-ops.
+ */
+const PUBLIC = process.env.VAPID_PUBLIC_KEY?.trim();
+const PRIVATE = process.env.VAPID_PRIVATE_KEY?.trim();
+const SUBJECT = process.env.VAPID_SUBJECT?.trim() || 'mailto:support@useclear.org';
+
+let configured = false;
+if (PUBLIC && PRIVATE) {
+  try {
+    webpush.setVapidDetails(SUBJECT, PUBLIC, PRIVATE);
+    configured = true;
+  } catch (e) {
+    console.error('[push] VAPID configuration failed:', e);
+  }
+}
+
+const TABLE = 'push_subscriptions';
+
+export const pushService = {
+  isConfigured: () => configured,
+
+  /** Send a push to every registered subscription for a wallet; prune dead endpoints (404/410). */
+  async sendToWallet(wallet: string, payload: { title: string; body: string; data?: Record<string, unknown> | null; tag?: string }): Promise<void> {
+    const pool = getPostgresPool();
+    if (!pool || !configured) return;
+    const w = wallet.trim().toLowerCase();
+    let rows: { endpoint: string; subscription: webpush.PushSubscription }[] = [];
+    try {
+      const res = await pool.query<{ endpoint: string; subscription: webpush.PushSubscription }>(
+        `SELECT endpoint, subscription FROM ${TABLE} WHERE owner_wallet = $1`,
+        [w],
+      );
+      rows = res.rows;
+    } catch {
+      return;
+    }
+    const body = JSON.stringify({ title: payload.title, body: payload.body, data: payload.data ?? {}, tag: payload.tag });
+    await Promise.all(
+      rows.map(async (r) => {
+        try {
+          await webpush.sendNotification(r.subscription, body);
+        } catch (err) {
+          const status = (err as { statusCode?: number })?.statusCode;
+          if (status === 404 || status === 410) {
+            await pool.query(`DELETE FROM ${TABLE} WHERE endpoint = $1`, [r.endpoint]).catch(() => {});
+          }
+        }
+      }),
+    );
+  },
+};

--- a/app/server/src/services/transfersService.ts
+++ b/app/server/src/services/transfersService.ts
@@ -1,5 +1,6 @@
 import { getAlchemyRestUrl, getAlchemyApiKey } from '../utils/rpc.js';
 import { websocketService } from './websocketService.js';
+import { notificationStore } from './notificationStore.js';
 import { getRedisClient, CacheService, CacheKeys } from '../config/redis.js';
 import { computeUnitTracker } from '../utils/computeUnitTracker.js';
 import { getAlchemyPricesBatch } from './priceService.js';
@@ -727,6 +728,9 @@ class TransfersService {
     const isIncoming = toLower === normalizedAddress;
     const isOutgoing = fromLower === normalizedAddress;
 
+    const t = transfer as { value?: string | number; asset?: string; hash?: string };
+    const amountLabel = t.value != null ? `${t.value} ${t.asset ?? ''}`.trim() : (t.asset ?? 'funds');
+
     if (isIncoming && transfer.to) {
       await websocketService.broadcastToAddress(transfer.to, 'transfer_received', {
         chainId,
@@ -734,6 +738,14 @@ class TransfersService {
         type: 'incoming',
         timestamp: Date.now(),
       });
+      void notificationStore.emit({
+        wallet: transfer.to,
+        kind: 'received',
+        title: 'Money received',
+        body: `You received ${amountLabel}`,
+        data: { txHash: t.hash ?? null, chainId, href: '/transactions' },
+        dedupeKey: `tx:${t.hash ?? `${transfer.to}-${Date.now()}`}:in`,
+      }).catch(() => {});
     }
 
     if (isOutgoing && transfer.from) {
@@ -743,6 +755,14 @@ class TransfersService {
         type: 'outgoing',
         timestamp: Date.now(),
       });
+      void notificationStore.emit({
+        wallet: transfer.from,
+        kind: 'sent',
+        title: 'Payment sent',
+        body: `You sent ${amountLabel}`,
+        data: { txHash: t.hash ?? null, chainId, href: '/transactions' },
+        dedupeKey: `tx:${t.hash ?? `${transfer.from}-${Date.now()}`}:out`,
+      }).catch(() => {});
     }
 
     // Also send a general balance update

--- a/app/src/components/app-ui/NotificationsMenu.tsx
+++ b/app/src/components/app-ui/NotificationsMenu.tsx
@@ -1,38 +1,45 @@
-import { useState, type ReactNode } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import { motion, AnimatePresence, type PanInfo } from 'framer-motion';
-import { Bell, ArrowDownLeft, Receipt, Sparkles, CreditCard, Trash2, ShieldCheck, type LucideIcon } from 'lucide-react';
+import {
+  Bell, ArrowDownLeft, ArrowUpRight, Receipt, Sparkles, CreditCard, Clock, Trash2, ShieldCheck, type LucideIcon,
+} from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import { useNotifications } from '@/hooks/useNotifications';
+import { useXMTP } from '@/context/XMTPContext';
 import { cn } from '@/lib/utils';
 
-interface Notif {
-  id: string;
-  icon: LucideIcon;
-  tint: string;
-  title: string;
-  body: string;
-  time: string;
-  unread: boolean;
-}
-const NOTIFS0: Notif[] = [
-  { id: '1', icon: ArrowDownLeft, tint: 'bg-positive/10 text-positive', title: 'Money received', body: '+$349.00 from Macellyn Annya', time: '2h', unread: true },
-  { id: '2', icon: Sparkles, tint: 'bg-info/10 text-info', title: '1:1 match applied', body: '+$520 added to your Clear Deed', time: '5h', unread: true },
-  { id: '3', icon: Receipt, tint: 'bg-negative/10 text-negative', title: 'Rent due soon', body: '$1,850 due in 3 days', time: '1d', unread: false },
-  { id: '4', icon: CreditCard, tint: 'bg-secondary text-foreground', title: 'Card payment posted', body: '$320.00 · Card', time: '2d', unread: false },
-];
+// kind → icon + tint (matches the notification kinds emitted by the backend producers).
+const KIND_STYLE: Record<string, { icon: LucideIcon; tint: string }> = {
+  received: { icon: ArrowDownLeft, tint: 'bg-positive/10 text-positive' },
+  sent: { icon: ArrowUpRight, tint: 'bg-secondary text-foreground' },
+  card: { icon: CreditCard, tint: 'bg-secondary text-foreground' },
+  pending: { icon: Clock, tint: 'bg-info/10 text-info' },
+  credit: { icon: Sparkles, tint: 'bg-info/10 text-info' },
+  milestone: { icon: Sparkles, tint: 'bg-info/10 text-info' },
+  due: { icon: Receipt, tint: 'bg-negative/10 text-negative' },
+  kyc: { icon: ShieldCheck, tint: 'bg-info/10 text-info' },
+  system: { icon: Bell, tint: 'bg-secondary text-foreground' },
+};
+const styleFor = (kind: string) => KIND_STYLE[kind] ?? KIND_STYLE.system;
 
-interface Thread {
-  id: string;
-  avatar: string;
-  name: string;
-  preview: string;
-  time: string;
-  unread: boolean;
+function ago(iso: string): string {
+  const s = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
+  if (s < 60) return 'now';
+  if (s < 3600) return `${Math.floor(s / 60)}m`;
+  if (s < 86_400) return `${Math.floor(s / 3600)}h`;
+  return `${Math.floor(s / 86_400)}d`;
 }
-const THREADS0: Thread[] = [
-  { id: 't1', avatar: 'AS', name: 'Ahmad Sulaiman', preview: 'Thanks, got the transfer 🙏', time: '1h', unread: true },
-  { id: 't2', avatar: 'CS', name: 'Clear Support', preview: 'Your dispute was resolved — $134 refunded.', time: '3h', unread: true },
-  { id: 't3', avatar: 'MA', name: 'Maple Apartments', preview: 'June rent receipt attached.', time: '1d', unread: false },
-];
+
+const initials = (name: string) =>
+  name.trim().split(/\s+/).slice(0, 2).map((w) => w[0]?.toUpperCase() ?? '').join('') || '#';
+
+function loadConvNames(): Record<string, string> {
+  try {
+    return JSON.parse(localStorage.getItem('xmtp_conversation_names') || '{}');
+  } catch {
+    return {};
+  }
+}
 
 /** Swipe-left-to-delete row (Apple-style): a red delete bg is revealed as the row drags left. */
 function SwipeRow({ onDelete, children }: { onDelete: () => void; children: ReactNode }) {
@@ -57,25 +64,31 @@ function SwipeRow({ onDelete, children }: { onDelete: () => void; children: Reac
 }
 
 /**
- * Top-bar bell popover: tabbed Notifications + Messages (XMTP), swipe-to-delete rows.
- *
- * Opening a thread / "Open inbox" calls `onOpenConversation(conversationId?)`, wired in
- * TopBar to `useGlobalModals().openXmtpModal` — which opens the real XMTPMessaging modal
- * mounted in AppShell.
+ * Top-bar bell popover: tabbed Notifications (persistent, backend-backed) + Messages (real XMTP
+ * conversations). Opening a thread / "Open inbox" calls onOpenConversation, wired in TopBar to the
+ * real XMTPMessaging modal.
  */
 export default function NotificationsMenu({ onOpenConversation }: { onOpenConversation?: (conversationId?: string) => void }) {
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<'notifications' | 'messages'>('notifications');
-  const [notifs, setNotifs] = useState(NOTIFS0);
-  const [threads, setThreads] = useState(THREADS0);
+  const { notifications, unreadCount, markRead, markAllRead, dismiss } = useNotifications();
+  const { conversations } = useXMTP();
+
+  // Real XMTP conversations → threads (names from the conversation-name map we persist on message).
+  const convNames = useMemo(() => (open ? loadConvNames() : {}), [open]);
+  const threads = useMemo(
+    () =>
+      conversations.map((c) => {
+        const name = convNames[c.id] || 'Conversation';
+        return { id: c.id, name, avatar: initials(name) };
+      }),
+    [conversations, convNames],
+  );
+
   const openConversation = (id?: string) => {
     setOpen(false);
     onOpenConversation?.(id);
   };
-
-  const unreadN = notifs.filter((n) => n.unread).length;
-  const unreadM = threads.filter((t) => t.unread).length;
-  const totalUnread = unreadN + unreadM;
 
   const Tab = ({ id, label, count }: { id: 'notifications' | 'messages'; label: string; count: number }) => (
     <button
@@ -98,82 +111,81 @@ export default function NotificationsMenu({ onOpenConversation }: { onOpenConver
           className="relative flex h-9 w-9 items-center justify-center rounded-lg bg-secondary text-secondary-foreground transition-colors hover:bg-muted"
         >
           <Bell className="h-[18px] w-[18px]" />
-          {totalUnread > 0 && (
+          {unreadCount > 0 && (
             <span className="absolute -right-0.5 -top-0.5 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold text-primary-foreground ring-2 ring-background">
-              {totalUnread}
+              {unreadCount > 9 ? '9+' : unreadCount}
             </span>
           )}
         </button>
       </PopoverTrigger>
       <PopoverContent align="end" sideOffset={8} className="w-80 p-0">
         <div className="flex border-b border-border">
-          <Tab id="notifications" label="Notifications" count={unreadN} />
-          <Tab id="messages" label="Messages" count={unreadM} />
+          <Tab id="notifications" label="Notifications" count={unreadCount} />
+          <Tab id="messages" label="Messages" count={0} />
         </div>
 
         {tab === 'notifications' ? (
           <>
             <div className="max-h-80 overflow-y-auto">
               <AnimatePresence initial={false}>
-                {notifs.map((n) => {
-                  const Icon = n.icon;
+                {notifications.map((n) => {
+                  const st = styleFor(n.kind);
+                  const Icon = st.icon;
                   return (
-                    <SwipeRow key={n.id} onDelete={() => setNotifs((xs) => xs.filter((x) => x.id !== n.id))}>
-                      <div className={cn('flex gap-3 border-b border-border px-4 py-3', n.unread && 'bg-secondary/30')}>
-                        <span className={cn('flex h-8 w-8 shrink-0 items-center justify-center rounded-lg', n.tint)}>
+                    <SwipeRow key={n.id} onDelete={() => dismiss(n.id)}>
+                      <button
+                        type="button"
+                        onClick={() => markRead(n.id)}
+                        className={cn('flex w-full gap-3 border-b border-border px-4 py-3 text-left', !n.read && 'bg-secondary/30')}
+                      >
+                        <span className={cn('flex h-8 w-8 shrink-0 items-center justify-center rounded-lg', st.tint)}>
                           <Icon className="h-4 w-4" />
                         </span>
                         <div className="min-w-0 flex-1">
                           <div className="flex items-center gap-1.5">
                             <span className="truncate text-sm font-medium text-foreground">{n.title}</span>
-                            {n.unread && <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-info" />}
+                            {!n.read && <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-info" />}
                           </div>
                           <div className="truncate text-xs text-muted-foreground">{n.body}</div>
                         </div>
-                        <span className="shrink-0 text-[11px] text-muted-foreground">{n.time}</span>
-                      </div>
+                        <span className="shrink-0 text-[11px] text-muted-foreground">{ago(n.createdAt)}</span>
+                      </button>
                     </SwipeRow>
                   );
                 })}
               </AnimatePresence>
-              {notifs.length === 0 && <div className="px-4 py-10 text-center text-sm text-muted-foreground">You're all caught up.</div>}
+              {notifications.length === 0 && <div className="px-4 py-10 text-center text-sm text-muted-foreground">You're all caught up.</div>}
             </div>
             <div className="flex items-center justify-between border-t border-border px-4 py-2.5 text-xs">
               <button
                 type="button"
-                disabled={unreadN === 0}
-                onClick={() => setNotifs((xs) => xs.map((x) => ({ ...x, unread: false })))}
+                disabled={unreadCount === 0}
+                onClick={markAllRead}
                 className="font-medium text-muted-foreground transition-colors hover:text-foreground disabled:opacity-40"
               >
                 Mark all read
-              </button>
-              <button type="button" className="font-medium text-muted-foreground transition-colors hover:text-foreground">
-                See all
               </button>
             </div>
           </>
         ) : (
           <>
             <div className="max-h-80 overflow-y-auto">
-              <AnimatePresence initial={false}>
-                {threads.map((t) => (
-                  <SwipeRow key={t.id} onDelete={() => setThreads((xs) => xs.filter((x) => x.id !== t.id))}>
-                    <button type="button" onClick={() => openConversation(t.id)} className="flex w-full gap-3 border-b border-border px-4 py-3 text-left">
-                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-secondary text-xs font-medium text-secondary-foreground">
-                        {t.avatar}
-                      </span>
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-1.5">
-                          <span className="truncate text-sm font-medium text-foreground">{t.name}</span>
-                          {t.unread && <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-info" />}
-                        </div>
-                        <div className="truncate text-xs text-muted-foreground">{t.preview}</div>
-                      </div>
-                      <span className="shrink-0 text-[11px] text-muted-foreground">{t.time}</span>
-                    </button>
-                  </SwipeRow>
-                ))}
-              </AnimatePresence>
+              {threads.map((t) => (
+                <button
+                  key={t.id}
+                  type="button"
+                  onClick={() => openConversation(t.id)}
+                  className="flex w-full gap-3 border-b border-border px-4 py-3 text-left transition-colors hover:bg-secondary/40"
+                >
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-secondary text-xs font-medium text-secondary-foreground">
+                    {t.avatar}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium text-foreground">{t.name}</span>
+                    <span className="block truncate text-xs text-muted-foreground">Tap to open conversation</span>
+                  </div>
+                </button>
+              ))}
               {threads.length === 0 && <div className="px-4 py-10 text-center text-sm text-muted-foreground">No messages yet.</div>}
             </div>
             <div className="flex items-center justify-between border-t border-border px-4 py-2.5 text-[11px] text-muted-foreground">

--- a/app/src/hooks/useNotifications.ts
+++ b/app/src/hooks/useNotifications.ts
@@ -6,8 +6,23 @@ import {
   markNotificationRead,
   markAllNotificationsRead,
   archiveNotificationApi,
+  savePushSubscription,
   type ApiNotification,
 } from '@/utils/apiClient';
+
+// Public VAPID key (safe to expose). Overridable via env; falls back to the app's key.
+const VAPID_PUBLIC_KEY =
+  (import.meta.env.VITE_VAPID_PUBLIC_KEY as string | undefined) ||
+  'BMu0BQLWQctkLTZlOD2me1X-vOBVcfAZxU0kxXOKb_3eWMwBcJPSMrPightFAAz_exbQm-EYxoJOdJPNr74HWck';
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  const arr = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i += 1) arr[i] = raw.charCodeAt(i);
+  return arr;
+}
 
 /**
  * Persistent in-app notifications from the backend (wallet-scoped). Fetches on mount + focus, receives
@@ -39,6 +54,29 @@ export function useNotifications() {
     window.addEventListener('focus', onFocus);
     return () => window.removeEventListener('focus', onFocus);
   }, [refresh]);
+
+  // Web Push: once permission is granted (requested elsewhere on connect), register/refresh this
+  // device's push subscription so important notifications arrive when the app is closed.
+  useEffect(() => {
+    if (!address || !isConnected) return;
+    if (typeof window === 'undefined' || !('serviceWorker' in navigator) || !('PushManager' in window)) return;
+    if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const reg = await navigator.serviceWorker.ready;
+        const sub =
+          (await reg.pushManager.getSubscription()) ||
+          (await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY) }));
+        if (!cancelled) await savePushSubscription(address, sub.toJSON());
+      } catch {
+        /* push is optional */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [address, isConnected]);
 
   // Live: prepend notifications pushed by producers.
   useEffect(() => {

--- a/app/src/hooks/useNotifications.ts
+++ b/app/src/hooks/useNotifications.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAppKitAccount } from '@/lib/walletCompat';
+import { useWebSocket } from '@/hooks/useWebSocket';
+import {
+  getNotifications,
+  markNotificationRead,
+  markAllNotificationsRead,
+  archiveNotificationApi,
+  type ApiNotification,
+} from '@/utils/apiClient';
+
+/**
+ * Persistent in-app notifications from the backend (wallet-scoped). Fetches on mount + focus, receives
+ * new ones live over the WebSocket (`notification:new`), and applies read/dismiss optimistically.
+ */
+export function useNotifications() {
+  const { address, isConnected } = useAppKitAccount();
+  const { socket } = useWebSocket(address, isConnected);
+  const [notifications, setNotifications] = useState<ApiNotification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  const refresh = useCallback(async () => {
+    if (!address || !isConnected) {
+      setNotifications([]);
+      setUnreadCount(0);
+      return;
+    }
+    const res = await getNotifications(address);
+    setNotifications(res.notifications);
+    setUnreadCount(res.unreadCount);
+  }, [address, isConnected]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    const onFocus = () => void refresh();
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, [refresh]);
+
+  // Live: prepend notifications pushed by producers.
+  useEffect(() => {
+    if (!socket) return;
+    const onNew = (n: ApiNotification) => {
+      setNotifications((prev) => (prev.some((x) => x.id === n.id) ? prev : [n, ...prev].slice(0, 40)));
+      setUnreadCount((c) => c + 1);
+    };
+    socket.on('notification:new', onNew);
+    return () => {
+      socket.off('notification:new', onNew);
+    };
+  }, [socket]);
+
+  const markRead = useCallback(
+    (id: string) => {
+      setNotifications((prev) => {
+        const was = prev.find((n) => n.id === id && !n.read);
+        if (was) setUnreadCount((c) => Math.max(0, c - 1));
+        return prev.map((n) => (n.id === id ? { ...n, read: true } : n));
+      });
+      if (address) void markNotificationRead(address, id).catch(() => {});
+    },
+    [address],
+  );
+
+  const markAllRead = useCallback(() => {
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+    setUnreadCount(0);
+    if (address) void markAllNotificationsRead(address).catch(() => {});
+  }, [address]);
+
+  const dismiss = useCallback(
+    (id: string) => {
+      setNotifications((prev) => {
+        const was = prev.find((n) => n.id === id && !n.read);
+        if (was) setUnreadCount((c) => Math.max(0, c - 1));
+        return prev.filter((n) => n.id !== id);
+      });
+      if (address) void archiveNotificationApi(address, id).catch(() => {});
+    },
+    [address],
+  );
+
+  return { notifications, unreadCount, refresh, markRead, markAllRead, dismiss };
+}

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2294,6 +2294,30 @@ export async function deleteContactApi(wallet: string, id: string): Promise<bool
   return !r.error;
 }
 
+// ---- In-app notifications (persistent, wallet-scoped) ----
+export interface ApiNotification {
+  id: string;
+  kind: string;
+  title: string;
+  body: string;
+  data: Record<string, unknown> | null;
+  read: boolean;
+  createdAt: string;
+}
+export async function getNotifications(wallet: string): Promise<{ notifications: ApiNotification[]; unreadCount: number }> {
+  const r = await apiRequest<{ notifications: ApiNotification[]; unreadCount: number }>(`/api/notifications/${wallet.toLowerCase()}`);
+  return r.error || !r.data ? { notifications: [], unreadCount: 0 } : r.data;
+}
+export async function markNotificationRead(wallet: string, id: string): Promise<void> {
+  await apiRequest(`/api/notifications/${wallet.toLowerCase()}/${id}/read`, { method: 'POST' });
+}
+export async function markAllNotificationsRead(wallet: string): Promise<void> {
+  await apiRequest(`/api/notifications/${wallet.toLowerCase()}/read-all`, { method: 'POST' });
+}
+export async function archiveNotificationApi(wallet: string, id: string): Promise<void> {
+  await apiRequest(`/api/notifications/${wallet.toLowerCase()}/${id}/archive`, { method: 'POST' });
+}
+
 /** Directory lookup: resolve a wallet from a known email/phone (exact match, opt-out aware). */
 export async function lookupDirectory(
   wallet: string,

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2317,6 +2317,9 @@ export async function markAllNotificationsRead(wallet: string): Promise<void> {
 export async function archiveNotificationApi(wallet: string, id: string): Promise<void> {
   await apiRequest(`/api/notifications/${wallet.toLowerCase()}/${id}/archive`, { method: 'POST' });
 }
+export async function savePushSubscription(wallet: string, subscription: unknown): Promise<void> {
+  await apiRequest(`/api/notifications/${wallet.toLowerCase()}/subscribe`, { method: 'POST', body: JSON.stringify({ subscription }) });
+}
 
 /** Directory lookup: resolve a wallet from a known email/phone (exact match, opt-out aware). */
 export async function lookupDirectory(


### PR DESCRIPTION
Replaces the mock bell with a real, backend-backed notification system.

- **Store**: `notifications` table (wallet-scoped, idempotent `dedupe_key`) + `notificationStore` + `/api/notifications` (list / read / read-all / archive / subscribe).
- **Producers**: incoming/outgoing transfers → received/sent; equity credits + deposit 1:1 match → credit; daily cron for bills due within 3 days → due.
- **Realtime**: `emit()` broadcasts `notification:new` over the existing WebSocket; the client prepends live.
- **Web Push (VAPID)**: important kinds pushed to registered devices so they arrive with the app closed (SW push handler already existed). Requires `VAPID_*` env on the server.
- **Client**: `useNotifications` (fetch + focus + WS live + optimistic read/dismiss + push subscribe); `NotificationsMenu` wired to it. **Messages tab** now lists real XMTP conversations and opens the real thread.

Needs from ops: set VAPID env on the Railway server (keys provided out-of-band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)