### PR TITLE
XMTP: resolve conversation names from the global member directory

### DIFF
--- a/app/server/src/routes/contacts.ts
+++ b/app/server/src/routes/contacts.ts
@@ -123,6 +123,26 @@ router.get('/:wallet/lookup', async (req: Request, res: Response) => {
   }
 });
 
+// GET /api/contacts/:wallet/names?wallets=0x..,0x..  → { names: { <wallet>: <displayName> } }
+// Directory reverse-lookup so a conversation/peer known only by wallet can be shown by member name.
+router.get('/:wallet/names', async (req: Request, res: Response) => {
+  const w = wallet(req);
+  if (!requireWalletMatch(req, res, w, 'wallet')) return;
+  if (!ensureReady(res)) return;
+  if (rateLimited(w)) {
+    res.status(429).json({ error: 'Too many lookups' });
+    return;
+  }
+  const raw = typeof req.query.wallets === 'string' ? req.query.wallets : '';
+  const wallets = raw.split(',').map((s) => s.trim()).filter(Boolean).slice(0, 50);
+  try {
+    res.json({ names: await contactsStore.lookupNames(wallets) });
+  } catch (error) {
+    console.error('[contacts/names]', error);
+    res.json({ names: {} });
+  }
+});
+
 // GET/PUT /api/contacts/:wallet/optout  → directory discoverability toggle
 router.get('/:wallet/optout', async (req: Request, res: Response) => {
   const w = wallet(req);

--- a/app/server/src/services/contactsStore.ts
+++ b/app/server/src/services/contactsStore.ts
@@ -148,6 +148,39 @@ export const contactsStore = {
     return { wallet: String(row.wallet), matchedOn: row.by_email ? 'email' : 'phone' };
   },
 
+  /**
+   * Directory REVERSE-lookup: wallet addresses → each member's public display name (display_name, then
+   * username). Matches any of a member's verified wallets (member_wallets) or their primary wallet, and
+   * respects the directory opt-out. Returns a { lowercasedWallet: name } map for wallets that resolved.
+   */
+  async lookupNames(wallets: string[]): Promise<Record<string, string>> {
+    const pool = getPostgresPool();
+    if (!pool) return {};
+    await ensureTables();
+    const addrs = [...new Set(wallets.map((w) => String(w || '').toLowerCase()).filter((w) => /^0x[0-9a-f]{40}$/.test(w)))];
+    if (addrs.length === 0) return {};
+    const r = await pool.query(
+      `SELECT w.addr AS wallet, pub.display_name, pub.username
+         FROM (
+           SELECT member_id, lower(wallet_address) AS addr FROM member_wallets
+            WHERE lower(wallet_address) = ANY($1) AND status = 'ACTIVE'
+           UNION
+           SELECT id AS member_id, lower(primary_wallet) AS addr FROM members
+            WHERE lower(primary_wallet) = ANY($1)
+         ) w
+         JOIN members m ON m.id = w.member_id
+         LEFT JOIN member_profile_public pub ON pub.member_id = m.id
+        WHERE lower(m.primary_wallet) NOT IN (SELECT wallet FROM ${OPTOUT})`,
+      [addrs],
+    );
+    const out: Record<string, string> = {};
+    for (const row of r.rows) {
+      const name = (row.display_name && String(row.display_name).trim()) || (row.username && String(row.username).trim());
+      if (name && !out[String(row.wallet)]) out[String(row.wallet)] = name;
+    }
+    return out;
+  },
+
   async isOptedOut(wallet: string): Promise<boolean> {
     const pool = getPostgresPool();
     if (!pool) return false;

--- a/app/src/components/XMTPMessaging.tsx
+++ b/app/src/components/XMTPMessaging.tsx
@@ -129,7 +129,7 @@ const XMTPMessaging: React.FC<XMTPMessagingProps> = ({
   } = useXMTP();
   
   const { handleConnect, isConnecting, isEmbeddedWallet, address } = useXMTPConnection();
-  const { contacts, lookupWallet } = useContacts();
+  const { contacts, lookupWallet, lookupNames } = useContacts();
   const contactsWithWallet = contacts.filter((c) => c.wallet);
 
   const [selectedConversation, setSelectedConversation] = useState<string | null>(initialConversationId || null);
@@ -177,6 +177,8 @@ const XMTPMessaging: React.FC<XMTPMessagingProps> = ({
   // Resolved peer wallet per DM conversation id — lets us title a DM by the contact's name even when
   // it was loaded from the network (not created this session, so no cached name).
   const [peerAddresses, setPeerAddresses] = useState<Record<string, string>>({});
+  // Peer wallet → member display name, resolved from the global member directory (opt-out aware).
+  const [directoryNames, setDirectoryNames] = useState<Record<string, string>>({});
   // Message scroll containers (mobile + desktop layouts) — we scroll whichever is visible to the bottom.
   const msgScrollMobileRef = useRef<HTMLDivElement>(null);
   const msgScrollDesktopRef = useRef<HTMLDivElement>(null);
@@ -352,27 +354,43 @@ const XMTPMessaging: React.FC<XMTPMessagingProps> = ({
     }
   }, []);
 
-  // Resolve each DM's peer wallet (from its XMTP members) so we can title it by the contact's name,
-  // even for conversations loaded from the network. Best-effort + cached, so it runs once per DM.
+  // Resolve each DM's peer wallet (from its XMTP members), then title the thread by the peer's name —
+  // first from local contacts, otherwise from the GLOBAL member directory (like the email/phone
+  // autofill). Best-effort + cached, so each peer is only fetched once. Falls back to the address.
   useEffect(() => {
     if (!isConnected || !currentUserInboxId || conversations.length === 0) return;
     let cancelled = false;
     (async () => {
+      const resolved: string[] = [];
       for (const conv of conversations) {
         if (cancelled) break;
-        if (isGroupConversation(conv.id) || peerAddresses[conv.id]) continue;
-        try {
-          const members = await (conv as any).members?.();
-          if (!members || cancelled) continue;
-          const peer = members.find((m: any) => m.inboxId && m.inboxId !== currentUserInboxId);
-          const addr: string | undefined = peer?.accountIdentifiers?.[0]?.identifier;
-          if (addr) setPeerAddresses((prev) => (prev[conv.id] ? prev : { ...prev, [conv.id]: addr }));
-        } catch { /* ignore — falls back to the conversation id */ }
+        if (isGroupConversation(conv.id)) continue;
+        let addr: string | undefined = peerAddresses[conv.id];
+        if (!addr) {
+          try {
+            const members = await (conv as any).members?.();
+            if (!members || cancelled) continue;
+            const peer = members.find((m: any) => m.inboxId && m.inboxId !== currentUserInboxId);
+            addr = peer?.accountIdentifiers?.[0]?.identifier;
+            if (addr) setPeerAddresses((prev) => (prev[conv.id] ? prev : { ...prev, [conv.id]: addr as string }));
+          } catch { continue; }
+        }
+        if (addr) resolved.push(addr.toLowerCase());
       }
+      if (cancelled || resolved.length === 0) return;
+      // Fetch member names from the directory for peers we don't already have a name for.
+      const need = [...new Set(resolved)].filter(
+        (a) => !directoryNames[a] && !contacts.some((c) => c.wallet?.toLowerCase() === a),
+      );
+      if (need.length === 0) return;
+      try {
+        const names = await lookupNames(need);
+        if (!cancelled && Object.keys(names).length > 0) setDirectoryNames((prev) => ({ ...prev, ...names }));
+      } catch { /* ignore — falls back to the address */ }
     })();
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isConnected, conversations, currentUserInboxId]);
+  }, [isConnected, conversations, currentUserInboxId, contacts]);
 
   // Unified auto-sync system
   useEffect(() => {
@@ -585,7 +603,8 @@ const XMTPMessaging: React.FC<XMTPMessagingProps> = ({
     const contactName = peer
       ? contacts.find((c) => c.wallet?.toLowerCase() === peer.toLowerCase())?.name
       : undefined;
-    return conversationNames[id] || contactName || (peer ? formatAddress(peer) : formatAddress(id));
+    const directoryName = peer ? directoryNames[peer.toLowerCase()] : undefined;
+    return conversationNames[id] || contactName || directoryName || (peer ? formatAddress(peer) : formatAddress(id));
   };
 
   const openRenameGroup = (conversationId: string) => {

--- a/app/src/context/ContactsContext.tsx
+++ b/app/src/context/ContactsContext.tsx
@@ -7,6 +7,7 @@ import {
   updateContactApi,
   deleteContactApi,
   lookupDirectory,
+  lookupDirectoryNames,
   type ApiContact,
 } from '@/utils/apiClient';
 
@@ -27,6 +28,8 @@ interface ContactsValue {
   removeContact: (id: string) => void;
   /** Directory autofill: resolve a member's wallet from a known email/phone (exact match, opt-out aware). */
   lookupWallet: (q: { email?: string; phone?: string }) => Promise<string | null>;
+  /** Directory reverse-lookup: wallet addresses → member display names ({ lowercasedWallet: name }). */
+  lookupNames: (wallets: string[]) => Promise<Record<string, string>>;
   /** Open the contacts manager; pass { add: true } to jump straight to the add form. */
   openManager: (opts?: { add?: boolean }) => void;
 }
@@ -51,6 +54,7 @@ export function useContacts(): ContactsValue {
       updateContact: () => {},
       removeContact: () => {},
       lookupWallet: async () => null,
+      lookupNames: async () => ({}),
       openManager: () => {},
     }
   );
@@ -145,6 +149,14 @@ export function ContactsProvider({ children }: { children: ReactNode }) {
     [address],
   );
 
+  const lookupNames = useCallback(
+    async (wallets: string[]) => {
+      if (!address) return {};
+      return lookupDirectoryNames(address, wallets);
+    },
+    [address],
+  );
+
   const value: ContactsValue = {
     contacts,
     getContact: (id) => contacts.find((c) => c.id === id),
@@ -152,6 +164,7 @@ export function ContactsProvider({ children }: { children: ReactNode }) {
     updateContact,
     removeContact,
     lookupWallet,
+    lookupNames,
     openManager: (opts) => {
       setManagerAdd(Boolean(opts?.add));
       setManagerOpen(true);

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2346,6 +2346,17 @@ export async function lookupDirectory(
   return r.error || !r.data ? { wallet: null } : r.data;
 }
 
+/** Directory reverse-lookup: wallet addresses → member display names ({ lowercasedWallet: name }). */
+export async function lookupDirectoryNames(wallet: string, wallets: string[]): Promise<Record<string, string>> {
+  const list = wallets.map((w) => w.trim()).filter(Boolean);
+  if (list.length === 0) return {};
+  const params = new URLSearchParams({ wallets: list.join(',') });
+  const r = await apiRequest<{ names: Record<string, string> }>(
+    `/api/contacts/${wallet.toLowerCase()}/names?${params.toString()}`,
+  );
+  return r.error || !r.data ? {} : r.data.names;
+}
+
 export async function getDirectoryOptout(wallet: string): Promise<boolean> {
   const r = await apiRequest<{ optedOut: boolean }>(`/api/contacts/${wallet.toLowerCase()}/optout`);
   return r.error || !r.data ? false : r.data.optedOut;


### PR DESCRIPTION
DM names now fall back to the **global member directory** when the peer isn't in your local contacts — the mirror of the existing email/phone → wallet autofill, and opt-out aware.

### Backend
- `contactsStore.lookupNames(wallets[])` → `{ lowercasedWallet: name }`, using `member_profile_public.display_name` (then `username`), matching any of a member's verified wallets (`member_wallets`) or their `primary_wallet`, and respecting `member_directory_optout`.
- `GET /api/contacts/:wallet/names?wallets=0x..,0x..` — wallet-scoped (`requireWalletMatch`), rate-limited (reuses the 30/min directory limiter), capped at 50 wallets.

### Frontend
- `apiClient.lookupDirectoryNames` + `ContactsContext.lookupNames` (scoped to the authed smart wallet, like `lookupWallet`).
- `XMTPMessaging` resolves each DM's peer wallet from its XMTP members, then titles the thread: **captured name → local contact → directory name → address**.

Resolution order means a name you've saved locally always wins; the directory only fills the gap for members you haven't added. Verified with frontend + backend `tsc` and `vite build`; end-to-end needs a live session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)