### PR TITLE
fix(server): route errors no longer crash the server (502/CORS)

### DIFF
--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -295,6 +295,13 @@ process.on('SIGINT', async () => {
   process.exit(0);
 });
 
+// A rejected promise in a request handler (e.g. an async route that throws) must NOT take the whole
+// server down — otherwise one bad request 502s every user until Railway restarts. Log and keep serving;
+// the failing request still returns an error to its own caller.
+process.on('unhandledRejection', (reason) => {
+  console.error('⚠️ Unhandled promise rejection (server kept alive):', reason);
+});
+
 // Start server with error handling
 startServer().catch((error) => {
   console.error('❌ Failed to start server:', error);

--- a/app/server/src/routes/requests.ts
+++ b/app/server/src/routes/requests.ts
@@ -52,38 +52,43 @@ router.post('/', async (req: Request, res: Response) => {
     return;
   }
 
-  // Resolve the recipient to a Clear member — the caller can't target an arbitrary wallet.
-  const match = await contactsStore.lookupWallet(recipientEmail || undefined, recipientPhone || undefined);
-  if (!match?.wallet) {
-    res.status(404).json({ error: 'Recipient not found', message: "That person isn't a Clear member (or isn't discoverable)." });
-    return;
+  try {
+    // Resolve the recipient to a Clear member — the caller can't target an arbitrary wallet.
+    const match = await contactsStore.lookupWallet(recipientEmail || undefined, recipientPhone || undefined);
+    if (!match?.wallet) {
+      res.status(404).json({ error: 'Recipient not found', message: "That person isn't a Clear member (or isn't discoverable)." });
+      return;
+    }
+    if (match.wallet.toLowerCase() === fromWallet) {
+      res.status(400).json({ error: 'Invalid recipient', message: "You can't request money from yourself." });
+      return;
+    }
+
+    const fromName = await senderDisplayName(req);
+    const created = await requestStore.create({
+      fromWallet,
+      fromName,
+      toWallet: match.wallet,
+      amountUsd: amt,
+      note: note?.trim() || null,
+    });
+
+    await notificationStore
+      .emit({
+        wallet: match.wallet,
+        kind: 'request',
+        title: 'Payment request',
+        body: `${fromName} requested ${fmt(amt)}${note?.trim() ? ` · ${note.trim()}` : ''}`,
+        data: { requestId: created?.id ?? null, amount: amt, from: fromWallet, href: '/pay' },
+        dedupeKey: `request:${created?.id ?? `${fromWallet}-${Date.now()}`}`,
+      })
+      .catch(() => {});
+
+    res.json({ ok: true, id: created?.id ?? null });
+  } catch (err) {
+    console.error('[requests] create failed:', err);
+    res.status(500).json({ error: 'Request failed', message: err instanceof Error ? err.message : 'Unknown error' });
   }
-  if (match.wallet.toLowerCase() === fromWallet) {
-    res.status(400).json({ error: 'Invalid recipient', message: "You can't request money from yourself." });
-    return;
-  }
-
-  const fromName = await senderDisplayName(req);
-  const created = await requestStore.create({
-    fromWallet,
-    fromName,
-    toWallet: match.wallet,
-    amountUsd: amt,
-    note: note?.trim() || null,
-  });
-
-  await notificationStore
-    .emit({
-      wallet: match.wallet,
-      kind: 'request',
-      title: 'Payment request',
-      body: `${fromName} requested ${fmt(amt)}${note?.trim() ? ` · ${note.trim()}` : ''}`,
-      data: { requestId: created?.id ?? null, amount: amt, from: fromWallet, href: '/pay' },
-      dedupeKey: `request:${created?.id ?? `${fromWallet}-${Date.now()}`}`,
-    })
-    .catch(() => {});
-
-  res.json({ ok: true, id: created?.id ?? null });
 });
 
 export default router;


### PR DESCRIPTION
The `502 Bad Gateway` + "No Access-Control-Allow-Origin" on `/api/requests` was the server **crashing**, not a CORS config issue (a crashed/gateway response has no CORS header).

Root cause: `/api/requests` had no try/catch, so an async throw (e.g. a DB error in `lookupWallet`/`create`) became an **unhandled promise rejection** → process crash on modern Node → 502 + socket drop, until Railway restarted (which is why the endpoint 401s fine again between attempts).

Fixes:
- Wrap the requests handler in try/catch → returns a clean `500` with the real error message **and** CORS headers, instead of crashing.
- Add a global `unhandledRejection` guard that logs and **keeps the server alive** — so a single bad request can never 502 every user again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)