### PR TITLE
fix(directory): resolve members by login email/phone (messaging said 'not on Clear')

### DIFF
--- a/app/server/src/services/contactsStore.ts
+++ b/app/server/src/services/contactsStore.ts
@@ -125,12 +125,16 @@ export const contactsStore = {
     const eHashes = email ? emailHashes(email) : [];
     const pHashes = phone ? phoneHashes(phone) : [];
     if (eHashes.length === 0 && pHashes.length === 0) return null;
+    // Match either the saved profile contact (member_profile_public.email_hash/phone_hash) OR the
+    // login identity the member signed up with (members.reown_email_hash/reown_phone_hash). LEFT JOIN
+    // so members who never saved a profile contact are still discoverable by their login email/phone.
     const r = await pool.query(
       `SELECT m.primary_wallet AS wallet,
-              (p.email_hash = ANY($1)) AS by_email
-         FROM member_profile_public p
-         JOIN members m ON m.id = p.member_id
-        WHERE (p.email_hash = ANY($1) OR p.phone_hash = ANY($2))
+              (p.email_hash = ANY($1) OR m.reown_email_hash = ANY($1)) AS by_email
+         FROM members m
+         LEFT JOIN member_profile_public p ON p.member_id = m.id
+        WHERE (p.email_hash = ANY($1) OR p.phone_hash = ANY($2)
+               OR m.reown_email_hash = ANY($1) OR m.reown_phone_hash = ANY($2))
           AND m.primary_wallet IS NOT NULL
           AND lower(m.primary_wallet) NOT IN (SELECT wallet FROM ${OPTOUT})
         LIMIT 1`,


### PR DESCRIPTION
Messaging someone by email said "they aren't on Clear yet" even when they are. The directory lookup (also used by request/send recipient resolution) only matched `member_profile_public.email_hash/phone_hash` — the contact a member explicitly **saved on their profile**. Someone who signed in with an email but never set a profile contact wasn't found.

Now the lookup also matches `members.reown_email_hash/reown_phone_hash` (the login identity), via a `LEFT JOIN` so members without a profile row still resolve. Opt-out is still respected. Hashing matches (`sha256Hex`, raw + lowercased candidates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)