### PR TITLE
feat(notifications): money-request notifications

### DIFF
--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -28,6 +28,7 @@ import withdrawRouter from './routes/withdraw.js';
 import autopayRouter from './routes/autopay.js';
 import contactsRouter from './routes/contacts.js';
 import notificationsRouter from './routes/notifications.js';
+import requestsRouter from './routes/requests.js';
 import onramperRouter from './routes/onramper.js';
 import onramperWebhookRouter from './routes/onramperWebhook.js';
 import { startPriceUpdater } from './jobs/priceUpdater.js';
@@ -197,6 +198,7 @@ async function startServer() {
     app.use('/api/autopay', requireAuth, autopayRouter);
     app.use('/api/contacts', requireAuth, contactsRouter);
     app.use('/api/notifications', requireAuth, notificationsRouter);
+    app.use('/api/requests', requireAuth, requestsRouter);
     app.use('/api/onramper', requireAuth, onramperRouter);
 
     console.log('✅ API routes registered:');

--- a/app/server/src/routes/requests.ts
+++ b/app/server/src/routes/requests.ts
@@ -1,0 +1,54 @@
+import { Router, type Request, type Response } from 'express';
+import { requestStore } from '../services/requestStore.js';
+import { notificationStore } from '../services/notificationStore.js';
+
+/*
+ * Money requests, under requireAuth. Creating a request notifies the target wallet ("X requested $Y").
+ * The requester is taken from the authed session, not the body.
+ */
+const router = Router();
+
+const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+// POST /api/requests { toWallet, amount, note?, fromName? }
+router.post('/', async (req: Request, res: Response) => {
+  const fromWallet = req.auth?.walletAddress?.trim().toLowerCase();
+  if (!fromWallet) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  const { toWallet, amount, note, fromName } = (req.body ?? {}) as {
+    toWallet?: string;
+    amount?: number;
+    note?: string;
+    fromName?: string;
+  };
+  const amt = Number(amount);
+  if (!toWallet || !/^0x[a-fA-F0-9]{40}$/.test(toWallet) || !Number.isFinite(amt) || amt <= 0) {
+    res.status(400).json({ error: 'Invalid request', message: 'toWallet and a positive amount are required' });
+    return;
+  }
+
+  const created = await requestStore.create({
+    fromWallet,
+    fromName: fromName?.trim() || null,
+    toWallet,
+    amountUsd: amt,
+    note: note?.trim() || null,
+  });
+
+  await notificationStore
+    .emit({
+      wallet: toWallet,
+      kind: 'request',
+      title: 'Payment request',
+      body: `${fromName?.trim() || 'Someone'} requested ${fmt(amt)}${note?.trim() ? ` · ${note.trim()}` : ''}`,
+      data: { requestId: created?.id ?? null, amount: amt, from: fromWallet, href: '/pay' },
+      dedupeKey: `request:${created?.id ?? `${fromWallet}-${Date.now()}`}`,
+    })
+    .catch(() => {});
+
+  res.json({ ok: true, id: created?.id ?? null });
+});
+
+export default router;

--- a/app/server/src/services/notificationStore.ts
+++ b/app/server/src/services/notificationStore.ts
@@ -4,7 +4,7 @@ import { websocketService } from './websocketService.js';
 import { pushService } from './pushService.js';
 
 // Kinds worth a Web Push (arrive when the app is closed); noisy/low-value ones stay in-app only.
-const PUSH_KINDS = new Set<NotificationKind>(['received', 'credit', 'milestone', 'due', 'kyc']);
+const PUSH_KINDS = new Set<NotificationKind>(['received', 'credit', 'milestone', 'due', 'kyc', 'request']);
 
 /*
  * Persistent in-app notifications, scoped by owner wallet (same scoping as contacts / pay_credits, and
@@ -16,7 +16,7 @@ const TABLE = 'notifications';
 let ensured = false;
 
 export type NotificationKind =
-  | 'received' | 'sent' | 'card' | 'pending' | 'credit' | 'milestone' | 'due' | 'kyc' | 'system';
+  | 'received' | 'sent' | 'card' | 'pending' | 'credit' | 'milestone' | 'due' | 'kyc' | 'request' | 'system';
 
 export interface NotificationRow {
   id: string;

--- a/app/server/src/services/requestStore.ts
+++ b/app/server/src/services/requestStore.ts
@@ -1,0 +1,54 @@
+import crypto from 'crypto';
+import { getPostgresPool } from '../config/postgres.js';
+
+/*
+ * Money requests ("ask a contact to pay you"). A request from A → B is persisted here and surfaces to
+ * B as a notification (see routes/requests.ts). Settling on pay is a later step; for now this records
+ * the ask and drives the "someone requested money" notification.
+ */
+const TABLE = 'payment_requests';
+let ensured = false;
+
+async function ensureTables(): Promise<void> {
+  const pool = getPostgresPool();
+  if (!pool || ensured) return;
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS ${TABLE} (
+      id TEXT PRIMARY KEY,
+      from_wallet TEXT NOT NULL,
+      from_name TEXT,
+      to_wallet TEXT NOT NULL,
+      amount_usd NUMERIC(20,2) NOT NULL,
+      note TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    CREATE INDEX IF NOT EXISTS payment_requests_to_idx ON ${TABLE} (to_wallet, created_at DESC);
+  `);
+  ensured = true;
+}
+
+export interface PaymentRequestInput {
+  fromWallet: string;
+  fromName?: string | null;
+  toWallet: string;
+  amountUsd: number;
+  note?: string | null;
+}
+
+export const requestStore = {
+  isConfigured: () => !!getPostgresPool(),
+
+  async create(input: PaymentRequestInput): Promise<{ id: string } | null> {
+    const pool = getPostgresPool();
+    if (!pool) return null;
+    await ensureTables();
+    const id = crypto.randomUUID();
+    await pool.query(
+      `INSERT INTO ${TABLE} (id, from_wallet, from_name, to_wallet, amount_usd, note)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+      [id, input.fromWallet.toLowerCase(), input.fromName ?? null, input.toWallet.toLowerCase(), input.amountUsd, input.note ?? null],
+    );
+    return { id };
+  },
+};

--- a/app/src/components/app-ui/NotificationsMenu.tsx
+++ b/app/src/components/app-ui/NotificationsMenu.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, type ReactNode } from 'react';
 import { motion, AnimatePresence, type PanInfo } from 'framer-motion';
 import {
-  Bell, ArrowDownLeft, ArrowUpRight, Receipt, Sparkles, CreditCard, Clock, Trash2, ShieldCheck, type LucideIcon,
+  Bell, ArrowDownLeft, ArrowUpRight, Receipt, Sparkles, CreditCard, Clock, HandCoins, Trash2, ShieldCheck, type LucideIcon,
 } from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
 import { useNotifications } from '@/hooks/useNotifications';
@@ -17,6 +17,7 @@ const KIND_STYLE: Record<string, { icon: LucideIcon; tint: string }> = {
   credit: { icon: Sparkles, tint: 'bg-info/10 text-info' },
   milestone: { icon: Sparkles, tint: 'bg-info/10 text-info' },
   due: { icon: Receipt, tint: 'bg-negative/10 text-negative' },
+  request: { icon: HandCoins, tint: 'bg-amber-500/10 text-amber-500' },
   kyc: { icon: ShieldCheck, tint: 'bg-info/10 text-info' },
   system: { icon: Bell, tint: 'bg-secondary text-foreground' },
 };

--- a/app/src/components/app-ui/RequestModal.tsx
+++ b/app/src/components/app-ui/RequestModal.tsx
@@ -4,6 +4,8 @@ import { QRCodeSVG } from 'qrcode.react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { useContacts, contactInitials } from '@/context/ContactsContext';
 import { useAppKitAccount } from '@/lib/walletCompat';
+import { useMemberProfile } from '@/hooks/useMemberProfile';
+import { createPaymentRequest } from '@/utils/apiClient';
 import { cn } from '@/lib/utils';
 
 /*
@@ -21,6 +23,7 @@ const QUICK = [25, 50, 100, 250];
 export default function RequestModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
   const { contacts, getContact, openManager } = useContacts();
   const { address } = useAppKitAccount();
+  const { firstName } = useMemberProfile();
   const [tab, setTab] = useState<'request' | 'receive'>('request');
   const [step, setStep] = useState<'compose' | 'review' | 'status'>('compose');
   const [picking, setPicking] = useState(false);
@@ -310,7 +313,14 @@ export default function RequestModal({ open, onOpenChange }: { open: boolean; on
 
             <button
               type="button"
-              onClick={() => setStep('status')}
+              onClick={() => {
+                // In-app request (recipient has a wallet) → persist + notify them. Link sends (email/
+                // phone-only) still show the copy-link flow below until the pay-link backend lands.
+                if (instant && recipient?.wallet) {
+                  void createPaymentRequest({ toWallet: recipient.wallet, amount, note: note || undefined, fromName: firstName });
+                }
+                setStep('status');
+              }}
               className="mt-4 w-full rounded-xl bg-primary py-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.99]"
             >
               Request {fmt(amount)}

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2321,6 +2321,12 @@ export async function savePushSubscription(wallet: string, subscription: unknown
   await apiRequest(`/api/notifications/${wallet.toLowerCase()}/subscribe`, { method: 'POST', body: JSON.stringify({ subscription }) });
 }
 
+/** Request money from a Clear member — notifies them ("X requested $Y"). */
+export async function createPaymentRequest(input: { toWallet: string; amount: number; note?: string; fromName?: string }): Promise<boolean> {
+  const r = await apiRequest<{ ok: boolean }>('/api/requests', { method: 'POST', body: JSON.stringify(input) });
+  return !r.error;
+}
+
 /** Directory lookup: resolve a wallet from a known email/phone (exact match, opt-out aware). */
 export async function lookupDirectory(
   wallet: string,


### PR DESCRIPTION
Wires the previously-mock "Request money" flow to real notifications.

- New `request` notification kind (+ push).
- `requestStore` (`payment_requests` table) + `POST /api/requests` — requester from the authed session; creating a request notifies the target wallet ("X requested \$Y", with note), in-app + Web Push.
- `RequestModal` fires it on confirm for in-app recipients (those with a wallet); email/phone-only recipients keep the copy-link flow until the pay-link backend lands.

"Someone sent you money" was already wired via the on-chain transfers watcher (`received`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)