### PR TITLE
Fix Spent-this-month $0 stat + split Entertainment from Subscriptions

### DIFF
--- a/app/src/components/app-ui/charts/CategoryRadial.tsx
+++ b/app/src/components/app-ui/charts/CategoryRadial.tsx
@@ -20,6 +20,7 @@ const CATEGORY_COLORS: Record<string, string> = {
   'Food & Drink': '#f59e0b',
   Retail: 'rgb(var(--info))',
   Subscriptions: '#ec4899',
+  Entertainment: '#d946ef',
   Transport: '#14b8a6',
   Bills: '#a855f7',
   Health: '#ef4444',

--- a/app/src/hooks/useClearTransactions.ts
+++ b/app/src/hooks/useClearTransactions.ts
@@ -82,7 +82,11 @@ function formatDate(iso?: string): string {
 function plaidSpendCategory(primary: string, detailed: string): string {
   const p = primary.toUpperCase();
   const d = detailed.toUpperCase();
-  if (d.includes('SUBSCRIPTION') || p.includes('ENTERTAINMENT')) return 'Subscriptions';
+  // Plaid has no dedicated "subscription" category — recurring detection is a separate signal — so only
+  // an explicit *_SUBSCRIPTION detailed tag counts as Subscriptions. Everything else Plaid files under
+  // ENTERTAINMENT (streaming, games, events, music) is its own bucket.
+  if (d.includes('SUBSCRIPTION')) return 'Subscriptions';
+  if (p.includes('ENTERTAINMENT')) return 'Entertainment';
   if (p.includes('FOOD')) return 'Food & Drink';
   if (p.includes('GENERAL_MERCHANDISE')) return 'Retail';
   if (p.includes('RENT_AND_UTILITIES')) return d.includes('RENT') ? 'Rent' : 'Utilities';

--- a/app/src/pages/app/TransactionsPage.tsx
+++ b/app/src/pages/app/TransactionsPage.tsx
@@ -54,19 +54,22 @@ export default function TransactionsPage() {
   const s = useMemo(() => buildSpend(range, flows, transfers), [range, flows, transfers]);
 
   const stats = useMemo(() => {
+    // Spent / Income / Net over a TRAILING 30-day window — this matches the "1M" spend chart and the
+    // spending donut, which both label the same window "this month". (A strict calendar month reads ~$0
+    // early in the month, which looked like a bug even though the spend was sitting in the prior weeks.)
+    const cutoff = Date.now() - 30 * 86_400_000;
+    const win = flows.filter((f) => f.ts >= cutoff);
+    const spent = Math.abs(win.filter((f) => f.usd < 0).reduce((a, f) => a + f.usd, 0));
+    const income = win.filter((f) => f.usd > 0).reduce((a, f) => a + f.usd, 0);
+    // The heatmap below is a calendar grid keyed by day-of-month, so its buckets stay scoped to the
+    // current calendar month (otherwise June 15 + July 15 would collide on cell "15").
     const now = new Date();
-    const inMonth = (ts: number) => {
-      const d = new Date(ts);
-      return d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear();
-    };
-    const month = flows.filter((f) => inMonth(f.ts));
-    const spent = Math.abs(month.filter((f) => f.usd < 0).reduce((a, f) => a + f.usd, 0));
-    const income = month.filter((f) => f.usd > 0).reduce((a, f) => a + f.usd, 0);
     const byDay: Record<number, number> = {};
-    for (const f of month) {
+    for (const f of flows) {
       if (f.usd >= 0) continue;
-      const day = new Date(f.ts).getDate();
-      byDay[day] = (byDay[day] || 0) + Math.abs(f.usd);
+      const d = new Date(f.ts);
+      if (d.getMonth() !== now.getMonth() || d.getFullYear() !== now.getFullYear()) continue;
+      byDay[d.getDate()] = (byDay[d.getDate()] || 0) + Math.abs(f.usd);
     }
     return { spent, income, net: income - spent, byDay };
   }, [flows]);


### PR DESCRIPTION
## What
- **Fix "Spent this month" reading $0** — the Transactions stat cards computed over the strict *calendar* month, which reads ~$0 early in the month (e.g. Jul 1–2) even when real spend sits in the prior weeks. Now they use a **trailing 30-day window**, matching the "1M" spend chart and the spending donut (both already label that window "this month"). The spend heatmap stays on the calendar month since it's a day-of-month grid.
- **Split Entertainment from Subscriptions** in the donut — Plaid has no dedicated subscription category (recurring detection is a separate signal), so only an explicit `*_SUBSCRIPTION` detailed tag → **Subscriptions**; everything Plaid files under `ENTERTAINMENT` (streaming, games, events, music) is now its own **Entertainment** bucket with a distinct color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)