### PR TITLE
Pay: non-rent bill credits scale with amount (1 credit / $2, cap 500)

### DIFF
--- a/app/server/src/services/payLedgerStore.ts
+++ b/app/server/src/services/payLedgerStore.ts
@@ -19,6 +19,8 @@ export type EarnSource = 'in_app' | 'detected';
 const GRACE_DAYS = 3; // paid within N days of due_date still counts as on-time
 const VEST_DAYS = 30; // pending → vested clawback/settlement window
 const IN_APP_BONUS = 1.1; // paying through the app earns a 10% bonus
+const BILL_CREDIT_RATE = 0.5; // non-rent bills earn 1 equity credit per $2 paid
+const BILL_CREDIT_CAP = 500; // max BASE credits from a single non-rent bill (before streak/in-app bonus)
 const DEPOSIT_MATCH_PER_USD = 1; // equity credits matched per $1 deposited into the ESA vault
 const DEPOSIT_MATCH_MONTHLY_CAP = 1500; // max deposit-match credits awarded per calendar month
 
@@ -41,11 +43,18 @@ function streakMultiplier(streak: number): number {
   return 1 + Math.min(Math.max(streak, 0), 12) * 0.05;
 }
 
-/** Equity credits for an on-time payment: base by type × streak × in-app bonus, rounded to 5. */
-function creditAmount(type: BillerType, streak: number, source: EarnSource): number {
-  const base = type === 'rent' ? 300 : 50;
+/**
+ * Equity credits for an on-time payment.
+ *  - Rent: a flat 300 base × streak × in-app bonus, rounded to 5.
+ *  - Non-rent bills: 1 credit per $2 paid, the BASE capped at 500, then × streak × in-app bonus
+ *    (so a small dollar payment no longer earns the old flat 50). Rounded to the nearest credit.
+ */
+function creditAmount(type: BillerType, streak: number, source: EarnSource, paidAmount: number): number {
   const bonus = source === 'in_app' ? IN_APP_BONUS : 1;
-  return Math.round((base * streakMultiplier(streak) * bonus) / 5) * 5;
+  const mult = streakMultiplier(streak) * bonus;
+  if (type === 'rent') return Math.round((300 * mult) / 5) * 5;
+  const base = Math.min(Math.max(paidAmount, 0) * BILL_CREDIT_RATE, BILL_CREDIT_CAP);
+  return Math.round(base * mult);
 }
 
 async function ensureTables(): Promise<void> {
@@ -371,7 +380,7 @@ export const payLedgerStore = {
     if (!onTime) return { creditAwarded: 0, onTime, duplicate: false };
 
     const streak = await computeStreak(input.wallet);
-    const amount = creditAmount(input.type, streak, input.source);
+    const amount = creditAmount(input.type, streak, input.source, input.amount);
     const vestUntil = new Date(paidAt);
     vestUntil.setDate(vestUntil.getDate() + VEST_DAYS);
     await pool.query(

--- a/app/src/components/app-ui/PayModal.tsx
+++ b/app/src/components/app-ui/PayModal.tsx
@@ -177,7 +177,7 @@ export default function PayModal({
   const bill = billId ? getBill(billId) : undefined;
   const source = sources.find((s) => s.id === sourceId) ?? sources[0];
   const isRent = bill?.type === 'rent';
-  const credits = bill ? creditsFor(bill, streak) : 0;
+  const credits = bill ? creditsFor(bill, streak, amount) : 0;
   const mult = streakMultiplier(streak);
 
   const saveBiller = () => {

--- a/app/src/context/PayContext.tsx
+++ b/app/src/context/PayContext.tsx
@@ -55,14 +55,23 @@ export const ON_TIME_STREAK = 0;
 /** Streak multiplier: +5% per on-time month, capped at 12 months (1.0×–1.6×). */
 export const streakMultiplier = (streak = ON_TIME_STREAK) => 1 + Math.min(Math.max(streak, 0), 12) * 0.05;
 
+/** Non-rent bills earn 1 equity credit per $2 paid, with the base capped here (before multipliers). */
+export const BILL_CREDIT_RATE = 0.5;
+export const BILL_CREDIT_CAP = 500;
+
 /**
- * Clear Pay equity credits for paying a bill ON TIME (preview of what the backend awards). Flat base
- * by type (rent rewards most) × the on-time streak multiplier, rounded to 5. NON-redeemable — credits
- * only count toward the Clear Deed milestone. Never interest/APY.
+ * Clear Pay equity credits for paying a bill ON TIME (preview of what the backend awards). Rent is a
+ * flat 300 base; non-rent bills earn 1 credit per $2 paid (base capped at 500) — so a small dollar
+ * payment no longer earns the old flat 50. Then × the on-time streak multiplier. NON-redeemable —
+ * credits only count toward the Clear Deed milestone. Never interest/APY. Pass `amount` to price the
+ * exact payment; otherwise the biller's default amount is used.
  */
-export const creditsFor = (bill: Pick<Bill, 'type'>, streak = ON_TIME_STREAK) => {
-  const base = bill.type === 'rent' ? 300 : 50;
-  return Math.round((base * streakMultiplier(streak)) / 5) * 5;
+export const creditsFor = (bill: Pick<Bill, 'type' | 'amount'>, streak = ON_TIME_STREAK, amount = 0) => {
+  const mult = streakMultiplier(streak);
+  if (bill.type === 'rent') return Math.round((300 * mult) / 5) * 5;
+  const paid = amount > 0 ? amount : bill.amount || 0;
+  const base = Math.min(paid * BILL_CREDIT_RATE, BILL_CREDIT_CAP);
+  return Math.round(base * mult);
 };
 
 const ICONS: Record<BillType, LucideIcon> = { rent: Home, utility: Zap, subscription: Repeat, card: CreditCard, phone: Smartphone, other: Receipt };


### PR DESCRIPTION
## What
Non-rent bills earned a **flat 50 equity credits** regardless of size — a $1 phone top-up earned the same as a $2,000 bill. Now:

- **Non-rent bills earn 1 equity credit per $2 paid**, with the **base capped at 500** *before* the streak + in-app multipliers are applied (per the chosen "cap the base, then multiply" rule), rounded to the nearest credit.
- **Rent is unchanged** — flat 300 base × streak × in-app bonus.
- Frontend `creditsFor` now takes the payment amount so the Pay modal preview matches what the backend awards for the exact amount being paid.

### Examples (streak 0, in-app)
| Bill paid | Base (÷2, cap 500) | × in-app 1.1 | Awarded |
|-----------|--------------------|--------------|---------|
| $1       | 0.5                | 0.55         | ~1      |
| $100     | 50                 | 55           | 55      |
| $1,000   | 500                | 550          | 550     |
| $5,000   | 500 (capped)       | 550          | 550     |

Source of truth: `payLedgerStore.creditAmount`; preview mirror: `PayContext.creditsFor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)