### PR TITLE
Coinbase Onramp — Phase A (on-ramp) with Onramper fallback

### DIFF
--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -31,6 +31,7 @@ import notificationsRouter from './routes/notifications.js';
 import requestsRouter from './routes/requests.js';
 import onramperRouter from './routes/onramper.js';
 import onramperWebhookRouter from './routes/onramperWebhook.js';
+import rampRouter from './routes/ramp.js';
 import { startPriceUpdater } from './jobs/priceUpdater.js';
 import { startPortfolioSnapshotter } from './jobs/portfolioSnapshotter.js';
 import { startAutopayRunner } from './jobs/autopayRunner.js';
@@ -201,6 +202,7 @@ async function startServer() {
     app.use('/api/notifications', requireAuth, notificationsRouter);
     app.use('/api/requests', requireAuth, requestsRouter);
     app.use('/api/onramper', requireAuth, onramperRouter);
+    app.use('/api/ramp', requireAuth, rampRouter);
 
     console.log('✅ API routes registered:');
     console.log('  - /api/prices');

--- a/app/server/src/routes/ramp.ts
+++ b/app/server/src/routes/ramp.ts
@@ -1,0 +1,175 @@
+import { Router, type Request, type Response } from 'express';
+import { requireWalletMatch } from '../middleware/auth.js';
+import { coinbaseOnrampService, type NormalizedRampQuote } from '../services/coinbaseOnrampService.js';
+import { onramperStore } from '../services/onramperStore.js';
+
+/*
+ * Unified fiat↔crypto ramp API. One set of endpoints the frontend calls; the actual provider is chosen
+ * server-side by RAMP_PROVIDER ('coinbase' default, 'onramper' fallback), so we can flip back to the
+ * Onramper aggregator instantly via env without a client change. Coinbase (CDP) Onramp is cheaper and we
+ * already hold the CDP keys. Bank/ACH deposits are NOT here — those stay on Bridge.
+ *
+ * Phase A (this route): on-ramp (buy) + transaction status. Off-ramp (sell) is added alongside.
+ */
+const router = Router();
+
+function provider(): 'coinbase' | 'onramper' {
+  const p = (process.env.RAMP_PROVIDER || 'coinbase').trim().toLowerCase();
+  return p === 'onramper' ? 'onramper' : 'coinbase';
+}
+
+// ---- Onramper fallback helpers (mirror routes/onramper.ts upstream calls) --------------------------
+const ONRAMPER_BASE = process.env.ONRAMPER_API_BASE || 'https://api.onramper.com';
+const onramperKey = () => process.env.ONRAMPER_API_KEY?.trim() || null;
+
+async function onramperBuyQuotes(p: { amount: number; paymentMethod: string; walletAddress?: string; fiat: string; crypto: string; country: string }) {
+  const key = onramperKey();
+  if (!key) return [];
+  const params = new URLSearchParams({ amount: String(p.amount), type: 'buy', paymentMethod: p.paymentMethod, country: p.country });
+  if (p.walletAddress) params.set('walletAddress', p.walletAddress);
+  const r = await fetch(`${ONRAMPER_BASE}/quotes/${p.fiat}/${p.crypto}?${params.toString()}`, { headers: { Authorization: key } });
+  const data = await r.json().catch(() => null);
+  const arr = Array.isArray(data) ? data : Array.isArray((data as any)?.message) ? (data as any).message : [];
+  return arr as Array<Record<string, any>>;
+}
+
+function normalizeOnramperQuote(q: Record<string, any> | undefined, amount: number, crypto: string): NormalizedRampQuote {
+  const payout = Number(q?.payout);
+  return {
+    provider: 'onramper',
+    fiatAmount: amount,
+    fiatSubtotal: amount,
+    cryptoAmount: Number.isFinite(payout) ? payout : undefined,
+    coinbaseFee: Number(q?.transactionFee) || undefined,
+    networkFee: Number(q?.networkFee) || undefined,
+    quoteId: q?.ramp ? String(q.ramp) : undefined,
+    asset: crypto,
+    network: 'base',
+    raw: q,
+  };
+}
+
+async function onramperCheckout(p: { onramp: string; amount: number; paymentMethod: string; walletAddress: string; fiat: string; crypto: string; type: 'buy' | 'sell' }): Promise<string | null> {
+  const key = onramperKey();
+  if (!key) return null;
+  const body = {
+    onramp: p.onramp,
+    source: p.type === 'buy' ? p.fiat : p.crypto,
+    destination: p.type === 'buy' ? p.crypto : p.fiat,
+    amount: p.amount,
+    type: p.type,
+    paymentMethod: p.paymentMethod,
+    network: 'base',
+    wallet: { address: p.walletAddress },
+    country: 'us',
+  };
+  const r = await fetch(`${ONRAMPER_BASE}/checkout/intent`, {
+    method: 'POST',
+    headers: { Authorization: key, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = (await r.json().catch(() => null)) as Record<string, any> | null;
+  return data?.sessionInformation?.url || data?.transactionInformation?.url || data?.url || data?.redirectUrl || null;
+}
+
+// ---- Routes ---------------------------------------------------------------------------------------
+
+// GET /api/ramp/config → which provider is active (for display / feature-gating on the client)
+router.get('/config', (_req: Request, res: Response) => {
+  const p = provider();
+  res.json({ provider: p, configured: p === 'coinbase' ? coinbaseOnrampService.isConfigured() : Boolean(onramperKey()) });
+});
+
+// GET /api/ramp/buy/quote?amount=&paymentMethod=&country=&subdivision=  → best/normalized buy quote
+router.get('/buy/quote', async (req: Request, res: Response) => {
+  const amount = Number(req.query.amount);
+  if (!(amount > 0)) {
+    res.status(400).json({ error: 'amount must be > 0' });
+    return;
+  }
+  const paymentMethod = String(req.query.paymentMethod || 'creditcard');
+  const country = String(req.query.country || 'us');
+  try {
+    if (provider() === 'coinbase') {
+      if (!coinbaseOnrampService.isConfigured()) {
+        res.status(503).json({ error: 'Coinbase Onramp not configured' });
+        return;
+      }
+      const quote = await coinbaseOnrampService.buyQuote({
+        amount,
+        paymentMethod,
+        country,
+        subdivision: req.query.subdivision ? String(req.query.subdivision) : undefined,
+      });
+      res.json({ quote });
+      return;
+    }
+    // Onramper fallback: aggregate quotes, return the best (highest USDC payout).
+    const raw = await onramperBuyQuotes({ amount, paymentMethod, walletAddress: req.query.walletAddress ? String(req.query.walletAddress) : undefined, fiat: 'usd', crypto: 'usdc_base', country });
+    const best = raw.filter((q) => Number.isFinite(Number(q.payout))).sort((a, b) => Number(b.payout) - Number(a.payout))[0];
+    res.json({ quote: best ? normalizeOnramperQuote(best, amount, 'usdc_base') : null });
+  } catch (error: any) {
+    console.error('[ramp/buy/quote]', error?.message || error);
+    res.status(502).json({ error: 'Quote fetch failed' });
+  }
+});
+
+// POST /api/ramp/buy/session { amount, paymentMethod, walletAddress, quoteId?, redirectUrl? }
+//   → { url } to open the hosted checkout (Coinbase Pay or the Onramper provider page).
+router.post('/buy/session', async (req: Request, res: Response) => {
+  const b = (req.body || {}) as Record<string, unknown>;
+  const amount = Number(b.amount);
+  const walletAddress = String(b.walletAddress || '');
+  if (!(amount > 0) || !/^0x[a-fA-F0-9]{40}$/.test(walletAddress)) {
+    res.status(400).json({ error: 'amount and a valid walletAddress are required' });
+    return;
+  }
+  // Users may only on-ramp to a wallet they've verified.
+  if (!requireWalletMatch(req, res, walletAddress.toLowerCase(), 'walletAddress')) return;
+  const paymentMethod = String(b.paymentMethod || 'creditcard');
+  try {
+    if (provider() === 'coinbase') {
+      if (!coinbaseOnrampService.isConfigured()) {
+        res.status(503).json({ error: 'Coinbase Onramp not configured' });
+        return;
+      }
+      const { token } = await coinbaseOnrampService.createSessionToken({ address: walletAddress });
+      const url = coinbaseOnrampService.buildBuyUrl({
+        token,
+        amount,
+        paymentMethod,
+        quoteId: b.quoteId ? String(b.quoteId) : undefined,
+        partnerUserId: walletAddress.toLowerCase(),
+        redirectUrl: b.redirectUrl ? String(b.redirectUrl) : undefined,
+      });
+      res.json({ url });
+      return;
+    }
+    // Onramper fallback: pick the best onramp, then create its checkout intent.
+    const quotes = await onramperBuyQuotes({ amount, paymentMethod, walletAddress, fiat: 'usd', crypto: 'usdc_base', country: 'us' });
+    const best = quotes.filter((q) => Number.isFinite(Number(q.payout))).sort((a, b2) => Number(b2.payout) - Number(a.payout))[0];
+    if (!best?.ramp) {
+      res.status(502).json({ error: 'No onramp available' });
+      return;
+    }
+    const url = await onramperCheckout({ onramp: String(best.ramp), amount, paymentMethod, walletAddress, fiat: 'usd', crypto: 'usdc_base', type: 'buy' });
+    res.json({ url });
+  } catch (error: any) {
+    console.error('[ramp/buy/session]', error?.message || error);
+    res.status(502).json({ error: 'Checkout failed' });
+  }
+});
+
+// GET /api/ramp/transactions/:wallet → recent ramp orders + status (from webhooks / status polling)
+router.get('/transactions/:wallet', async (req: Request, res: Response) => {
+  const w = String(req.params.wallet || '').toLowerCase();
+  if (!requireWalletMatch(req, res, w, 'wallet')) return;
+  try {
+    res.json({ transactions: await onramperStore.listByWallet(w) });
+  } catch (error) {
+    console.error('[ramp/transactions]', error);
+    res.status(500).json({ error: 'Failed to load transactions' });
+  }
+});
+
+export default router;

--- a/app/server/src/services/coinbaseOnrampService.ts
+++ b/app/server/src/services/coinbaseOnrampService.ts
@@ -1,0 +1,183 @@
+import { generateJwt } from '@coinbase/cdp-sdk/auth';
+
+/*
+ * Coinbase CDP Onramp/Offramp (headless) — fiat↔USDC for the Add-money / Withdraw flows, replacing the
+ * Onramper aggregator (kept as an env fallback). We reuse the SAME CDP API key the gasless relayer uses
+ * (generateJwt from @coinbase/cdp-sdk/auth) to authenticate the Onramp API; the browser only ever gets a
+ * short-lived session token + a pay.coinbase.com URL, never the key. Mainly Base + USDC.
+ *
+ * Setup (one-time, in the CDP portal): enable Onramp on the project and allowlist the app domain.
+ * Docs: https://docs.cdp.coinbase.com/onramp/introduction/welcome
+ *
+ * NOTE: exact request/response field names for the Onramp REST API are followed from the docs but parsed
+ * defensively (like the Onramper integration was) until verified against live responses.
+ */
+
+const API_HOST = 'api.developer.coinbase.com';
+const PAY_URL = 'https://pay.coinbase.com';
+
+// Default asset/network for Clear — Base USDC.
+const DEFAULT_NETWORK = 'base';
+const DEFAULT_ASSET = 'USDC';
+
+function keyId(): string | null {
+  return (process.env.CDP_ONRAMP_API_KEY_ID || process.env.CDP_API_KEY_ID || process.env.CDP_API_KEY_NAME || '').trim() || null;
+}
+function keySecret(): string | null {
+  return (process.env.CDP_ONRAMP_API_KEY_SECRET || process.env.CDP_API_KEY_SECRET || '').trim() || null;
+}
+
+/** Map the UI's payment-method id to Coinbase's enum. Guest checkout (no Coinbase login) is offered by
+ *  the widget automatically when eligible, so we pass the plain method and let Coinbase pick the lane. */
+export function toCoinbasePaymentMethod(methodId?: string): string {
+  switch ((methodId || '').toLowerCase()) {
+    case 'applepay':
+    case 'apple_pay':
+      return 'APPLE_PAY';
+    case 'ach':
+    case 'bank':
+    case 'ach_bank_account':
+      return 'ACH_BANK_ACCOUNT';
+    default:
+      return 'CARD';
+  }
+}
+
+export const coinbaseOnrampService = {
+  isConfigured(): boolean {
+    return Boolean(keyId() && keySecret());
+  },
+
+  /** Bearer auth header for an Onramp API request (short-lived JWT signed with the CDP API key). */
+  async authHeader(method: string, path: string): Promise<string> {
+    const apiKeyId = keyId();
+    const apiKeySecret = keySecret();
+    if (!apiKeyId || !apiKeySecret) throw new Error('Coinbase Onramp not configured (CDP_API_KEY_ID/SECRET)');
+    const jwt = await generateJwt({
+      apiKeyId,
+      apiKeySecret,
+      requestMethod: method,
+      requestHost: API_HOST,
+      requestPath: path,
+      expiresIn: 120,
+    });
+    return `Bearer ${jwt}`;
+  },
+
+  async apiFetch(method: 'GET' | 'POST', path: string, body?: unknown): Promise<any> {
+    const auth = await this.authHeader(method, path);
+    const r = await fetch(`https://${API_HOST}${path}`, {
+      method,
+      headers: { Authorization: auth, 'Content-Type': 'application/json' },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    const data: any = await r.json().catch(() => null);
+    if (!r.ok) {
+      const msg = (data && (data.message || data.error || data.error_message)) || `Coinbase Onramp API ${r.status}`;
+      const err = new Error(String(msg)) as Error & { status?: number; raw?: unknown };
+      err.status = r.status;
+      err.raw = data;
+      throw err;
+    }
+    return data;
+  },
+
+  /**
+   * Create a single-use session token scoped to the destination wallet + assets/networks. Required to
+   * open the hosted pay.coinbase.com flow without exposing the API key. ~5 min TTL, one-time use.
+   */
+  async createSessionToken(params: {
+    address: string;
+    blockchains?: string[];
+    assets?: string[];
+  }): Promise<{ token: string; channelId?: string }> {
+    const data = await this.apiFetch('POST', '/onramp/v1/token', {
+      addresses: [{ address: params.address, blockchains: params.blockchains ?? [DEFAULT_NETWORK] }],
+      assets: params.assets ?? [DEFAULT_ASSET],
+    });
+    const token = data?.token || data?.session_token || data?.data?.token;
+    if (!token) {
+      const err = new Error('Coinbase session token missing from response') as Error & { raw?: unknown };
+      err.raw = data;
+      throw err;
+    }
+    return { token: String(token), channelId: data?.channel_id ? String(data.channel_id) : undefined };
+  },
+
+  /** Buy quote (fees + rate) for a fiat amount → USDC on Base. Normalized to the app's quote shape. */
+  async buyQuote(params: {
+    amount: number;
+    fiat?: string;
+    asset?: string;
+    network?: string;
+    paymentMethod?: string;
+    country?: string;
+    subdivision?: string;
+  }): Promise<NormalizedRampQuote> {
+    const data = await this.apiFetch('POST', '/onramp/v1/buy/quote', {
+      purchase_currency: params.asset ?? DEFAULT_ASSET,
+      purchase_network: params.network ?? DEFAULT_NETWORK,
+      payment_amount: params.amount.toFixed(2),
+      payment_currency: (params.fiat ?? 'USD').toUpperCase(),
+      payment_method: toCoinbasePaymentMethod(params.paymentMethod),
+      country: (params.country ?? 'US').toUpperCase(),
+      ...(params.subdivision ? { subdivision: params.subdivision.toUpperCase() } : {}),
+    });
+    const num = (v: unknown): number | undefined => {
+      const n = typeof v === 'object' && v ? Number((v as any).amount ?? (v as any).value) : Number(v);
+      return Number.isFinite(n) ? n : undefined;
+    };
+    return {
+      provider: 'coinbase',
+      fiatAmount: num(data?.payment_total) ?? params.amount,
+      fiatSubtotal: num(data?.payment_subtotal) ?? params.amount,
+      cryptoAmount: num(data?.purchase_amount),
+      coinbaseFee: num(data?.coinbase_fee),
+      networkFee: num(data?.network_fee),
+      quoteId: data?.quote_id ? String(data.quote_id) : undefined,
+      asset: params.asset ?? DEFAULT_ASSET,
+      network: params.network ?? DEFAULT_NETWORK,
+      raw: data,
+    };
+  },
+
+  /** Build the hosted onramp URL to redirect the user to (session token carries the appId + wallet). */
+  buildBuyUrl(params: {
+    token: string;
+    amount: number;
+    fiat?: string;
+    asset?: string;
+    network?: string;
+    paymentMethod?: string;
+    quoteId?: string;
+    partnerUserId?: string;
+    redirectUrl?: string;
+  }): string {
+    const q = new URLSearchParams({
+      sessionToken: params.token,
+      defaultAsset: params.asset ?? DEFAULT_ASSET,
+      defaultNetwork: params.network ?? DEFAULT_NETWORK,
+      defaultPaymentMethod: toCoinbasePaymentMethod(params.paymentMethod),
+      presetFiatAmount: String(Math.round(params.amount)),
+      fiatCurrency: (params.fiat ?? 'USD').toUpperCase(),
+      defaultExperience: 'buy',
+    });
+    if (params.quoteId) q.set('quoteId', params.quoteId);
+    if (params.partnerUserId) q.set('partnerUserId', params.partnerUserId);
+    if (params.redirectUrl) q.set('redirectUrl', params.redirectUrl);
+    return `${PAY_URL}/buy/select-asset?${q.toString()}`;
+  },
+};
+
+export interface NormalizedRampQuote {
+  provider: string;
+  fiatAmount: number; // total the user pays (incl. fees) for buy; total received for sell
+  fiatSubtotal: number;
+  cryptoAmount?: number; // USDC bought (buy) / sold (sell)
+  coinbaseFee?: number;
+  networkFee?: number;
+  quoteId?: string;
+  asset: string;
+  network: string;
+  raw?: unknown;
+}

--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -6,7 +6,7 @@ import { useExternalAccounts } from '@/context/ExternalAccountsContext';
 import { useBridge } from '@/context/BridgeContext';
 import { useKyc } from '@/context/KycContext';
 import DepositInstructions from '@/components/app-ui/DepositInstructions';
-import { getOnramperQuotes, createOnramperCheckout, type OnramperQuote } from '@/utils/apiClient';
+import { getRampBuyQuote, createRampBuySession, type RampQuote } from '@/utils/apiClient';
 import { cn } from '@/lib/utils';
 
 /*
@@ -40,17 +40,14 @@ interface QuoteVM {
   payout: number;
 }
 const prettyRamp = (id: string) => (id ? id.charAt(0).toUpperCase() + id.slice(1) : 'Provider');
-// Map Onramper's /quotes array → the UI shape (USDC ≈ $1, so payout in USDC ≈ USD value).
-function mapQuotes(raw: OnramperQuote[], amount: number): QuoteVM[] {
-  return raw
-    .map((q) => {
-      const payout = Number(q.payout) || 0;
-      return { p: { id: String(q.ramp), name: prettyRamp(String(q.ramp)) }, payout, fee: Math.max(0, amount - payout) };
-    })
-    .filter((q) => q.payout > 0)
-    .sort((a, b) => b.payout - a.payout);
+// Normalize the unified ramp quote → the UI shape (USDC ≈ $1). The provider (Coinbase / Onramper) is
+// picked server-side, so there's one best quote; `fee` is the summed provider + network fee.
+function toQuoteVM(q: RampQuote, amount: number): QuoteVM {
+  const fees = (q.coinbaseFee ?? 0) + (q.networkFee ?? 0);
+  const fee = fees > 0 ? fees : Math.max(0, amount - (q.cryptoAmount ?? amount));
+  return { p: { id: q.provider, name: prettyRamp(q.provider) }, fee, payout: Math.max(0, amount - fee) };
 }
-const onramperPM = (methodId: string) => (methodId === 'applepay' ? 'applepay' : 'creditcard');
+const rampPM = (methodId: string) => (methodId === 'applepay' ? 'applepay' : 'creditcard');
 
 /*
  * Bank funding rails. A bank deposit pulls fiat from a Plaid-linked account through the user's
@@ -80,6 +77,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
   const [sourceOpen, setSourceOpen] = useState(false);
   const [depositOpen, setDepositOpen] = useState(false);
   const [apiQuotes, setApiQuotes] = useState<QuoteVM[]>([]);
+  const [quoteId, setQuoteId] = useState<string | undefined>(undefined); // locked-quote id for checkout
   const [quotesLoading, setQuotesLoading] = useState(false);
   const [checkoutLoading, setCheckoutLoading] = useState(false);
   const [checkoutError, setCheckoutError] = useState<string | null>(null);
@@ -105,11 +103,11 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
     }
     setCheckoutError(null);
     setCheckoutLoading(true);
-    const { url } = await createOnramperCheckout({
-      onramp: selected.p.id,
+    const { url } = await createRampBuySession({
       amount,
-      paymentMethod: onramperPM(methodId),
+      paymentMethod: rampPM(methodId),
       walletAddress: wallet.address,
+      quoteId,
     });
     setCheckoutLoading(false);
     if (url) {
@@ -134,6 +132,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
     setSourceOpen(false);
     setDepositOpen(false);
     setApiQuotes([]);
+    setQuoteId(undefined);
     setCheckoutError(null);
     setCheckoutLoading(false);
   }, [open]);
@@ -156,18 +155,20 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
     (providerId ? quotes.find((q) => q.p.id === providerId) : null) ??
     best ?? { p: { id: '', name: '—' }, fee: 0, payout: amount };
 
-  // Live Onramper quotes for card / Apple Pay (debounced); bank uses the Bridge rail instead.
+  // Live ramp quote for card / Apple Pay (debounced); bank uses the Bridge rail instead.
   useEffect(() => {
     if (!open || isBank || !amountValid) {
       setApiQuotes([]);
+      setQuoteId(undefined);
       return;
     }
     let cancelled = false;
     setQuotesLoading(true);
     const t = setTimeout(async () => {
-      const raw = await getOnramperQuotes({ amount, paymentMethod: onramperPM(methodId), walletAddress: wallet.address || undefined });
+      const q = await getRampBuyQuote({ amount, paymentMethod: rampPM(methodId), walletAddress: wallet.address || undefined });
       if (cancelled) return;
-      setApiQuotes(mapQuotes(raw, amount));
+      setApiQuotes(q ? [toQuoteVM(q, amount)] : []);
+      setQuoteId(q?.quoteId);
       setQuotesLoading(false);
     }, 350);
     return () => {

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2446,3 +2446,46 @@ export async function createOnramperSellCheckout(p: {
   const r = await apiRequest<{ url: string | null }>(`/api/onramper/sell-checkout`, { method: 'POST', body: JSON.stringify(p) });
   return r.error || !r.data ? { url: null } : r.data;
 }
+
+// ---- Unified ramp (Coinbase Onramp by default; Onramper as an env-selected fallback) ----
+// The backend picks the provider (RAMP_PROVIDER); the client just calls /api/ramp/* and gets a
+// normalized quote + a hosted checkout URL, so switching providers is a server-side env flip.
+
+export interface RampQuote {
+  provider: string;
+  fiatAmount: number; // total the user pays (buy) incl. fees
+  fiatSubtotal: number;
+  cryptoAmount?: number; // USDC received
+  coinbaseFee?: number;
+  networkFee?: number;
+  quoteId?: string;
+  asset: string;
+  network: string;
+}
+
+/** Normalized buy quote (card / Apple Pay → USDC on Base). */
+export async function getRampBuyQuote(p: {
+  amount: number;
+  paymentMethod: string;
+  walletAddress?: string;
+  country?: string;
+  subdivision?: string;
+}): Promise<RampQuote | null> {
+  const params = new URLSearchParams({ amount: String(p.amount), paymentMethod: p.paymentMethod, country: p.country || 'us' });
+  if (p.walletAddress) params.set('walletAddress', p.walletAddress);
+  if (p.subdivision) params.set('subdivision', p.subdivision);
+  const r = await apiRequest<{ quote: RampQuote | null }>(`/api/ramp/buy/quote?${params.toString()}`);
+  return r.error || !r.data ? null : r.data.quote;
+}
+
+/** Create a buy session → hosted checkout URL to redirect the user to. */
+export async function createRampBuySession(p: {
+  amount: number;
+  paymentMethod: string;
+  walletAddress: string;
+  quoteId?: string;
+  redirectUrl?: string;
+}): Promise<{ url: string | null }> {
+  const r = await apiRequest<{ url: string | null }>(`/api/ramp/buy/session`, { method: 'POST', body: JSON.stringify(p) });
+  return r.error || !r.data ? { url: null } : r.data;
+}


### PR DESCRIPTION
Swaps the Add-money **card / Apple Pay** rail from Onramper to **Coinbase CDP Onramp** (cheaper; we already hold the CDP keys and are mainly Base + USDC), behind an env flag so we can revert instantly.

### How it works
- `coinbaseOnrampService` mints the Onramp API JWT with our existing CDP key (`generateJwt` from `@coinbase/cdp-sdk/auth`), then creates a **single-use session token** + a **buy quote**. The browser only ever gets the session token + a `pay.coinbase.com` URL — never the key.
- New unified `/api/ramp/*` route **dispatches on `RAMP_PROVIDER`** (`coinbase` default, `onramper` fallback) and returns a **normalized quote + checkout URL**, so flipping providers is a server-side env change with no client edit.
- `apiClient.getRampBuyQuote` / `createRampBuySession`; `AddMoneyModal` rewired to them (redirect UX unchanged).
- Onramper route/webhook/store left intact as the fallback. **Bridge ACH untouched.**

### Scope
This is **on-ramp only**. Off-ramp (sell + the auto-send of USDC that Coinbase Offramp requires) is **Phase B** — Withdraw still uses Onramper until then.

### Setup needed (CDP portal)
- Enable **Onramp** on the CDP project.
- Allowlist the app domain (`app.useclear.org`).
- Optional env: `RAMP_PROVIDER` (default `coinbase`), `CDP_ONRAMP_API_KEY_ID/SECRET` overrides (else reuses `CDP_API_KEY_ID/SECRET`).

Field names for the Onramp REST API are parsed defensively (like the Onramper integration) pending live verification. Verified with backend + frontend `tsc` and `vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)