### PR TITLE
fix(activity): live refresh of linked balances + transactions after a money action

### DIFF
--- a/app/src/hooks/useClearBalances.ts
+++ b/app/src/hooks/useClearBalances.ts
@@ -139,6 +139,9 @@ export function ClearBalancesProvider({ children }: { children: ReactNode }) {
         };
       });
       void refreshTokens(true);
+      // Every money action goes through here, so it's the one place to nudge the other live views
+      // (linked-wallet balances + the transactions feed) to refetch after a transfer/send/deposit.
+      if (typeof window !== 'undefined') window.dispatchEvent(new Event('clear:activity'));
     },
     [fetched, refreshTokens],
   );

--- a/app/src/hooks/useClearTransactions.ts
+++ b/app/src/hooks/useClearTransactions.ts
@@ -169,10 +169,18 @@ export function ClearTransactionsProvider({ children }: { children: ReactNode })
     if (!isConnected || !address) return;
     const id = setInterval(() => void load(), 120_000);
     const onFocus = () => void load();
+    // Right after a money action (transfer/send/deposit) — refetch now and again shortly, since the
+    // on-chain event can lag the indexer by a few seconds.
+    const onActivity = () => {
+      void load();
+      setTimeout(() => void load(), 4000);
+    };
     window.addEventListener('focus', onFocus);
+    window.addEventListener('clear:activity', onActivity);
     return () => {
       clearInterval(id);
       window.removeEventListener('focus', onFocus);
+      window.removeEventListener('clear:activity', onActivity);
     };
   }, [load, isConnected, address]);
 

--- a/app/src/hooks/useLinkedWalletBalances.ts
+++ b/app/src/hooks/useLinkedWalletBalances.ts
@@ -17,7 +17,20 @@ export interface LinkedBalance {
 export function useLinkedWalletBalances(addresses: string[], enabled: boolean) {
   const [balances, setBalances] = useState<Record<string, LinkedBalance>>({});
   const [loading, setLoading] = useState(false);
+  const [nonce, setNonce] = useState(0);
   const key = enabled ? addresses.map((a) => a.toLowerCase()).sort().join(',') : '';
+
+  // Refetch after a money action — a transfer FROM a linked wallet drops its balance, which otherwise
+  // stayed stale (only refetched when the address list changed). Refetch now + again after the indexer
+  // catches up.
+  useEffect(() => {
+    const onActivity = () => {
+      setNonce((n) => n + 1);
+      setTimeout(() => setNonce((n) => n + 1), 4000);
+    };
+    window.addEventListener('clear:activity', onActivity);
+    return () => window.removeEventListener('clear:activity', onActivity);
+  }, []);
 
   useEffect(() => {
     if (!enabled || addresses.length === 0) {
@@ -63,7 +76,7 @@ export function useLinkedWalletBalances(addresses: string[], enabled: boolean) {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key, enabled]);
+  }, [key, enabled, nonce]);
 
   return { balances, loading };
 }


### PR DESCRIPTION
Two stale-data bugs after a transfer:
- **Linked-wallet balance** only refetched when the linked address list changed, so a transfer *from* a linked wallet (e.g. MetaMask → Clear) left its balance stale (56 USDC shown instead of 6).
- **Transactions** only polled every 120s, so they didn't update in real time after a transfer/send.

`applyOptimistic` is the common path for every money action, so it now broadcasts a `clear:activity` event. `useLinkedWalletBalances` and `useClearTransactions` listen and refetch immediately + again after 4s (to clear on-chain indexer lag). The smart-wallet balance was already optimistic + polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)