### PR TITLE
feat(charts): granular spend categories in the donut

### DIFF
--- a/app/src/components/app-ui/charts/CategoryRadial.tsx
+++ b/app/src/components/app-ui/charts/CategoryRadial.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from 'react';
 import { Cell, Label, Pie, PieChart } from 'recharts';
 import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from '@/components/ui/chart';
 import { useClearTransactions } from '@/hooks/useClearTransactions';
-import type { Category } from '@/components/app-ui/TransactionFilterModal';
 import { cn } from '@/lib/utils';
 
 type Range = 'week' | 'month' | 'year';
@@ -14,14 +13,18 @@ const RANGES: { value: Range; label: string }[] = [
 const WINDOW_DAYS: Record<Range, number> = { week: 7, month: 30, year: 365 };
 const SUB: Record<Range, string> = { week: 'this week', month: 'this month', year: 'this year' };
 
-// Per-category slice colors (spending categories are the outflow ones).
-const CATEGORY_COLORS: Record<Category, string> = {
-  Card: 'rgb(var(--info))',
-  Bill: '#8b5cf6',
-  Subscription: '#06b6d4',
-  Transfer: '#f59e0b',
-  Deposit: '#10b981',
-  Payroll: '#22c55e',
+// Per-spend-category slice colors. Unknown buckets fall back to a neutral grey.
+const CATEGORY_COLORS: Record<string, string> = {
+  Rent: '#8b5cf6',
+  Utilities: '#06b6d4',
+  'Food & Drink': '#f59e0b',
+  Retail: 'rgb(var(--info))',
+  Subscriptions: '#ec4899',
+  Transport: '#14b8a6',
+  Bills: '#a855f7',
+  Health: '#ef4444',
+  Services: '#0ea5e9',
+  Misc: '#94a3b8',
 };
 
 const config = {} satisfies ChartConfig;
@@ -44,10 +47,11 @@ export default function CategoryRadial({ className }: { className?: string }) {
 
   const data = useMemo(() => {
     const cutoff = Date.now() - WINDOW_DAYS[range] * 86_400_000;
-    const byCat = new Map<Category, number>();
+    const byCat = new Map<string, number>();
     for (const it of items) {
       if (it.amount < 0 && !it.internal && it.ts > 0 && it.ts >= cutoff) {
-        byCat.set(it.category, (byCat.get(it.category) ?? 0) + Math.abs(it.amount));
+        const cat = it.spendCategory || 'Misc';
+        byCat.set(cat, (byCat.get(cat) ?? 0) + Math.abs(it.amount));
       }
     }
     return [...byCat.entries()]

--- a/app/src/hooks/useClearTransactions.ts
+++ b/app/src/hooks/useClearTransactions.ts
@@ -26,6 +26,9 @@ export interface ActivityItem {
   /** True when this is a move between the user's OWN accounts (Clear ↔ linked wallet / bank) — not
    *  real income or spending, so it's excluded from those charts and shown as a transfer instead. */
   internal: boolean;
+  /** Granular spend bucket for the category donut (Rent, Utilities, Food & Drink, Retail, …). Derived
+   *  from Plaid's personal-finance category for bank txs; on-chain sends are 'Misc'. */
+  spendCategory: string;
 }
 
 export interface CashFlow {
@@ -75,6 +78,21 @@ function formatDate(iso?: string): string {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
+/** Map Plaid's personal-finance category (primary + detailed) to a friendly spend bucket for the donut. */
+function plaidSpendCategory(primary: string, detailed: string): string {
+  const p = primary.toUpperCase();
+  const d = detailed.toUpperCase();
+  if (d.includes('SUBSCRIPTION') || p.includes('ENTERTAINMENT')) return 'Subscriptions';
+  if (p.includes('FOOD')) return 'Food & Drink';
+  if (p.includes('GENERAL_MERCHANDISE')) return 'Retail';
+  if (p.includes('RENT_AND_UTILITIES')) return d.includes('RENT') ? 'Rent' : 'Utilities';
+  if (p.includes('TRANSPORTATION') || p.includes('TRAVEL')) return 'Transport';
+  if (p.includes('LOAN') || p.includes('BANK_FEES') || p.includes('GOVERNMENT')) return 'Bills';
+  if (p.includes('MEDICAL') || p.includes('PERSONAL_CARE')) return 'Health';
+  if (p.includes('GENERAL_SERVICES') || p.includes('HOME_IMPROVEMENT')) return 'Services';
+  return 'Misc';
+}
+
 function toActivity(tx: RawTx, source: string, own: Set<string>): ActivityItem {
   const inbound = /deposit|receiv|incoming|claim/i.test(tx.type || '');
   const usd = typeof tx.amountUsd === 'number' && tx.amountUsd > 0 ? tx.amountUsd : Number(tx.amount) || 0;
@@ -99,6 +117,7 @@ function toActivity(tx: RawTx, source: string, own: Set<string>): ActivityItem {
     status,
     source,
     internal,
+    spendCategory: internal ? 'Transfer' : inbound ? 'Income' : 'Misc',
   };
 }
 
@@ -126,6 +145,7 @@ function plaidToActivity(t: PlaidRecentTransaction): ActivityItem {
     status: t.pending ? 'pending' : 'completed',
     source: 'bank',
     internal,
+    spendCategory: internal ? 'Transfer' : inbound ? 'Income' : plaidSpendCategory(t.category_primary || '', t.category_detailed || ''),
   };
 }
 

--- a/app/src/pages/app/AccountsPage.tsx
+++ b/app/src/pages/app/AccountsPage.tsx
@@ -107,7 +107,8 @@ export default function AccountsPage() {
       const day = d.getDate();
       const amt = Math.abs(it.amount);
       totals[day] = (totals[day] || 0) + amt;
-      (byCat[day] ||= {})[it.category] = (byCat[day][it.category] || 0) + amt;
+      const cat = it.spendCategory || 'Misc';
+      (byCat[day] ||= {})[cat] = (byCat[day][cat] || 0) + amt;
     }
     const detail: Record<number, { category: string; amount: number }[]> = {};
     for (const [day, cats] of Object.entries(byCat)) {


### PR DESCRIPTION
The category donut was coarse (Bill/Card/Transfer) and the now-excluded Transfer slice showed 0%. Replaced it with real spend buckets derived from Plaid's personal-finance category (primary + detailed): **Rent, Utilities, Food & Drink, Retail, Subscriptions, Transport, Bills, Health, Services, Misc**. On-chain sends (no merchant data) fall into Misc.

The donut and the spend-heatmap tooltip now group by this `spendCategory` (spending only; internal transfers excluded), each with its own colour. The shared `Category` enum (used by filters/display) is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)