### PR TITLE
Fix spend analytics dropping transactions past the 80-item cap

### DIFF
--- a/app/src/components/app-ui/RecentActivity.tsx
+++ b/app/src/components/app-ui/RecentActivity.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Search, SlidersHorizontal, ArrowLeftRight, ArrowDownLeft, Briefcase, Receipt, CreditCard, Repeat, type LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -46,6 +46,9 @@ export default function RecentActivity({ className, limit }: { className?: strin
   const [adv, setAdv] = useState<AdvFilters>(DEFAULT_ADV);
   const [modalOpen, setModalOpen] = useState(false);
   const activeAdv = advCount(adv);
+  // Full list can be hundreds of rows — render in pages of PAGE and grow on demand.
+  const PAGE = 30;
+  const [shown, setShown] = useState(PAGE);
 
   // Source filter options: All, Clear account (primary smart wallet), each linked wallet, external bank.
   const sources: SourceOption[] = [
@@ -76,7 +79,10 @@ export default function RecentActivity({ className, limit }: { className?: strin
     });
   }, [items, query, filter, adv]);
 
-  const visible = compact ? filtered.slice(0, limit) : filtered;
+  // Reset the page size whenever the filters/search narrow the list.
+  useEffect(() => setShown(PAGE), [query, filter, adv]);
+  const visible = compact ? filtered.slice(0, limit) : filtered.slice(0, shown);
+  const hasMore = !compact && filtered.length > visible.length;
 
   return (
     <div className={cn('flex flex-col rounded-xl border border-border bg-card p-5', className)}>
@@ -187,6 +193,16 @@ export default function RecentActivity({ className, limit }: { className?: strin
           })
         )}
       </div>
+
+      {hasMore && (
+        <button
+          type="button"
+          onClick={() => setShown((n) => n + PAGE)}
+          className="mt-3 w-full rounded-lg border border-border py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+        >
+          Show more ({filtered.length - visible.length})
+        </button>
+      )}
 
       <TransactionFilterModal open={modalOpen} onOpenChange={setModalOpen} value={adv} onApply={setAdv} sources={sources} />
     </div>

--- a/app/src/hooks/useClearTransactions.ts
+++ b/app/src/hooks/useClearTransactions.ts
@@ -189,7 +189,10 @@ export function ClearTransactionsProvider({ children }: { children: ReactNode })
       );
       const bank = (plaid?.transactions || []).map(plaidToActivity);
       const merged = [...onchain, ...bank].sort((a, b) => b.ts - a.ts);
-      setItems(merged.slice(0, 80));
+      // Keep the FULL list — the charts (donut, heatmap) and the "Transactions" count all derive from
+      // `items`, so truncating here silently drops in-window spend (the backend returns up to ~500 bank
+      // txs over 90 days). The activity LIST paginates its own rendering, so this stays cheap.
+      setItems(merged);
       // Charts reflect the user's CLEAR cashflow (primary wallet + bank), not linked external wallets.
       // Internal transfers are excluded from income/spending; they feed the separate transfer overlay.
       const clearSide = merged.filter((x) => x.ts > 0 && (x.source === primaryLower || x.source === 'bank'));


### PR DESCRIPTION
## The bug
"Spent this month" / the "Spent · 1M" chart read ~$2,126 while the donut only accounted for ~$1,118 — a ~$1,000 gap that wasn't on-chain sends.

Root cause: the transaction provider truncated `items` to the **newest 80** (`merged.slice(0, 80)`), but the **donut, spend heatmap, and "Transactions" count all derive from `items`**. The chart, meanwhile, reads `flows`/`transfers` which are computed from the **uncapped** merged list. The backend returns up to ~500 bank transactions over 90 days, so everything ranked 81+ silently vanished from the category/heatmap/count views but still counted in the chart. (It's also why the "Transactions" stat read exactly 80.)

## Fix
- Keep the **full list** in `items` so every in-window transaction reaches the analytics.
- **Paginate** RecentActivity's full list ("Show more", pages of 30) so lifting the cap doesn't render hundreds of rows at once. Compact mode (Accounts dashboard, limit=5) is unchanged.

After this the donut total lines up with the Spent figure, and "Bills 92%" should fall back to a realistic share once the previously-dropped categorized spend is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)