### PR TITLE
Fix XMTP reachability check querying the wrong network

### DIFF
--- a/app/src/context/XMTPContext.tsx
+++ b/app/src/context/XMTPContext.tsx
@@ -260,14 +260,14 @@ export const XMTPProvider: React.FC<XMTPProviderProps> = ({ children }) => {
     }
 
     try {
-      const target = await resolvePeerAddress(walletAddress);
+      const target = (await resolvePeerAddress(walletAddress)).toLowerCase();
       console.log('XMTP: Creating conversation with wallet:', walletAddress, '→ xmtp:', target);
 
       // Check if wallet can receive messages
       const canMessageResult = await Client.canMessage([{
         identifier: target,
         identifierKind: "Ethereum"
-      }]);
+      }], XMTP_ENV);
       const isReachable = canMessageResult.get(target);
       
       console.log('XMTP: Can message check result:', {
@@ -331,8 +331,8 @@ export const XMTPProvider: React.FC<XMTPProviderProps> = ({ children }) => {
             const result = await Client.canMessage([{
               identifier: member,
               identifierKind: "Ethereum"
-            }]);
-            return { member, canMessage: result.get(member) };
+            }], XMTP_ENV);
+            return { member, canMessage: result.get(member.toLowerCase()) };
           } catch (err) {
             console.warn('XMTP: Could not check message capability for:', member, err);
             return { member, canMessage: false };
@@ -788,12 +788,13 @@ export const XMTPProvider: React.FC<XMTPProviderProps> = ({ children }) => {
       return false;
     }
     try {
-      const target = await resolvePeerAddress(walletAddress);
+      // canMessage keys its result map by identifier.toLowerCase(), so normalize before the .get() lookup.
+      const target = (await resolvePeerAddress(walletAddress)).toLowerCase();
       console.log('XMTP: Checking if wallet is reachable:', walletAddress, '→ xmtp:', target);
       const response = await Client.canMessage([{
         identifier: target,
         identifierKind: "Ethereum"
-      }]);
+      }], XMTP_ENV);
       const isReachable = response.get(target);
       console.log('XMTP: Can message check result:', {
         walletAddress,
@@ -863,8 +864,8 @@ export const XMTPProvider: React.FC<XMTPProviderProps> = ({ children }) => {
               const result = await Client.canMessage([{
                 identifier: member,
                 identifierKind: "Ethereum"
-              }]);
-              return { member, canMessage: result.get(member) };
+              }], XMTP_ENV);
+              return { member, canMessage: result.get(member.toLowerCase()) };
             } catch (err) {
               return { member, canMessage: false };
             }


### PR DESCRIPTION
## The bug
Messaging showed "the user hasn't created a wallet" for real members (e.g. Kyngkai ↔ Miesha, both directions) even though working DMs exist.

Root cause: `Client.canMessage(identifiers, env?)` — the **static** overload — defaults to the **dev** network when `env` is omitted (confirmed in the SDK: it calls `getInboxIdForIdentifier(id, env)` with `env=undefined`). Our client is created with `env: 'production'`, but all four `Client.canMessage` calls omitted the env, so every reachability check queried **dev** and returned `false` for production identities.

## Fix
- Pass `XMTP_ENV` ('production') to all four `Client.canMessage` call sites (DM create, DM check, and both group-member checks).
- **Latent bug also fixed:** `canMessage` keys its result `Map` by `identifier.toLowerCase()`, but the `.get()` lookups used the raw (sometimes checksummed) address and missed the entry. Normalized the DM target and group-member lookups to lowercase.

Verified with `tsc` + `vite build`. (Behavior needs a real production XMTP session to confirm end-to-end.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)