### PR TITLE
Ramp: diagnostic empty-state for on-ramp

### DIFF
--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -6,7 +6,7 @@ import { useExternalAccounts } from '@/context/ExternalAccountsContext';
 import { useBridge } from '@/context/BridgeContext';
 import { useKyc } from '@/context/KycContext';
 import DepositInstructions from '@/components/app-ui/DepositInstructions';
-import { getRampBuyQuote, createRampBuySession, type RampQuote } from '@/utils/apiClient';
+import { getRampBuyQuote, createRampBuySession, getRampConfig, type RampQuote } from '@/utils/apiClient';
 import { cn } from '@/lib/utils';
 
 /*
@@ -78,6 +78,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
   const [depositOpen, setDepositOpen] = useState(false);
   const [apiQuotes, setApiQuotes] = useState<QuoteVM[]>([]);
   const [quoteId, setQuoteId] = useState<string | undefined>(undefined); // locked-quote id for checkout
+  const [rampConfigured, setRampConfigured] = useState<boolean | null>(null); // null = unknown yet
   const [quotesLoading, setQuotesLoading] = useState(false);
   const [checkoutLoading, setCheckoutLoading] = useState(false);
   const [checkoutError, setCheckoutError] = useState<string | null>(null);
@@ -135,6 +136,15 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
     setQuoteId(undefined);
     setCheckoutError(null);
     setCheckoutLoading(false);
+  }, [open]);
+
+  // Whether the ramp provider is actually configured — lets us explain an empty quote (setup pending
+  // vs no coverage) instead of a vague "no providers".
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    getRampConfig().then((c) => { if (!cancelled) setRampConfigured(c.configured); }).catch(() => { if (!cancelled) setRampConfigured(false); });
+    return () => { cancelled = true; };
   }, [open]);
 
   useEffect(() => {
@@ -466,7 +476,9 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
                 </div>
               ) : quotes.length === 0 ? (
                 <div className="rounded-lg border border-border bg-secondary/40 px-3 py-2 text-[11px] text-muted-foreground">
-                  No providers available right now — check back soon.
+                  {rampConfigured === false
+                    ? 'Card & Apple Pay top-ups are being set up — use a bank transfer for now.'
+                    : 'No quote available for this amount right now — try a different amount or method.'}
                 </div>
               ) : (
                 <>

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2478,6 +2478,12 @@ export async function getRampBuyQuote(p: {
   return r.error || !r.data ? null : r.data.quote;
 }
 
+/** Which ramp provider is active + whether it's configured (so the UI can explain an empty quote). */
+export async function getRampConfig(): Promise<{ provider: string; configured: boolean }> {
+  const r = await apiRequest<{ provider: string; configured: boolean }>(`/api/ramp/config`);
+  return r.error || !r.data ? { provider: 'coinbase', configured: false } : r.data;
+}
+
 /** Create a buy session → hosted checkout URL to redirect the user to. */
 export async function createRampBuySession(p: {
   amount: number;


### PR DESCRIPTION
When Coinbase Onramp isn't enabled/configured yet, the Add-money modal now explains it ('Card & Apple Pay top-ups are being set up — use a bank transfer for now') instead of the vague 'No providers available right now'. Checks `/api/ramp/config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)