### PR TITLE
feat(notifications): hardened requests + greetings + self-test

### DIFF
--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -35,6 +35,7 @@ import { startPriceUpdater } from './jobs/priceUpdater.js';
 import { startPortfolioSnapshotter } from './jobs/portfolioSnapshotter.js';
 import { startAutopayRunner } from './jobs/autopayRunner.js';
 import { startDueBillNotifier } from './jobs/dueBillNotifier.js';
+import { startGreetingNotifier } from './jobs/greetingNotifier.js';
 import { websocketService } from './services/websocketService.js';
 import { eventListenerService } from './services/eventListenerService.js';
 
@@ -253,6 +254,9 @@ async function startServer() {
     });
     startDueBillNotifier().catch((error) => {
       console.error('⚠️ Due-bill notifier failed to start:', error);
+    });
+    startGreetingNotifier().catch((error) => {
+      console.error('⚠️ Greeting notifier failed to start:', error);
     });
 
     // Start HTTP server (Express + WebSocket)

--- a/app/server/src/jobs/greetingNotifier.ts
+++ b/app/server/src/jobs/greetingNotifier.ts
@@ -1,0 +1,52 @@
+import { getPostgresPool } from '../config/postgres.js';
+import { notificationStore } from '../services/notificationStore.js';
+
+/*
+ * Time-of-day greeting notifications (morning / afternoon / evening) — a gentle nudge to open the app,
+ * and a live end-to-end test of the notification + push pipeline. Sent to opted-in users (those with a
+ * Web Push subscription). Idempotent per day+period via the dedupe key, and time-of-day is computed in
+ * APP_TZ (default America/New_York) so "good morning" lands in the morning regardless of server TZ.
+ */
+const CHECK_MS = 30 * 60 * 1000; // every 30 minutes
+const TZ = process.env.APP_TZ || 'America/New_York';
+
+function greetingForHour(hour: number): { period: string; title: string; body: string } | null {
+  if (hour === 8) return { period: 'morning', title: 'Good morning ☀️', body: 'Here’s where your money stands today.' };
+  if (hour === 13) return { period: 'afternoon', title: 'Good afternoon 👋', body: 'A quick check-in on your accounts and upcoming bills.' };
+  if (hour === 18) return { period: 'evening', title: 'Good evening 🌙', body: 'Review today’s spending and your Clear Deed progress.' };
+  return null;
+}
+
+async function run(): Promise<void> {
+  const pool = getPostgresPool();
+  if (!pool) return;
+  const now = new Date();
+  const hour = Number(new Intl.DateTimeFormat('en-US', { timeZone: TZ, hour: 'numeric', hour12: false }).format(now));
+  const greeting = greetingForHour(hour);
+  if (!greeting) return;
+  const date = new Intl.DateTimeFormat('en-CA', { timeZone: TZ, year: 'numeric', month: '2-digit', day: '2-digit' }).format(now); // YYYY-MM-DD
+
+  try {
+    const { rows } = await pool.query<{ owner_wallet: string }>(`SELECT DISTINCT owner_wallet FROM push_subscriptions`);
+    for (const r of rows) {
+      await notificationStore
+        .emit({
+          wallet: r.owner_wallet,
+          kind: 'system',
+          title: greeting.title,
+          body: greeting.body,
+          data: { href: '/' },
+          dedupeKey: `greeting:${date}:${greeting.period}`,
+          push: true,
+        })
+        .catch(() => {});
+    }
+  } catch (e) {
+    console.error('[greetingNotifier] error', e);
+  }
+}
+
+export async function startGreetingNotifier(): Promise<void> {
+  await run();
+  setInterval(() => void run(), CHECK_MS);
+}

--- a/app/server/src/routes/notifications.ts
+++ b/app/server/src/routes/notifications.ts
@@ -36,6 +36,20 @@ router.post('/:wallet/:id/read', requireWalletMatch, async (req, res) => {
   res.json({ ok: true });
 });
 
+// POST /api/notifications/:wallet/test — send yourself a test notification (verifies in-app + push)
+router.post('/:wallet/test', requireWalletMatch, async (req, res) => {
+  await notificationStore.emit({
+    wallet: wallet(req),
+    kind: 'system',
+    title: 'Test notification 🎉',
+    body: 'If you can see this, your notifications are working.',
+    data: { href: '/' },
+    dedupeKey: `test:${Date.now()}`,
+    push: true,
+  });
+  res.json({ ok: true });
+});
+
 // POST /api/notifications/:wallet/subscribe — register a Web Push subscription
 router.post('/:wallet/subscribe', requireWalletMatch, async (req, res) => {
   const { subscription } = (req.body ?? {}) as { subscription?: { endpoint?: string } & Record<string, unknown> };

--- a/app/server/src/routes/requests.ts
+++ b/app/server/src/routes/requests.ts
@@ -1,48 +1,83 @@
 import { Router, type Request, type Response } from 'express';
 import { requestStore } from '../services/requestStore.js';
 import { notificationStore } from '../services/notificationStore.js';
+import { contactsStore } from '../services/contactsStore.js';
+import { memberStore } from '../services/memberStore.js';
 
 /*
- * Money requests, under requireAuth. Creating a request notifies the target wallet ("X requested $Y").
- * The requester is taken from the authed session, not the body.
+ * Money requests, under requireAuth. Hardened against spoofing:
+ *  - the requester (from_wallet) comes from the authed session, never the body;
+ *  - the recipient is resolved server-side from their email/phone via the member directory, so the
+ *    caller can't target an arbitrary wallet (only a discoverable Clear member);
+ *  - the sender's display name is read from their own member profile, not client-supplied.
+ * Creating a request notifies the recipient ("<name> requested $Y").
  */
 const router = Router();
-
 const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
-// POST /api/requests { toWallet, amount, note?, fromName? }
+async function senderDisplayName(req: Request): Promise<string> {
+  try {
+    const authSubject = await memberStore.resolveCanonicalAuthSubject({
+      authSubject: req.auth?.profileUuid ?? req.auth?.walletAddress?.toLowerCase() ?? null,
+      profileUuid: req.auth?.profileUuid ?? null,
+      walletAddress: req.auth?.walletAddress ?? null,
+      walletAddresses: req.auth?.addresses ?? null,
+      email: req.auth?.email ?? null,
+      phone: req.auth?.phone ?? null,
+    });
+    if (!authSubject) return 'Someone';
+    const profile = await memberStore.getProfileByAuthSubject(authSubject);
+    return profile?.publicProfile.displayName?.trim() || profile?.publicProfile.username?.trim() || 'Someone';
+  } catch {
+    return 'Someone';
+  }
+}
+
+// POST /api/requests { recipientEmail?, recipientPhone?, amount, note? }
 router.post('/', async (req: Request, res: Response) => {
   const fromWallet = req.auth?.walletAddress?.trim().toLowerCase();
   if (!fromWallet) {
     res.status(401).json({ error: 'Unauthorized' });
     return;
   }
-  const { toWallet, amount, note, fromName } = (req.body ?? {}) as {
-    toWallet?: string;
+  const { recipientEmail, recipientPhone, amount, note } = (req.body ?? {}) as {
+    recipientEmail?: string;
+    recipientPhone?: string;
     amount?: number;
     note?: string;
-    fromName?: string;
   };
   const amt = Number(amount);
-  if (!toWallet || !/^0x[a-fA-F0-9]{40}$/.test(toWallet) || !Number.isFinite(amt) || amt <= 0) {
-    res.status(400).json({ error: 'Invalid request', message: 'toWallet and a positive amount are required' });
+  if ((!recipientEmail && !recipientPhone) || !Number.isFinite(amt) || amt <= 0) {
+    res.status(400).json({ error: 'Invalid request', message: 'A recipient email/phone and a positive amount are required.' });
     return;
   }
 
+  // Resolve the recipient to a Clear member — the caller can't target an arbitrary wallet.
+  const match = await contactsStore.lookupWallet(recipientEmail || undefined, recipientPhone || undefined);
+  if (!match?.wallet) {
+    res.status(404).json({ error: 'Recipient not found', message: "That person isn't a Clear member (or isn't discoverable)." });
+    return;
+  }
+  if (match.wallet.toLowerCase() === fromWallet) {
+    res.status(400).json({ error: 'Invalid recipient', message: "You can't request money from yourself." });
+    return;
+  }
+
+  const fromName = await senderDisplayName(req);
   const created = await requestStore.create({
     fromWallet,
-    fromName: fromName?.trim() || null,
-    toWallet,
+    fromName,
+    toWallet: match.wallet,
     amountUsd: amt,
     note: note?.trim() || null,
   });
 
   await notificationStore
     .emit({
-      wallet: toWallet,
+      wallet: match.wallet,
       kind: 'request',
       title: 'Payment request',
-      body: `${fromName?.trim() || 'Someone'} requested ${fmt(amt)}${note?.trim() ? ` · ${note.trim()}` : ''}`,
+      body: `${fromName} requested ${fmt(amt)}${note?.trim() ? ` · ${note.trim()}` : ''}`,
       data: { requestId: created?.id ?? null, amount: amt, from: fromWallet, href: '/pay' },
       dedupeKey: `request:${created?.id ?? `${fromWallet}-${Date.now()}`}`,
     })

--- a/app/server/src/services/notificationStore.ts
+++ b/app/server/src/services/notificationStore.ts
@@ -87,6 +87,8 @@ export interface EmitInput {
   data?: Record<string, unknown> | null;
   /** Stable key so the same event never duplicates (e.g. `tx:0xabc`, `credit:2026-06`). */
   dedupeKey: string;
+  /** Force (or suppress) Web Push regardless of kind. Defaults to whether the kind is push-worthy. */
+  push?: boolean;
 }
 
 export const notificationStore = {
@@ -116,8 +118,8 @@ export const notificationStore = {
     } catch {
       /* realtime is best-effort */
     }
-    // Web Push for important kinds so it lands even when the app is closed (best-effort).
-    if (PUSH_KINDS.has(notif.kind)) {
+    // Web Push for important kinds (or when explicitly forced) so it lands even when the app is closed.
+    if (input.push ?? PUSH_KINDS.has(notif.kind)) {
       void pushService.sendToWallet(wallet, { title: notif.title, body: notif.body, data: notif.data, tag: notif.id }).catch(() => {});
     }
     return notif;

--- a/app/src/components/app-ui/NotificationsMenu.tsx
+++ b/app/src/components/app-ui/NotificationsMenu.tsx
@@ -72,7 +72,7 @@ function SwipeRow({ onDelete, children }: { onDelete: () => void; children: Reac
 export default function NotificationsMenu({ onOpenConversation }: { onOpenConversation?: (conversationId?: string) => void }) {
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<'notifications' | 'messages'>('notifications');
-  const { notifications, unreadCount, markRead, markAllRead, dismiss } = useNotifications();
+  const { notifications, unreadCount, markRead, markAllRead, dismiss, sendTest } = useNotifications();
   const { conversations } = useXMTP();
 
   // Real XMTP conversations → threads (names from the conversation-name map we persist on message).
@@ -165,6 +165,13 @@ export default function NotificationsMenu({ onOpenConversation }: { onOpenConver
                 className="font-medium text-muted-foreground transition-colors hover:text-foreground disabled:opacity-40"
               >
                 Mark all read
+              </button>
+              <button
+                type="button"
+                onClick={() => void sendTest()}
+                className="font-medium text-muted-foreground transition-colors hover:text-foreground"
+              >
+                Send test
               </button>
             </div>
           </>

--- a/app/src/components/app-ui/RequestModal.tsx
+++ b/app/src/components/app-ui/RequestModal.tsx
@@ -4,7 +4,6 @@ import { QRCodeSVG } from 'qrcode.react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { useContacts, contactInitials } from '@/context/ContactsContext';
 import { useAppKitAccount } from '@/lib/walletCompat';
-import { useMemberProfile } from '@/hooks/useMemberProfile';
 import { createPaymentRequest } from '@/utils/apiClient';
 import { cn } from '@/lib/utils';
 
@@ -23,7 +22,6 @@ const QUICK = [25, 50, 100, 250];
 export default function RequestModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
   const { contacts, getContact, openManager } = useContacts();
   const { address } = useAppKitAccount();
-  const { firstName } = useMemberProfile();
   const [tab, setTab] = useState<'request' | 'receive'>('request');
   const [step, setStep] = useState<'compose' | 'review' | 'status'>('compose');
   const [picking, setPicking] = useState(false);
@@ -314,10 +312,10 @@ export default function RequestModal({ open, onOpenChange }: { open: boolean; on
             <button
               type="button"
               onClick={() => {
-                // In-app request (recipient has a wallet) → persist + notify them. Link sends (email/
-                // phone-only) still show the copy-link flow below until the pay-link backend lands.
-                if (instant && recipient?.wallet) {
-                  void createPaymentRequest({ toWallet: recipient.wallet, amount, note: note || undefined, fromName: firstName });
+                // In-app request (recipient is a member) → server resolves them by email/phone + notifies.
+                // Link sends (non-members) still show the copy-link flow below until the pay-link backend lands.
+                if (instant && (recipient?.email || recipient?.phone)) {
+                  void createPaymentRequest({ recipientEmail: recipient.email || undefined, recipientPhone: recipient.phone || undefined, amount, note: note || undefined });
                 }
                 setStep('status');
               }}

--- a/app/src/hooks/useNotifications.ts
+++ b/app/src/hooks/useNotifications.ts
@@ -7,6 +7,7 @@ import {
   markAllNotificationsRead,
   archiveNotificationApi,
   savePushSubscription,
+  sendTestNotification,
   type ApiNotification,
 } from '@/utils/apiClient';
 
@@ -121,5 +122,11 @@ export function useNotifications() {
     [address],
   );
 
-  return { notifications, unreadCount, refresh, markRead, markAllRead, dismiss };
+  const sendTest = useCallback(async () => {
+    if (!address) return;
+    await sendTestNotification(address).catch(() => {});
+    await refresh();
+  }, [address, refresh]);
+
+  return { notifications, unreadCount, refresh, markRead, markAllRead, dismiss, sendTest };
 }

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2321,9 +2321,14 @@ export async function savePushSubscription(wallet: string, subscription: unknown
   await apiRequest(`/api/notifications/${wallet.toLowerCase()}/subscribe`, { method: 'POST', body: JSON.stringify({ subscription }) });
 }
 
-/** Request money from a Clear member — notifies them ("X requested $Y"). */
-export async function createPaymentRequest(input: { toWallet: string; amount: number; note?: string; fromName?: string }): Promise<boolean> {
+/** Request money from a Clear member — server resolves them by email/phone and notifies them. */
+export async function createPaymentRequest(input: { recipientEmail?: string; recipientPhone?: string; amount: number; note?: string }): Promise<boolean> {
   const r = await apiRequest<{ ok: boolean }>('/api/requests', { method: 'POST', body: JSON.stringify(input) });
+  return !r.error;
+}
+/** Send yourself a test notification (verifies the in-app + push pipeline). */
+export async function sendTestNotification(wallet: string): Promise<boolean> {
+  const r = await apiRequest<{ ok: boolean }>(`/api/notifications/${wallet.toLowerCase()}/test`, { method: 'POST' });
   return !r.error;
 }
 


### PR DESCRIPTION
- **Hardened money requests** (anti-spoof): the requester is taken from the authed session; the recipient is resolved **server-side** from their email/phone via the member directory (so a caller can't target an arbitrary wallet — only a discoverable member); the sender's display name is read from their **own member profile**, not client-supplied. Self-requests rejected.
- **Greeting notifications**: `jobs/greetingNotifier` sends Good morning / afternoon / evening (08:00 / 13:00 / 18:00 in `APP_TZ`, default America/New_York) to opted-in (push-subscribed) users — an engagement nudge and a live end-to-end test of the pipeline. Idempotent per day+period.
- **Self-test**: `POST /api/notifications/:wallet/test` + a "Send test" button in the bell → emits a test notification to yourself (in-app + push). `emit()` gained a `push` override so greetings/tests always push.

Web Push still requires the `VAPID_*` env on the server to actually deliver pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)