### PR TITLE
feat(charts): separate internal transfers from income/spending

### DIFF
--- a/app/src/components/app-ui/charts/CategoryRadial.tsx
+++ b/app/src/components/app-ui/charts/CategoryRadial.tsx
@@ -46,7 +46,7 @@ export default function CategoryRadial({ className }: { className?: string }) {
     const cutoff = Date.now() - WINDOW_DAYS[range] * 86_400_000;
     const byCat = new Map<Category, number>();
     for (const it of items) {
-      if (it.amount < 0 && it.ts > 0 && it.ts >= cutoff) {
+      if (it.amount < 0 && !it.internal && it.ts > 0 && it.ts >= cutoff) {
         byCat.set(it.category, (byCat.get(it.category) ?? 0) + Math.abs(it.amount));
       }
     }

--- a/app/src/components/app-ui/charts/SpendingChart.tsx
+++ b/app/src/components/app-ui/charts/SpendingChart.tsx
@@ -1,15 +1,17 @@
-import { Bar, CartesianGrid, Cell, ComposedChart, Line, ReferenceLine, XAxis, YAxis } from 'recharts';
+import { Area, Bar, CartesianGrid, Cell, ComposedChart, Line, ReferenceLine, XAxis, YAxis } from 'recharts';
 import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from '@/components/ui/chart';
 
 const config = {
   spending: { label: 'This period', color: 'rgb(var(--positive))' },
   previous: { label: 'Last period', color: 'var(--chart-4)' },
+  transfers: { label: 'Transfers', color: 'rgb(var(--info))' },
 } satisfies ChartConfig;
 
 interface Bucket {
   label: string;
   spending: number;
   previous: number;
+  transfers: number;
 }
 
 const tick = (v: number) => (v >= 1000 ? `$${v / 1000}k` : `$${v}`);
@@ -34,6 +36,18 @@ export default function SpendingChart({
         <XAxis dataKey="label" tickLine={false} axisLine={false} tickMargin={8} fontSize={11} />
         <YAxis tickLine={false} axisLine={false} width={48} fontSize={11} tickMargin={6} tickFormatter={tick} />
         <ChartTooltip content={<ChartTooltipContent />} />
+        {/* Internal transfers — faded area behind the bars (not spending, shown for context). */}
+        <Area
+          dataKey="transfers"
+          type="monotone"
+          stroke="rgb(var(--info))"
+          strokeOpacity={0.35}
+          strokeWidth={1}
+          fill="rgb(var(--info))"
+          fillOpacity={0.1}
+          dot={false}
+          activeDot={false}
+        />
         <ReferenceLine
           y={budget}
           stroke="rgb(var(--info))"

--- a/app/src/hooks/useClearTransactions.ts
+++ b/app/src/hooks/useClearTransactions.ts
@@ -23,6 +23,9 @@ export interface ActivityItem {
   amount: number; // signed: + in, - out
   status: ActivityStatus;
   source: string; // lowercased wallet address (primary or a linked wallet), or 'bank'
+  /** True when this is a move between the user's OWN accounts (Clear ↔ linked wallet / bank) — not
+   *  real income or spending, so it's excluded from those charts and shown as a transfer instead. */
+  internal: boolean;
 }
 
 export interface CashFlow {
@@ -32,7 +35,8 @@ export interface CashFlow {
 
 interface TxValue {
   items: ActivityItem[];
-  flows: CashFlow[];
+  flows: CashFlow[]; // real income/spending (internal transfers excluded)
+  transfers: CashFlow[]; // internal moves between the user's own accounts (for the transfer overlay)
   loading: boolean;
   refresh: () => void;
 }
@@ -40,7 +44,7 @@ interface TxValue {
 const Ctx = createContext<TxValue | null>(null);
 
 export function useClearTransactions(): TxValue {
-  return useContext(Ctx) ?? { items: [], flows: [], loading: false, refresh: () => {} };
+  return useContext(Ctx) ?? { items: [], flows: [], transfers: [], loading: false, refresh: () => {} };
 }
 
 interface RawTx {
@@ -52,6 +56,8 @@ interface RawTx {
   date?: string;
   timestamp?: number;
   status?: string;
+  from?: string;
+  to?: string;
 }
 
 const cleanSymbol = (s?: string) => (s || '').replace(/[^\x20-\x7E]/g, '').trim();
@@ -69,7 +75,7 @@ function formatDate(iso?: string): string {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
-function toActivity(tx: RawTx, source: string): ActivityItem {
+function toActivity(tx: RawTx, source: string, own: Set<string>): ActivityItem {
   const inbound = /deposit|receiv|incoming|claim/i.test(tx.type || '');
   const usd = typeof tx.amountUsd === 'number' && tx.amountUsd > 0 ? tx.amountUsd : Number(tx.amount) || 0;
   const amount = inbound ? Math.abs(usd) : -Math.abs(usd);
@@ -79,15 +85,20 @@ function toActivity(tx: RawTx, source: string): ActivityItem {
       ? 'failed'
       : 'completed';
   const sym = cleanSymbol(tx.assetSymbol) || 'tokens';
+  // The counterparty is the other side of the transfer. If it's one of the user's own wallets, this is
+  // an internal move (Clear ↔ linked wallet) — a transfer, not income/spending.
+  const counterparty = (inbound ? tx.from : tx.to)?.toLowerCase() || '';
+  const internal = counterparty !== '' && own.has(counterparty);
   return {
     id: `${source}:${tx.id}`,
-    name: `${inbound ? 'Received' : 'Sent'} ${sym}`,
-    category: inbound ? 'Deposit' : 'Transfer',
+    name: internal ? `Transfer ${sym}` : `${inbound ? 'Received' : 'Sent'} ${sym}`,
+    category: inbound && !internal ? 'Deposit' : 'Transfer',
     date: formatDate(tx.date),
     ts: Date.parse(tx.date || '') || 0,
     amount,
     status,
     source,
+    internal,
   };
 }
 
@@ -95,8 +106,12 @@ function plaidToActivity(t: PlaidRecentTransaction): ActivityItem {
   const inbound = t.direction === 'inflow';
   const amt = Math.abs(t.amount || 0);
   const cat = (t.category_primary || '').toLowerCase();
+  // Plaid TRANSFER_IN/TRANSFER_OUT = money moving between accounts (incl. Clear ↔ this bank) — treat as
+  // an internal transfer, not income/spending.
+  const internal = /transfer/.test(cat);
   let category: Category = inbound ? 'Deposit' : 'Card';
-  if (!inbound) {
+  if (internal) category = 'Transfer';
+  else if (!inbound) {
     if (/rent|util|bill|loan|mortgage|insurance/.test(cat)) category = 'Bill';
     else if (/subscription|recurring/.test(cat)) category = 'Subscription';
     else if (/income|payroll|deposit/.test(cat)) category = 'Payroll';
@@ -110,6 +125,7 @@ function plaidToActivity(t: PlaidRecentTransaction): ActivityItem {
     amount: inbound ? amt : -amt,
     status: t.pending ? 'pending' : 'completed',
     source: 'bank',
+    internal,
   };
 }
 
@@ -120,12 +136,14 @@ export function ClearTransactionsProvider({ children }: { children: ReactNode })
   const linkedKey = externalWallets.map((w) => w.address.toLowerCase()).sort().join(',');
   const [items, setItems] = useState<ActivityItem[]>([]);
   const [flows, setFlows] = useState<CashFlow[]>([]);
+  const [transfers, setTransfers] = useState<CashFlow[]>([]);
   const [loading, setLoading] = useState(false);
 
   const load = useCallback(async () => {
     if (!isConnected || !address) {
       setItems([]);
       setFlows([]);
+      setTransfers([]);
       return;
     }
     setLoading(true);
@@ -135,26 +153,28 @@ export function ClearTransactionsProvider({ children }: { children: ReactNode })
       // and tagged by source so the Transactions filter can narrow to a specific wallet or bank.
       const primaryLower = address.toLowerCase();
       const linked = linkedKey ? linkedKey.split(',').filter((a) => a && a !== primaryLower) : [];
+      // The user's own wallets — a transfer whose counterparty is one of these is an internal move.
+      const own = new Set([primaryLower, ...linked]);
       const requests = [address, ...linked].map((a) => ({ chainId: ACTIVE_CHAIN_ID, address: a, limit: 15 }));
       const [chainResults, plaid] = await Promise.all([
         getTransactionsBatch(requests).catch(() => []),
         getPlaidRecentTransactions(address).catch(() => null),
       ]);
       const onchain = (chainResults || []).flatMap((r) =>
-        ((r.transactions as RawTx[]) || []).map((tx) => toActivity(tx, (r.address || '').toLowerCase())),
+        ((r.transactions as RawTx[]) || []).map((tx) => toActivity(tx, (r.address || '').toLowerCase(), own)),
       );
       const bank = (plaid?.transactions || []).map(plaidToActivity);
       const merged = [...onchain, ...bank].sort((a, b) => b.ts - a.ts);
       setItems(merged.slice(0, 80));
       // Charts reflect the user's CLEAR cashflow (primary wallet + bank), not linked external wallets.
-      setFlows(
-        merged
-          .filter((x) => x.ts > 0 && (x.source === primaryLower || x.source === 'bank'))
-          .map((x) => ({ ts: x.ts, usd: x.amount })),
-      );
+      // Internal transfers are excluded from income/spending; they feed the separate transfer overlay.
+      const clearSide = merged.filter((x) => x.ts > 0 && (x.source === primaryLower || x.source === 'bank'));
+      setFlows(clearSide.filter((x) => !x.internal).map((x) => ({ ts: x.ts, usd: x.amount })));
+      setTransfers(clearSide.filter((x) => x.internal).map((x) => ({ ts: x.ts, usd: x.amount })));
     } catch {
       setItems([]);
       setFlows([]);
+      setTransfers([]);
     } finally {
       setLoading(false);
     }
@@ -184,5 +204,5 @@ export function ClearTransactionsProvider({ children }: { children: ReactNode })
     };
   }, [load, isConnected, address]);
 
-  return createElement(Ctx.Provider, { value: { items, flows, loading, refresh: () => void load() } }, children);
+  return createElement(Ctx.Provider, { value: { items, flows, transfers, loading, refresh: () => void load() } }, children);
 }

--- a/app/src/pages/app/AccountsPage.tsx
+++ b/app/src/pages/app/AccountsPage.tsx
@@ -65,7 +65,7 @@ export default function AccountsPage() {
     const cutoff = Date.now() - 7 * 86_400_000;
     let net = 0;
     for (const it of items) {
-      if (it.ts < cutoff) continue;
+      if (it.ts < cutoff || it.internal) continue; // internal transfers aren't income/spending
       const isBank = it.source === 'bank';
       const include = field === 'totalUsd' ? true : field === 'bankUsd' ? isBank : !isBank;
       if (include) net += it.amount;
@@ -101,7 +101,7 @@ export default function AccountsPage() {
     const totals: Record<number, number> = {};
     const byCat: Record<number, Record<string, number>> = {};
     for (const it of items) {
-      if (it.amount >= 0) continue;
+      if (it.amount >= 0 || it.internal) continue; // exclude internal transfers from spend
       const d = new Date(it.ts);
       if (d.getMonth() !== now.getMonth() || d.getFullYear() !== now.getFullYear()) continue;
       const day = d.getDate();

--- a/app/src/pages/app/TransactionsPage.tsx
+++ b/app/src/pages/app/TransactionsPage.tsx
@@ -18,14 +18,18 @@ type Range = (typeof RANGES)[number];
 
 const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
-/** Real spending trend (current vs prior equal-length period) from transaction flows. */
-function buildSpend(range: Range, flows: CashFlow[]) {
+/** Real spending trend (current vs prior equal-length period) from transaction flows, plus internal
+ *  transfer volume per bucket (for the faded overlay — transfers aren't spending). */
+function buildSpend(range: Range, flows: CashFlow[], transfers: CashFlow[]) {
   const buckets = flowBuckets(range as FlowRange);
   const span = buckets.length ? buckets[buckets.length - 1].end - buckets[0].start : 0;
+  const volIn = (series: CashFlow[], b: { start: number; end: number }) =>
+    series.reduce((s, t) => (t.ts >= b.start && t.ts < b.end ? s + Math.abs(t.usd) : s), 0);
   const data = buckets.map((b) => ({
     label: b.label,
     spending: Math.round(spendingIn(flows, b)),
     previous: Math.round(spendingIn(flows, { start: b.start - span, end: b.end - span, label: '' })),
+    transfers: Math.round(volIn(transfers, b)),
   }));
   const total = data.reduce((s, b) => s + b.spending, 0);
   const prev = data.reduce((s, b) => s + b.previous, 0);
@@ -44,10 +48,10 @@ function buildSpend(range: Range, flows: CashFlow[]) {
 /** Transactions — visual-first dashboard: stat row, spending chart, category donut, activity, heatmap. */
 export default function TransactionsPage() {
   const [range, setRange] = useState<Range>('1M');
-  const { flows, items } = useClearTransactions();
+  const { flows, transfers, items } = useClearTransactions();
   const upcoming = useUpcoming();
 
-  const s = useMemo(() => buildSpend(range, flows), [range, flows]);
+  const s = useMemo(() => buildSpend(range, flows, transfers), [range, flows, transfers]);
 
   const stats = useMemo(() => {
     const now = new Date();


### PR DESCRIPTION
Transfers between a user's own accounts were being counted as **income**, skewing the charts.

The transaction data already carries the counterparty (`from`/`to`) — it just wasn't used. Now a tx is tagged **`internal`** when its counterparty is one of the user's own wallets (Clear smart wallet + linked wallets), or when Plaid categorizes a bank tx as a transfer. Internal moves are:
- **Excluded** from Income / Spent / Net-flow, the category donut, and the spend heatmap.
- **Surfaced separately** as a `transfers` series, drawn as a **faded area behind the spend bars** for context.

Real P2P sends (counterparty isn't yours) still count as spending. No backend change needed — the counterparty was already in the response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)