### PR TITLE
feat(notifications): enable prime + demo-only Send test

### DIFF
--- a/app/src/components/app-ui/NotificationPrime.tsx
+++ b/app/src/components/app-ui/NotificationPrime.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { Bell, X } from 'lucide-react';
+import { usePushRegistration, pushSupported, notificationPermission } from '@/hooks/usePushRegistration';
+import { cn } from '@/lib/utils';
+
+const DISMISS_KEY = 'clear_notif_prime_dismissed';
+
+const isIOS = () => typeof navigator !== 'undefined' && /iphone|ipad|ipod/i.test(navigator.userAgent);
+const isStandalone = () =>
+  typeof window !== 'undefined' &&
+  (window.matchMedia?.('(display-mode: standalone)').matches || (navigator as unknown as { standalone?: boolean }).standalone === true);
+
+/**
+ * One-time gesture CTA to turn on notifications — the tap is the user gesture iOS requires. Only shown
+ * when push can actually be enabled: supported, permission still undecided, and (on iOS) running as an
+ * installed Home-Screen PWA. Dismissible; self-hides once permission is decided.
+ */
+export default function NotificationPrime({ className }: { className?: string }) {
+  const { enablePush } = usePushRegistration();
+  const [hidden, setHidden] = useState(() => {
+    try { return localStorage.getItem(DISMISS_KEY) === '1'; } catch { return false; }
+  });
+  const [busy, setBusy] = useState(false);
+
+  const iosBlocked = isIOS() && !isStandalone(); // iOS needs the installed PWA for push
+  if (hidden || iosBlocked || !pushSupported() || notificationPermission() !== 'default') return null;
+
+  const enable = async () => {
+    setBusy(true);
+    const result = await enablePush();
+    setBusy(false);
+    if (result !== 'default') setHidden(true); // decided (granted/denied/unsupported) → stop prompting
+  };
+  const dismiss = () => {
+    try { localStorage.setItem(DISMISS_KEY, '1'); } catch { /* ignore */ }
+    setHidden(true);
+  };
+
+  return (
+    <div className={cn('flex items-center gap-3 rounded-xl border border-info/20 bg-info/5 p-3', className)}>
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-info/10 text-info">
+        <Bell className="h-[18px] w-[18px]" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-medium text-foreground">Turn on notifications</span>
+        <span className="block text-xs text-muted-foreground">Get alerts for payments, requests &amp; credits — even when the app is closed.</span>
+      </span>
+      <button
+        type="button"
+        onClick={enable}
+        disabled={busy}
+        className="shrink-0 rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+      >
+        {busy ? 'Enabling…' : 'Enable'}
+      </button>
+      <button type="button" onClick={dismiss} aria-label="Dismiss" className="shrink-0 text-muted-foreground transition-colors hover:text-foreground">
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/app/src/components/app-ui/NotificationsMenu.tsx
+++ b/app/src/components/app-ui/NotificationsMenu.tsx
@@ -6,6 +6,7 @@ import {
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
 import { useNotifications } from '@/hooks/useNotifications';
 import { useXMTP } from '@/context/XMTPContext';
+import { IS_LIVE_APP } from '@/lib/clearNetwork';
 import { cn } from '@/lib/utils';
 
 // kind → icon + tint (matches the notification kinds emitted by the backend producers).
@@ -166,13 +167,15 @@ export default function NotificationsMenu({ onOpenConversation }: { onOpenConver
               >
                 Mark all read
               </button>
-              <button
-                type="button"
-                onClick={() => void sendTest()}
-                className="font-medium text-muted-foreground transition-colors hover:text-foreground"
-              >
-                Send test
-              </button>
+              {!IS_LIVE_APP && (
+                <button
+                  type="button"
+                  onClick={() => void sendTest()}
+                  className="font-medium text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  Send test
+                </button>
+              )}
             </div>
           </>
         ) : (

--- a/app/src/hooks/useNotifications.ts
+++ b/app/src/hooks/useNotifications.ts
@@ -6,24 +6,10 @@ import {
   markNotificationRead,
   markAllNotificationsRead,
   archiveNotificationApi,
-  savePushSubscription,
   sendTestNotification,
   type ApiNotification,
 } from '@/utils/apiClient';
-
-// Public VAPID key (safe to expose). Overridable via env; falls back to the app's key.
-const VAPID_PUBLIC_KEY =
-  (import.meta.env.VITE_VAPID_PUBLIC_KEY as string | undefined) ||
-  'BMu0BQLWQctkLTZlOD2me1X-vOBVcfAZxU0kxXOKb_3eWMwBcJPSMrPightFAAz_exbQm-EYxoJOdJPNr74HWck';
-
-function urlBase64ToUint8Array(base64String: string): Uint8Array {
-  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
-  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
-  const raw = atob(base64);
-  const arr = new Uint8Array(raw.length);
-  for (let i = 0; i < raw.length; i += 1) arr[i] = raw.charCodeAt(i);
-  return arr;
-}
+import { usePushRegistration } from '@/hooks/usePushRegistration';
 
 /**
  * Persistent in-app notifications from the backend (wallet-scoped). Fetches on mount + focus, receives
@@ -32,6 +18,7 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array {
 export function useNotifications() {
   const { address, isConnected } = useAppKitAccount();
   const { socket } = useWebSocket(address, isConnected);
+  const { enablePush } = usePushRegistration();
   const [notifications, setNotifications] = useState<ApiNotification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
 
@@ -56,29 +43,11 @@ export function useNotifications() {
     return () => window.removeEventListener('focus', onFocus);
   }, [refresh]);
 
-  // Request notification permission (iOS needs this from a user gesture) and register/refresh this
-  // device's push subscription so important notifications arrive when the app is closed.
-  const ensurePush = useCallback(async () => {
-    if (!address) return;
-    if (typeof window === 'undefined' || !('serviceWorker' in navigator) || !('PushManager' in window) || typeof Notification === 'undefined') return;
-    let perm = Notification.permission;
-    if (perm === 'default') perm = await Notification.requestPermission();
-    if (perm !== 'granted') return;
-    try {
-      const reg = await navigator.serviceWorker.ready;
-      const sub =
-        (await reg.pushManager.getSubscription()) ||
-        (await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY) }));
-      await savePushSubscription(address, sub.toJSON());
-    } catch {
-      /* push is optional */
-    }
-  }, [address]);
-
-  // If permission is already granted, subscribe silently on mount (no gesture needed).
+  // If permission is already granted, subscribe silently on mount (no gesture needed). The gesture path
+  // (first-time grant) is the "Enable notifications" prime and the demo "Send test" button.
   useEffect(() => {
-    if (address && isConnected && typeof Notification !== 'undefined' && Notification.permission === 'granted') void ensurePush();
-  }, [address, isConnected, ensurePush]);
+    if (address && isConnected && typeof Notification !== 'undefined' && Notification.permission === 'granted') void enablePush();
+  }, [address, isConnected, enablePush]);
 
   // Reflect the unread count on the app-icon badge while the app is open (installed PWA).
   useEffect(() => {
@@ -134,10 +103,10 @@ export function useNotifications() {
   // notification permission + register the push subscription, then it fires a test.
   const sendTest = useCallback(async () => {
     if (!address) return;
-    await ensurePush();
+    await enablePush();
     await sendTestNotification(address).catch(() => {});
     await refresh();
-  }, [address, ensurePush, refresh]);
+  }, [address, enablePush, refresh]);
 
   return { notifications, unreadCount, refresh, markRead, markAllRead, dismiss, sendTest };
 }

--- a/app/src/hooks/usePushRegistration.ts
+++ b/app/src/hooks/usePushRegistration.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+import { useAppKitAccount } from '@/lib/walletCompat';
+import { savePushSubscription } from '@/utils/apiClient';
+
+// Public VAPID key (safe to expose). Overridable via env; falls back to the app's key.
+const VAPID_PUBLIC_KEY =
+  (import.meta.env.VITE_VAPID_PUBLIC_KEY as string | undefined) ||
+  'BMu0BQLWQctkLTZlOD2me1X-vOBVcfAZxU0kxXOKb_3eWMwBcJPSMrPightFAAz_exbQm-EYxoJOdJPNr74HWck';
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  const arr = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i += 1) arr[i] = raw.charCodeAt(i);
+  return arr;
+}
+
+/** True when this browser can do Web Push at all (installed PWA still required on iOS). */
+export const pushSupported = () =>
+  typeof window !== 'undefined' && 'Notification' in window && 'serviceWorker' in navigator && 'PushManager' in window;
+
+export const notificationPermission = (): NotificationPermission | 'unsupported' =>
+  typeof window !== 'undefined' && 'Notification' in window ? Notification.permission : 'unsupported';
+
+/**
+ * Requests notification permission (iOS requires this from a user gesture) and registers/refreshes this
+ * device's push subscription with the backend. Also self-heals rotated subscriptions: `getSubscription`
+ * returns the browser's current one, which we re-save — so a rotation is picked up on next call.
+ */
+export function usePushRegistration() {
+  const { address } = useAppKitAccount();
+
+  const enablePush = useCallback(async (): Promise<NotificationPermission | 'unsupported'> => {
+    if (!address || !pushSupported()) return 'unsupported';
+    let perm = Notification.permission;
+    if (perm === 'default') perm = await Notification.requestPermission();
+    if (perm !== 'granted') return perm;
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const sub =
+        (await reg.pushManager.getSubscription()) ||
+        (await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY) }));
+      await savePushSubscription(address, sub.toJSON());
+    } catch {
+      /* push is optional */
+    }
+    return 'granted';
+  }, [address]);
+
+  return { enablePush };
+}

--- a/app/src/pages/app/AccountsPage.tsx
+++ b/app/src/pages/app/AccountsPage.tsx
@@ -17,6 +17,7 @@ import SpendHeatmap from '@/components/app-ui/SpendHeatmap';
 import UpcomingCalendar from '@/components/app-ui/UpcomingCalendar';
 import BalanceAnalyticsChart from '@/components/app-ui/charts/BalanceAnalyticsChart';
 import ClearDeedCard from '@/components/app-ui/ClearDeedCard';
+import NotificationPrime from '@/components/app-ui/NotificationPrime';
 
 /**
  * Accounts — the dashboard. Stat row (Total / Cash / Savings / External), a big
@@ -123,6 +124,9 @@ export default function AccountsPage() {
         <h1 className="font-display text-3xl tracking-tight text-foreground">Good morning, {firstName}</h1>
         <p className="mt-1 text-sm text-muted-foreground">Here's where your money stands today.</p>
       </div>
+
+      <NotificationPrime />
+
 
       {!verified && (
         <button


### PR DESCRIPTION
- **"Enable notifications" prime**: a one-time, dismissible gesture CTA on the dashboard — the tap is the gesture iOS needs to grant permission + register push. Shown only when push is supported, permission is still undecided, and (on iOS) the app is running as an installed Home-Screen PWA (so we never show an "Enable" that can't work in Safari).
- **Shared `usePushRegistration`**: extracted the permission + subscribe logic; `useNotifications` uses it (silent re-subscribe on mount when already granted). This also self-heals rotated subscriptions on next call, so a service-worker `pushsubscriptionchange` handler isn't needed (that would've required cross-origin auth from the SW; dead endpoints already get pruned on the 410).
- **"Send test" is demo-only** now (`IS_LIVE_APP` hostname check) — hidden on app.useclear.org, kept on the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)