### PR TITLE
feat(auth): full-screen login + onboarding gate + drop redundant re-auth

### DIFF
--- a/app/src/components/shell/AppShell.tsx
+++ b/app/src/components/shell/AppShell.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import { type ReactNode } from 'react';
+import { Outlet, Navigate } from 'react-router-dom';
 import Sidebar from './Sidebar';
 import TopBar from './TopBar';
 import SideMenu from './SideMenu';
@@ -8,7 +9,7 @@ import { KycProvider } from '@/context/KycContext';
 import { BridgeProvider } from '@/context/BridgeContext';
 import { ClearBalancesProvider } from '@/hooks/useClearBalances';
 import { ClearTransactionsProvider } from '@/hooks/useClearTransactions';
-import { MemberProfileProvider } from '@/hooks/useMemberProfile';
+import { MemberProfileProvider, useMemberProfile } from '@/hooks/useMemberProfile';
 import { LinkedWalletsProvider } from '@/context/LinkedWalletsContext';
 import { ExternalAccountsProvider } from '@/context/ExternalAccountsContext';
 import { ContactsProvider } from '@/context/ContactsContext';
@@ -37,6 +38,17 @@ function XmtpModalHost() {
  * column offset by its width and scrolling via the window (no sticky/flex sidebar).
  * Mobile uses the SideMenu drawer + floating TabBar. Collapse state is persisted.
  */
+/**
+ * Sends brand-new members (status ONBOARDING) to the onboarding flow. Only redirects once we've
+ * positively determined that status — while loading / on error / unknown it renders the app, so an
+ * existing member is never trapped. Onboarding lives outside AppShell, so there's no redirect loop.
+ */
+function OnboardingGate({ children }: { children: ReactNode }) {
+  const { memberStatus } = useMemberProfile();
+  if (memberStatus === 'ONBOARDING') return <Navigate to="/onboarding" replace />;
+  return <>{children}</>;
+}
+
 export default function AppShell() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem('sidebar-collapsed') === '1');
@@ -49,6 +61,7 @@ export default function AppShell() {
     <KycProvider>
       <BridgeProvider>
       <MemberProfileProvider>
+      <OnboardingGate>
       <ClearBalancesProvider>
       <LinkedWalletsProvider>
       <ClearTransactionsProvider>
@@ -79,6 +92,7 @@ export default function AppShell() {
       </ClearTransactionsProvider>
       </LinkedWalletsProvider>
       </ClearBalancesProvider>
+      </OnboardingGate>
       </MemberProfileProvider>
       </BridgeProvider>
     </KycProvider>

--- a/app/src/hooks/useMemberProfile.ts
+++ b/app/src/hooks/useMemberProfile.ts
@@ -1,6 +1,6 @@
 import { createContext, createElement, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
 import { useAppKitAccount } from '@/lib/walletCompat';
-import { getMemberAccountCenter, bootstrapMemberAccount, type MemberProfileViewResponse } from '@/utils/apiClient';
+import { getMemberAccountCenter, bootstrapMemberAccount, type MemberProfileViewResponse, type MemberStatus } from '@/utils/apiClient';
 import { getStoredAvatar, setStoredAvatar } from '@/lib/avatarStore';
 
 /**
@@ -30,6 +30,8 @@ export interface MemberProfile {
   address: string;
   initials: string;
   loading: boolean;
+  /** Member lifecycle status; 'ONBOARDING' = brand-new, hasn't completed onboarding. null until loaded. */
+  memberStatus: MemberStatus | null;
   refresh: () => void;
   /** Set/clear the local avatar (data URL); persists per-wallet in localStorage. */
   setAvatar: (dataUrl: string | null) => void;
@@ -38,7 +40,7 @@ export interface MemberProfile {
 
 const EMPTY: MemberProfile = {
   name: '', firstName: 'there', handle: '', email: '', phone: '', avatarUrl: null,
-  username: '', address: '', initials: 'CL', loading: false, refresh: () => {}, setAvatar: () => {}, raw: null,
+  username: '', address: '', initials: 'CL', loading: false, memberStatus: null, refresh: () => {}, setAvatar: () => {}, raw: null,
 };
 
 const Ctx = createContext<MemberProfile | null>(null);
@@ -50,6 +52,7 @@ export function useMemberProfile(): MemberProfile {
 export function MemberProfileProvider({ children }: { children: ReactNode }) {
   const { address, isConnected } = useAppKitAccount();
   const [raw, setRaw] = useState<MemberProfileViewResponse | null>(null);
+  const [memberStatus, setMemberStatus] = useState<MemberStatus | null>(null);
   const [loading, setLoading] = useState(false);
   const [localAvatar, setLocalAvatar] = useState<string | null>(null);
 
@@ -68,6 +71,7 @@ export function MemberProfileProvider({ children }: { children: ReactNode }) {
   const load = useCallback(async () => {
     if (!isConnected) {
       setRaw(null);
+      setMemberStatus(null);
       return;
     }
     setLoading(true);
@@ -78,8 +82,10 @@ export function MemberProfileProvider({ children }: { children: ReactNode }) {
       await bootstrapMemberAccount().catch(() => {});
       const r = await getMemberAccountCenter();
       setRaw(r?.profile ?? null);
+      setMemberStatus(r?.member?.status ?? null);
     } catch {
       setRaw(null);
+      setMemberStatus(null);
     } finally {
       setLoading(false);
     }
@@ -106,6 +112,7 @@ export function MemberProfileProvider({ children }: { children: ReactNode }) {
     address: addr,
     initials: initialsOf(pub?.displayName || pub?.username || '', addr),
     loading,
+    memberStatus,
     refresh: () => void load(),
     setAvatar,
     raw,

--- a/app/src/pages/auth/LoginView.tsx
+++ b/app/src/pages/auth/LoginView.tsx
@@ -6,19 +6,19 @@ import PrivyLoginControls from './PrivyLoginControls';
 interface Benefit {
   icon: LucideIcon;
   title: string;
-  body: string;
 }
 
 const BENEFITS: Benefit[] = [
-  { icon: Sparkles, title: '1:1 equity match', body: 'Every $1 you save earns $1 in equity credits.' },
-  { icon: Home, title: 'Rent that builds equity', body: 'On-time rent counts toward your own Clear Deed.' },
-  { icon: PiggyBank, title: 'Savings you control', body: 'Your balance stays liquid — withdraw it any time.' },
+  { icon: Sparkles, title: '1:1 equity match' },
+  { icon: Home, title: 'Rent builds equity' },
+  { icon: PiggyBank, title: 'Liquid savings' },
 ];
 
 /**
- * Login / sign-up — brand + value prop + the inline auth controls. Auth runs through Privy headlessly
- * (PrivyLoginControls: email OTP / Google+socials / wallet) — no third-party modal. All theme tokens,
- * so it adapts to light/dusk/dark.
+ * Login / sign-up — full-screen (not a card), using the whole viewport with generous spacing so it
+ * feels native on mobile: brand up top, value prop in the middle, auth controls in the thumb zone at
+ * the bottom. Auth runs through Privy headlessly (PrivyLoginControls: email/phone OTP up front, socials
+ * behind a slide-up sheet). All theme tokens, so it adapts to light/dusk/dark.
  */
 export default function LoginView({
   onPreviewOnboarding,
@@ -26,57 +26,61 @@ export default function LoginView({
   onPreviewOnboarding: () => void;
 }) {
   return (
-    <div className="relative grid min-h-screen place-items-center overflow-hidden bg-background px-5 py-10 text-foreground">
+    <div className="relative flex min-h-[100dvh] flex-col overflow-hidden bg-background text-foreground">
       {/* ambient */}
       <div className="pointer-events-none absolute inset-0" aria-hidden>
-        <div className="absolute -left-32 -top-32 h-96 w-96 rounded-full bg-info/[0.07] blur-3xl" />
+        <div className="absolute -left-32 -top-40 h-96 w-96 rounded-full bg-info/[0.07] blur-3xl" />
         <div className="absolute -bottom-40 -right-24 h-96 w-96 rounded-full bg-positive/[0.07] blur-3xl" />
       </div>
 
-      <div className="relative w-full max-w-[440px]">
+      <div className="relative mx-auto flex w-full max-w-[440px] flex-1 flex-col px-6">
         {/* brand */}
-        <div className="mb-6 flex items-center gap-3">
-          <img src={ClearPathLogo} alt="Clear" className="h-10 w-10 rounded-lg border border-border object-cover" />
+        <header className="flex items-center gap-3 pt-[max(1.75rem,env(safe-area-inset-top))]">
+          <img src={ClearPathLogo} alt="Clear" className="h-10 w-10 rounded-xl border border-border object-cover" />
           <div className="min-w-0">
             <Wordmark className="text-xl" />
             <div className="-mt-0.5 truncate text-[11px] text-muted-foreground">Turn rent into ownership</div>
           </div>
-        </div>
+        </header>
 
-        <div className="rounded-2xl border border-border bg-card p-6 shadow-sm">
-          <h1 className="font-display text-3xl leading-[1.1] tracking-tight">Stop renting.<br />Start owning.</h1>
-          <p className="mt-2 text-sm text-muted-foreground">Build equity with every rent payment and dollar you save. Free to start.</p>
+        {/* hero — fills the space between brand and controls */}
+        <main className="flex flex-1 flex-col justify-center py-10">
+          <h1 className="font-display text-[2.5rem] leading-[1.05] tracking-tight">
+            Stop renting.
+            <br />
+            Start owning.
+          </h1>
+          <p className="mt-3 max-w-[22rem] text-[15px] leading-relaxed text-muted-foreground">
+            Build equity with every rent payment and dollar you save. Free to start.
+          </p>
 
-          <div className="mt-5 space-y-3">
+          <div className="mt-6 flex flex-wrap gap-2">
             {BENEFITS.map((b) => {
               const Icon = b.icon;
               return (
-                <div key={b.title} className="flex gap-3">
-                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
-                    <Icon className="h-[18px] w-[18px]" />
-                  </span>
-                  <div className="min-w-0">
-                    <div className="text-sm font-medium text-foreground">{b.title}</div>
-                    <div className="text-xs text-muted-foreground">{b.body}</div>
-                  </div>
-                </div>
+                <span key={b.title} className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card/60 px-3 py-1.5 text-xs font-medium text-foreground">
+                  <Icon className="h-3.5 w-3.5 text-muted-foreground" /> {b.title}
+                </span>
               );
             })}
           </div>
+        </main>
 
+        {/* auth — thumb zone */}
+        <footer className="pb-[max(1.5rem,env(safe-area-inset-bottom))]">
           <PrivyLoginControls />
-        </div>
 
-        <p className="mt-4 text-center text-[11px] leading-relaxed text-muted-foreground">
-          By continuing you agree to our <span className="underline">Terms</span> &amp; <span className="underline">Privacy Policy</span>.
-        </p>
-        <button
-          type="button"
-          onClick={onPreviewOnboarding}
-          className="mx-auto mt-3 block text-center text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-        >
-          See how it works →
-        </button>
+          <p className="mt-4 text-center text-[11px] leading-relaxed text-muted-foreground">
+            By continuing you agree to our <span className="underline">Terms</span> &amp; <span className="underline">Privacy Policy</span>.
+          </p>
+          <button
+            type="button"
+            onClick={onPreviewOnboarding}
+            className="mx-auto mt-2 block text-center text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            See how it works →
+          </button>
+        </footer>
       </div>
     </div>
   );

--- a/app/src/pages/auth/PrivyLoginControls.tsx
+++ b/app/src/pages/auth/PrivyLoginControls.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
-import { ArrowRight, Loader2, Mail, Phone } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ArrowRight, Loader2, Mail, Phone, X } from 'lucide-react';
 import { useLoginWithEmail, useLoginWithOAuth, useLoginWithSms } from '@privy-io/react-auth';
 
 /*
  * Custom Privy login — identity only (email / phone / social). No wallet login: external wallets are
  * LINKED in-app (Privy linked accounts), and the Privy smart wallet is the user's primary wallet.
- * Email & phone are 2-step OTPs (send code → verify); socials redirect via initOAuth. All our own UI.
- * On success Privy flips `authenticated` → LoginPage navigates onward. See [[clearpath-privy-migration]].
+ * Email & phone are the guaranteed methods (2-step OTP: send code → verify), shown up front. Socials
+ * (OAuth redirect) live behind a "More ways to sign in" slide-up sheet. On success Privy flips
+ * `authenticated` → LoginPage routes onward. See [[clearpath-privy-migration]].
  */
 
 type OAuthProvider = 'google' | 'apple' | 'twitter' | 'discord' | 'github';
@@ -23,6 +25,9 @@ const SOCIALS: { id: OAuthProvider; label: string }[] = [
 const normalizePhone = (raw: string) => '+' + raw.replace(/[^\d]/g, '');
 const isValidPhone = (raw: string) => /^\+[1-9]\d{6,14}$/.test(normalizePhone(raw));
 
+const inputCls =
+  'w-full rounded-2xl border border-border bg-background px-4 py-4 text-base text-foreground placeholder:text-muted-foreground/60 focus:border-foreground/30 focus:outline-none';
+
 export default function PrivyLoginControls() {
   const { sendCode: sendEmailCode, loginWithCode: loginWithEmailCode } = useLoginWithEmail();
   const { sendCode: sendSmsCode, loginWithCode: loginWithSmsCode } = useLoginWithSms();
@@ -35,6 +40,7 @@ export default function PrivyLoginControls() {
   const [code, setCode] = useState('');
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [showMore, setShowMore] = useState(false);
 
   const destination = method === 'email' ? email : normalizePhone(phone);
 
@@ -66,7 +72,7 @@ export default function PrivyLoginControls() {
     try {
       if (method === 'email') await loginWithEmailCode({ code });
       else await loginWithSmsCode({ code });
-      // On success Privy authenticates; LoginPage's effect navigates onward.
+      // On success Privy authenticates; LoginPage's effect routes onward.
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Invalid or expired code.');
     } finally {
@@ -85,14 +91,10 @@ export default function PrivyLoginControls() {
     }
   };
 
-  const inputCls =
-    'w-full rounded-xl border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 focus:border-foreground/30 focus:outline-none';
-  const socialBtn =
-    'flex-1 rounded-xl border border-border py-2.5 text-xs font-medium text-foreground transition-colors hover:bg-secondary disabled:opacity-50';
-
+  // ---- Code step ----
   if (step === 'code') {
     return (
-      <div className="mt-6 space-y-3">
+      <div className="space-y-3">
         <p className="text-sm text-muted-foreground">
           Enter the 6-digit code we sent to <span className="font-medium text-foreground">{destination}</span>.
         </p>
@@ -103,16 +105,16 @@ export default function PrivyLoginControls() {
           onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
           onKeyDown={(e) => e.key === 'Enter' && code.length === 6 && verify()}
           placeholder="123456"
-          className={`${inputCls} text-center tracking-[0.5em]`}
+          className={`${inputCls} text-center text-xl tracking-[0.5em]`}
         />
         {error && <p className="text-xs text-destructive">{error}</p>}
         <button
           type="button"
           disabled={code.length !== 6 || busy === 'code'}
           onClick={verify}
-          className="flex w-full items-center justify-center gap-2 rounded-xl bg-primary py-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.99] disabled:opacity-40"
+          className="flex w-full items-center justify-center gap-2 rounded-2xl bg-primary py-4 text-base font-semibold text-primary-foreground transition-transform active:scale-[0.99] disabled:opacity-40"
         >
-          {busy === 'code' ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Verify & continue'}
+          {busy === 'code' ? <Loader2 className="h-5 w-5 animate-spin" /> : 'Verify & continue'}
         </button>
         <button
           type="button"
@@ -129,10 +131,11 @@ export default function PrivyLoginControls() {
     );
   }
 
+  // ---- Enter step ----
   return (
-    <div className="mt-6 space-y-3">
+    <div className="space-y-3">
       {/* Email / Phone toggle */}
-      <div className="flex gap-1 rounded-xl bg-secondary/50 p-1">
+      <div className="flex gap-1 rounded-2xl bg-secondary/60 p-1">
         {([
           { id: 'email' as const, label: 'Email', icon: Mail },
           { id: 'phone' as const, label: 'Phone', icon: Phone },
@@ -144,80 +147,122 @@ export default function PrivyLoginControls() {
               setMethod(m.id);
               setError(null);
             }}
-            className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg py-2 text-xs font-medium transition-colors ${
+            className={`flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-colors ${
               method === m.id ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
             }`}
           >
-            <m.icon className="h-3.5 w-3.5" /> {m.label}
+            <m.icon className="h-4 w-4" /> {m.label}
           </button>
         ))}
       </div>
 
       {/* Email or phone input */}
-      <div className="flex gap-2">
-        <div className="relative flex-1">
-          {method === 'email' ? (
-            <>
-              <Mail className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <input
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                onKeyDown={(e) => e.key === 'Enter' && send()}
-                placeholder="you@email.com"
-                className={`${inputCls} pl-9`}
-              />
-            </>
-          ) : (
-            <>
-              <Phone className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <input
-                type="tel"
-                value={phone}
-                onChange={(e) => setPhone(e.target.value)}
-                onKeyDown={(e) => e.key === 'Enter' && send()}
-                placeholder="+1 555 123 4567"
-                className={`${inputCls} pl-9`}
-              />
-            </>
-          )}
-        </div>
-        <button
-          type="button"
-          disabled={busy === 'send'}
-          onClick={send}
-          aria-label={`Continue with ${method}`}
-          className="flex w-12 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-transform active:scale-[0.97] disabled:opacity-40"
-        >
-          {busy === 'send' ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
-        </button>
+      <div className="relative">
+        {method === 'email' ? (
+          <>
+            <Mail className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+            <input
+              type="email"
+              inputMode="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && send()}
+              placeholder="you@email.com"
+              className={`${inputCls} pl-11`}
+            />
+          </>
+        ) : (
+          <>
+            <Phone className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+            <input
+              type="tel"
+              inputMode="tel"
+              autoComplete="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && send()}
+              placeholder="+1 555 123 4567"
+              className={`${inputCls} pl-11`}
+            />
+          </>
+        )}
       </div>
 
       {error && <p className="text-xs text-destructive">{error}</p>}
 
-      <div className="flex items-center gap-3 py-1 text-[11px] text-muted-foreground">
-        <span className="h-px flex-1 bg-border" /> or <span className="h-px flex-1 bg-border" />
-      </div>
-
-      {/* Google (prominent) */}
       <button
         type="button"
-        disabled={busy === 'google'}
-        onClick={() => oauth('google')}
-        className="flex w-full items-center justify-center gap-2 rounded-xl border border-border py-3 text-sm font-medium text-foreground transition-colors hover:bg-secondary disabled:opacity-50"
+        disabled={busy === 'send'}
+        onClick={send}
+        className="flex w-full items-center justify-center gap-2 rounded-2xl bg-primary py-4 text-base font-semibold text-primary-foreground transition-transform active:scale-[0.99] disabled:opacity-40"
       >
-        {busy === 'google' ? <Loader2 className="h-4 w-4 animate-spin" /> : <span className="font-display text-base">G</span>}
-        Continue with Google
+        {busy === 'send' ? <Loader2 className="h-5 w-5 animate-spin" /> : <>Continue <ArrowRight className="h-4 w-4" /></>}
       </button>
 
-      {/* Other socials */}
-      <div className="flex gap-2">
-        {SOCIALS.map((s) => (
-          <button key={s.id} type="button" disabled={busy === s.id} onClick={() => oauth(s.id)} className={socialBtn}>
-            {busy === s.id ? <Loader2 className="mx-auto h-3.5 w-3.5 animate-spin" /> : s.label}
-          </button>
-        ))}
-      </div>
+      <button
+        type="button"
+        onClick={() => setShowMore(true)}
+        className="w-full pt-1 text-center text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+      >
+        More ways to sign in
+      </button>
+
+      {/* Socials — slide-up sheet */}
+      <AnimatePresence>
+        {showMore && (
+          <>
+            <motion.div
+              className="fixed inset-0 z-[100] bg-black/40 backdrop-blur-sm"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setShowMore(false)}
+            />
+            <motion.div
+              className="fixed inset-x-0 bottom-0 z-[110] mx-auto max-w-[440px] rounded-t-3xl border-t border-border bg-card px-5 pb-[max(1.5rem,env(safe-area-inset-bottom))] pt-3"
+              initial={{ y: '100%' }}
+              animate={{ y: 0 }}
+              exit={{ y: '100%' }}
+              transition={{ type: 'spring', damping: 32, stiffness: 320 }}
+            >
+              <div className="mx-auto mb-4 h-1 w-10 rounded-full bg-border" />
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="text-base font-semibold text-foreground">More ways to sign in</h3>
+                <button type="button" onClick={() => setShowMore(false)} aria-label="Close" className="rounded-lg p-1 text-muted-foreground hover:bg-secondary hover:text-foreground">
+                  <X className="h-5 w-5" />
+                </button>
+              </div>
+
+              <button
+                type="button"
+                disabled={busy === 'google'}
+                onClick={() => oauth('google')}
+                className="mb-2 flex w-full items-center justify-center gap-2 rounded-2xl border border-border bg-background py-3.5 text-sm font-medium text-foreground transition-colors hover:bg-secondary disabled:opacity-50"
+              >
+                {busy === 'google' ? <Loader2 className="h-4 w-4 animate-spin" /> : <span className="font-display text-base">G</span>}
+                Continue with Google
+              </button>
+
+              <div className="grid grid-cols-2 gap-2">
+                {SOCIALS.map((s) => (
+                  <button
+                    key={s.id}
+                    type="button"
+                    disabled={busy === s.id}
+                    onClick={() => oauth(s.id)}
+                    className="rounded-2xl border border-border py-3 text-sm font-medium text-foreground transition-colors hover:bg-secondary disabled:opacity-50"
+                  >
+                    {busy === s.id ? <Loader2 className="mx-auto h-4 w-4 animate-spin" /> : s.label}
+                  </button>
+                ))}
+              </div>
+
+              {error && <p className="mt-3 text-center text-xs text-destructive">{error}</p>}
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/app/src/pages/auth/UserOnboarding.tsx
+++ b/app/src/pages/auth/UserOnboarding.tsx
@@ -17,7 +17,7 @@ import OnboardingView, { type OnboardingResult } from './OnboardingView';
  * flow doesn't collect use the previous valid defaults.
  */
 export default function UserOnboarding() {
-  const { isConnected, isAuthenticated, openModal, checkAuthentication, authenticate } = useAppKitAuth();
+  const { isAuthenticated } = useAppKitAuth();
   const navigate = useNavigate();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -26,14 +26,12 @@ export default function UserOnboarding() {
     setSubmitting(true);
     setError(null);
     try {
-      // Ensure the wallet/account is connected and the SIWX message is signed.
-      if (!isConnected || !isAuthenticated) {
-        await openModal('Connect');
-      }
-      let authed = await checkAuthentication();
-      if (!authed) authed = await authenticate();
-      if (!authed) {
-        throw new Error('Connect your account and approve the sign-in message to finish onboarding.');
+      // The user reaches onboarding already signed in (routed here by the onboarding gate) — no wallet
+      // re-connect / re-sign needed. If they somehow got here unauthenticated (e.g. the pre-auth
+      // "See how it works" preview), send them to sign in first.
+      if (!isAuthenticated) {
+        navigate('/login');
+        return;
       }
 
       const bootstrapped = await bootstrapMemberAccount();


### PR DESCRIPTION
Redesign the login and iron out the sign-in → onboarding → app flow.

**Login (already on dev):** full-screen, mobile-first (brand top, value prop middle, auth in the thumb zone). Email + phone up front (the guaranteed methods); Google + socials behind a "More ways to sign in" slide-up sheet (not all configured in Privy yet). Theme-aware (light/dusk/dark).

**Flow:**
- **Onboarding gate** — the profile provider now exposes the member `status`, and AppShell redirects to `/onboarding` **only** when it's positively `ONBOARDING`. Loading/unknown/error → render the app, so existing members are never trapped; onboarding is outside AppShell, so no loop. Safe because submit + terms flips status to `BASIC_ACTIVE` (`computeDerivedStatus`), so a completed user lands in the app.
- **Removed the legacy re-connect/re-sign** in the onboarding wrapper — the user is already signed in via Privy when routed here (the "Connect wallet" + re-auth was AppKit leftover). Unauthenticated preview → sent to sign in.

Verified via typecheck + build (auth screens can't render in the sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)