### PR TITLE
fix(requests): attempt request for any email/phone recipient

### DIFF
--- a/app/src/components/app-ui/RequestModal.tsx
+++ b/app/src/components/app-ui/RequestModal.tsx
@@ -312,9 +312,10 @@ export default function RequestModal({ open, onOpenChange }: { open: boolean; on
             <button
               type="button"
               onClick={() => {
-                // In-app request (recipient is a member) → server resolves them by email/phone + notifies.
-                // Link sends (non-members) still show the copy-link flow below until the pay-link backend lands.
-                if (instant && (recipient?.email || recipient?.phone)) {
+                // Always attempt a real request when we have an email/phone — the server resolves the
+                // recipient to a member and notifies them (even if we don't have their wallet locally).
+                // If they're not a member, it no-ops and the copy-link flow below is the fallback.
+                if (recipient?.email || recipient?.phone) {
                   void createPaymentRequest({ recipientEmail: recipient.email || undefined, recipientPhone: recipient.phone || undefined, amount, note: note || undefined });
                 }
                 setStep('status');


### PR DESCRIPTION
The Request modal only called the backend when the contact had a wallet saved locally (`instant`), so requesting from an email-only contact never notified them even if that email maps to a member. Now it always attempts when an email/phone is present — the server resolves the member and notifies; if they're not a member it no-ops and the copy-link flow is the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)