### PR TITLE
fix(notifications): read across all of a user's verified wallets

### DIFF
--- a/app/server/src/routes/notifications.ts
+++ b/app/server/src/routes/notifications.ts
@@ -9,6 +9,13 @@ import { notificationStore } from '../services/notificationStore.js';
  */
 const router = Router();
 const wallet = (req: Request) => String(req.params.wallet || '').toLowerCase();
+// All wallets this user controls (the :wallet param + every verified address on the session), so a
+// notification scoped to any of them (primary vs smart vs linked) is still read/marked/archived here.
+const wallets = (req: Request) => {
+  const set = new Set<string>([wallet(req)]);
+  for (const a of req.auth?.addresses ?? []) if (a) set.add(a.toLowerCase());
+  return [...set].filter(Boolean);
+};
 
 // GET /api/notifications/:wallet → { notifications, unreadCount }
 router.get('/:wallet', async (req: Request, res: Response) => {
@@ -18,14 +25,14 @@ router.get('/:wallet', async (req: Request, res: Response) => {
     res.json({ notifications: [], unreadCount: 0 });
     return;
   }
-  res.json(await notificationStore.list(w));
+  res.json(await notificationStore.list(wallets(req)));
 });
 
 // POST /api/notifications/:wallet/read-all
 router.post('/:wallet/read-all', async (req: Request, res: Response) => {
   const w = wallet(req);
   if (!requireWalletMatch(req, res, w, 'wallet')) return;
-  await notificationStore.markAllRead(w);
+  await notificationStore.markAllRead(wallets(req));
   res.json({ ok: true });
 });
 
@@ -62,7 +69,7 @@ router.post('/:wallet/subscribe', async (req: Request, res: Response) => {
 router.post('/:wallet/:id/read', async (req: Request, res: Response) => {
   const w = wallet(req);
   if (!requireWalletMatch(req, res, w, 'wallet')) return;
-  await notificationStore.markRead(w, String(req.params.id));
+  await notificationStore.markRead(wallets(req), String(req.params.id));
   res.json({ ok: true });
 });
 
@@ -70,7 +77,7 @@ router.post('/:wallet/:id/read', async (req: Request, res: Response) => {
 router.post('/:wallet/:id/archive', async (req: Request, res: Response) => {
   const w = wallet(req);
   if (!requireWalletMatch(req, res, w, 'wallet')) return;
-  await notificationStore.archive(w, String(req.params.id));
+  await notificationStore.archive(wallets(req), String(req.params.id));
   res.json({ ok: true });
 });
 

--- a/app/server/src/services/notificationStore.ts
+++ b/app/server/src/services/notificationStore.ts
@@ -39,6 +39,11 @@ interface DbRow {
 }
 
 const normalizeWallet = (w: string) => w.trim().toLowerCase();
+// A user can hold several wallets (smart wallet, EOA, linked). Notifications are scoped by a single
+// owner wallet, but the reader should see them across ALL their verified wallets so a scoping mismatch
+// (e.g. notification on primary_wallet vs the smart wallet the client fetches with) never hides them.
+const normalizeWallets = (w: string | string[]): string[] =>
+  [...new Set((Array.isArray(w) ? w : [w]).filter(Boolean).map(normalizeWallet))];
 
 async function ensureTables(): Promise<void> {
   const pool = getPostgresPool();
@@ -151,44 +156,45 @@ export const notificationStore = {
     );
   },
 
-  async list(wallet: string, limit = 40): Promise<{ notifications: NotificationRow[]; unreadCount: number }> {
+  async list(wallet: string | string[], limit = 40): Promise<{ notifications: NotificationRow[]; unreadCount: number }> {
     const pool = getPostgresPool();
     if (!pool) return { notifications: [], unreadCount: 0 };
     await ensureTables();
-    const w = normalizeWallet(wallet);
+    const ws = normalizeWallets(wallet);
+    if (ws.length === 0) return { notifications: [], unreadCount: 0 };
     const [rows, counts] = await Promise.all([
       pool.query<DbRow>(
         `SELECT id, kind, title, body, data, read_at, created_at FROM ${TABLE}
-           WHERE owner_wallet = $1 AND archived_at IS NULL
+           WHERE owner_wallet = ANY($1::text[]) AND archived_at IS NULL
            ORDER BY created_at DESC LIMIT $2`,
-        [w, Math.min(Math.max(limit, 1), 100)],
+        [ws, Math.min(Math.max(limit, 1), 100)],
       ),
       pool.query<{ count: string }>(
-        `SELECT COUNT(*)::text AS count FROM ${TABLE} WHERE owner_wallet = $1 AND archived_at IS NULL AND read_at IS NULL`,
-        [w],
+        `SELECT COUNT(*)::text AS count FROM ${TABLE} WHERE owner_wallet = ANY($1::text[]) AND archived_at IS NULL AND read_at IS NULL`,
+        [ws],
       ),
     ]);
     return { notifications: rows.rows.map(toRow), unreadCount: Number(counts.rows[0]?.count ?? 0) };
   },
 
-  async markRead(wallet: string, id: string): Promise<void> {
+  async markRead(wallet: string | string[], id: string): Promise<void> {
     const pool = getPostgresPool();
     if (!pool) return;
     await ensureTables();
-    await pool.query(`UPDATE ${TABLE} SET read_at = now() WHERE owner_wallet = $1 AND id = $2 AND read_at IS NULL`, [normalizeWallet(wallet), id]);
+    await pool.query(`UPDATE ${TABLE} SET read_at = now() WHERE owner_wallet = ANY($1::text[]) AND id = $2 AND read_at IS NULL`, [normalizeWallets(wallet), id]);
   },
 
-  async markAllRead(wallet: string): Promise<void> {
+  async markAllRead(wallet: string | string[]): Promise<void> {
     const pool = getPostgresPool();
     if (!pool) return;
     await ensureTables();
-    await pool.query(`UPDATE ${TABLE} SET read_at = now() WHERE owner_wallet = $1 AND read_at IS NULL`, [normalizeWallet(wallet)]);
+    await pool.query(`UPDATE ${TABLE} SET read_at = now() WHERE owner_wallet = ANY($1::text[]) AND read_at IS NULL`, [normalizeWallets(wallet)]);
   },
 
-  async archive(wallet: string, id: string): Promise<void> {
+  async archive(wallet: string | string[], id: string): Promise<void> {
     const pool = getPostgresPool();
     if (!pool) return;
     await ensureTables();
-    await pool.query(`UPDATE ${TABLE} SET archived_at = now() WHERE owner_wallet = $1 AND id = $2`, [normalizeWallet(wallet), id]);
+    await pool.query(`UPDATE ${TABLE} SET archived_at = now() WHERE owner_wallet = ANY($1::text[]) AND id = $2`, [normalizeWallets(wallet), id]);
   },
 };


### PR DESCRIPTION
A notification is scoped to one owner wallet, but a user can hold several (smart wallet, EOA, linked). If a request/send notification lands on their `primary_wallet` while the client fetches with a different one of their wallets, it was silently hidden. `list`/`markRead`/`markAllRead`/`archive` now span every verified address on the session (`owner_wallet = ANY`). `requireWalletMatch` still gates the path wallet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)