### PR TITLE
feat(notifications): app-icon badge + iOS gesture permission

### DIFF
--- a/app/public/sw.js
+++ b/app/public/sw.js
@@ -333,6 +333,13 @@ self.addEventListener('push', (event) => {
     timestamp: Date.now(),
   };
   
+  // Set the app-icon badge (native feel) from the unread count in the payload — works even while the
+  // app is closed since the push wakes the service worker.
+  if (typeof data.badgeCount === 'number' && self.navigator && 'setAppBadge' in self.navigator) {
+    if (data.badgeCount > 0) self.navigator.setAppBadge(data.badgeCount).catch(() => {});
+    else self.navigator.clearAppBadge?.().catch(() => {});
+  }
+
   event.waitUntil(
     self.registration.showNotification(options.title, options)
   );

--- a/app/server/src/services/notificationStore.ts
+++ b/app/server/src/services/notificationStore.ts
@@ -119,10 +119,23 @@ export const notificationStore = {
       /* realtime is best-effort */
     }
     // Web Push for important kinds (or when explicitly forced) so it lands even when the app is closed.
+    // Include the current unread count so the service worker can set the app-icon badge (native feel).
     if (input.push ?? PUSH_KINDS.has(notif.kind)) {
-      void pushService.sendToWallet(wallet, { title: notif.title, body: notif.body, data: notif.data, tag: notif.id }).catch(() => {});
+      const badge = await this.countUnread(wallet).catch(() => undefined);
+      void pushService.sendToWallet(wallet, { title: notif.title, body: notif.body, data: notif.data, tag: notif.id, badge }).catch(() => {});
     }
     return notif;
+  },
+
+  async countUnread(wallet: string): Promise<number> {
+    const pool = getPostgresPool();
+    if (!pool) return 0;
+    await ensureTables();
+    const r = await pool.query<{ c: string }>(
+      `SELECT COUNT(*)::text AS c FROM ${TABLE} WHERE owner_wallet = $1 AND archived_at IS NULL AND read_at IS NULL`,
+      [normalizeWallet(wallet)],
+    );
+    return Number(r.rows[0]?.c ?? 0);
   },
 
   /** Register/refresh a Web Push subscription for a wallet (keyed by endpoint). */

--- a/app/server/src/services/pushService.ts
+++ b/app/server/src/services/pushService.ts
@@ -26,7 +26,7 @@ export const pushService = {
   isConfigured: () => configured,
 
   /** Send a push to every registered subscription for a wallet; prune dead endpoints (404/410). */
-  async sendToWallet(wallet: string, payload: { title: string; body: string; data?: Record<string, unknown> | null; tag?: string }): Promise<void> {
+  async sendToWallet(wallet: string, payload: { title: string; body: string; data?: Record<string, unknown> | null; tag?: string; badge?: number }): Promise<void> {
     const pool = getPostgresPool();
     if (!pool || !configured) return;
     const w = wallet.trim().toLowerCase();
@@ -40,7 +40,7 @@ export const pushService = {
     } catch {
       return;
     }
-    const body = JSON.stringify({ title: payload.title, body: payload.body, data: payload.data ?? {}, tag: payload.tag });
+    const body = JSON.stringify({ title: payload.title, body: payload.body, data: payload.data ?? {}, tag: payload.tag, badgeCount: payload.badge });
     await Promise.all(
       rows.map(async (r) => {
         try {

--- a/app/src/hooks/useNotifications.ts
+++ b/app/src/hooks/useNotifications.ts
@@ -56,28 +56,36 @@ export function useNotifications() {
     return () => window.removeEventListener('focus', onFocus);
   }, [refresh]);
 
-  // Web Push: once permission is granted (requested elsewhere on connect), register/refresh this
+  // Request notification permission (iOS needs this from a user gesture) and register/refresh this
   // device's push subscription so important notifications arrive when the app is closed.
+  const ensurePush = useCallback(async () => {
+    if (!address) return;
+    if (typeof window === 'undefined' || !('serviceWorker' in navigator) || !('PushManager' in window) || typeof Notification === 'undefined') return;
+    let perm = Notification.permission;
+    if (perm === 'default') perm = await Notification.requestPermission();
+    if (perm !== 'granted') return;
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const sub =
+        (await reg.pushManager.getSubscription()) ||
+        (await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY) }));
+      await savePushSubscription(address, sub.toJSON());
+    } catch {
+      /* push is optional */
+    }
+  }, [address]);
+
+  // If permission is already granted, subscribe silently on mount (no gesture needed).
   useEffect(() => {
-    if (!address || !isConnected) return;
-    if (typeof window === 'undefined' || !('serviceWorker' in navigator) || !('PushManager' in window)) return;
-    if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const reg = await navigator.serviceWorker.ready;
-        const sub =
-          (await reg.pushManager.getSubscription()) ||
-          (await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY) }));
-        if (!cancelled) await savePushSubscription(address, sub.toJSON());
-      } catch {
-        /* push is optional */
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [address, isConnected]);
+    if (address && isConnected && typeof Notification !== 'undefined' && Notification.permission === 'granted') void ensurePush();
+  }, [address, isConnected, ensurePush]);
+
+  // Reflect the unread count on the app-icon badge while the app is open (installed PWA).
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('setAppBadge' in navigator)) return;
+    if (unreadCount > 0) void navigator.setAppBadge?.(unreadCount).catch(() => {});
+    else void navigator.clearAppBadge?.().catch(() => {});
+  }, [unreadCount]);
 
   // Live: prepend notifications pushed by producers.
   useEffect(() => {
@@ -122,11 +130,14 @@ export function useNotifications() {
     [address],
   );
 
+  // The bell's "Send test" doubles as the enable path: the tap is the user gesture iOS needs to grant
+  // notification permission + register the push subscription, then it fires a test.
   const sendTest = useCallback(async () => {
     if (!address) return;
+    await ensurePush();
     await sendTestNotification(address).catch(() => {});
     await refresh();
-  }, [address, refresh]);
+  }, [address, ensurePush, refresh]);
 
   return { notifications, unreadCount, refresh, markRead, markAllRead, dismiss, sendTest };
 }


### PR DESCRIPTION
Makes push feel native, including the app-icon badge, with iOS in mind.

- **Badge end-to-end**: `emit()` puts the current unread count in the push payload → `pushService` sends `badgeCount` → the **service worker** calls `setAppBadge` from the push (works even with the app closed) → the client mirrors the live unread count onto the badge while open (clears at 0).
- **iOS gesture permission**: permission is now requested from a **user tap** — the bell's "Send test" doubles as the enable path (requests permission + registers the push subscription, then fires a test). Silent re-subscribe on mount only when permission is already granted.

Still required to actually deliver on iPhone: set `VAPID_*` on the server, and the user must **install the PWA to their Home Screen** (iOS only allows web push from an installed PWA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)