### PR TITLE
feat(notifications): Send flow notifies the recipient directly (offline-safe)

### DIFF
--- a/app/server/src/routes/send.ts
+++ b/app/server/src/routes/send.ts
@@ -10,6 +10,35 @@ import {
 import { sendCryptoService } from '../services/sendCryptoService.js';
 import { sendClaimService } from '../services/sendClaimService.js';
 import { mapBridgeStateToDispatchStatus } from '../services/sendBridgePayoutService.js';
+import { contactsStore } from '../services/contactsStore.js';
+import { notificationStore } from '../services/notificationStore.js';
+
+/** Notify the recipient in-app if they're a Clear member (offline-safe; resolved via the directory). */
+async function notifyRecipientOfSend(updatedTransfer: {
+  id: number;
+  recipientType: 'email' | 'phone';
+  principalUsdc: string;
+}): Promise<void> {
+  try {
+    const contact = sendTransferStore.decryptRecipientContact(updatedTransfer as never);
+    const match = await contactsStore.lookupWallet(
+      updatedTransfer.recipientType === 'email' ? contact : undefined,
+      updatedTransfer.recipientType === 'phone' ? contact : undefined,
+    );
+    if (!match?.wallet) return;
+    const usd = Number(updatedTransfer.principalUsdc) / 1_000_000;
+    await notificationStore.emit({
+      wallet: match.wallet,
+      kind: 'received',
+      title: 'Money received',
+      body: `You received $${usd.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+      data: { transferId: updatedTransfer.id, href: '/transactions' },
+      dedupeKey: `send:${updatedTransfer.id}`,
+    });
+  } catch (error) {
+    console.error('Recipient in-app notification error:', error);
+  }
+}
 import { sendBridgeWebhookVerifier } from '../services/sendBridgeWebhookVerifier.js';
 import { sendPayoutService } from '../services/sendPayoutService.js';
 import { sendStripePayoutService } from '../services/sendStripePayoutService.js';
@@ -596,6 +625,9 @@ senderRouter.post('/transfers/:id/confirm-lock', requireAuth, async (req: Reques
       console.error('Claim link notification error:', error);
     }
 
+    // Our own send event → notify the recipient in-app (offline-safe, no watcher dependency).
+    await notifyRecipientOfSend(updatedTransfer);
+
     return res.json({
       transfer: publicTransferView(updatedTransfer),
       claimUrl,
@@ -748,6 +780,9 @@ senderRouter.post('/transfers/:id/submit-authorization', requireAuth, async (req
       notificationWarning = error instanceof Error ? error.message : 'Failed to dispatch claim notification';
       console.error('Claim link notification error:', error);
     }
+
+    // Our own send event → notify the recipient in-app (offline-safe, no watcher dependency).
+    await notifyRecipientOfSend(updatedTransfer);
 
     return res.json({
       transfer: publicTransferView(updatedTransfer),


### PR DESCRIPTION
Our own Send is a backend action, so we notify the recipient from it directly instead of relying on the on-chain watcher (which only fires for online/monitored addresses).

At lock time (both `confirm-lock` and the relayer `submit-authorization` paths), the server resolves the recipient to a Clear member via the directory (from the decrypted contact) and emits a `received` notification to their wallet — in-app, realtime, and Web Push. Works even when the recipient is offline. Idempotent per transfer (`dedupe_key = send:<id>`).

Combined with the earlier money-request work, both **our Send and Request** now notify directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)