### PR TITLE
Coinbase Onramp: headless Apple Pay + 503 fix + off-ramp backend

### DIFF
--- a/app/server/src/routes/ramp.ts
+++ b/app/server/src/routes/ramp.ts
@@ -160,6 +160,54 @@ router.post('/buy/session', async (req: Request, res: Response) => {
   }
 });
 
+// POST /api/ramp/buy/order { amount, walletAddress, email, phone, paymentMethod? }
+//   HEADLESS on-ramp: returns { paymentLinkUrl } — an Apple Pay button to embed in an iframe, so the
+//   buy happens inside our own UI (Coinbase only; the Onramper fallback has no equivalent).
+router.post('/buy/order', async (req: Request, res: Response) => {
+  if (provider() !== 'coinbase') {
+    res.status(400).json({ error: 'Headless order is only supported on the Coinbase provider' });
+    return;
+  }
+  if (!coinbaseOnrampService.isConfigured()) {
+    res.status(503).json({ error: 'Coinbase Onramp not configured' });
+    return;
+  }
+  const b = (req.body || {}) as Record<string, unknown>;
+  const amount = Number(b.amount);
+  const walletAddress = String(b.walletAddress || '');
+  const email = String(b.email || '').trim();
+  const phone = String(b.phone || '').trim();
+  if (!(amount > 0) || !/^0x[a-fA-F0-9]{40}$/.test(walletAddress)) {
+    res.status(400).json({ error: 'amount and a valid walletAddress are required' });
+    return;
+  }
+  if (!email || !phone) {
+    res.status(422).json({ error: 'verified email and phone are required for guest checkout', code: 'NEEDS_CONTACT' });
+    return;
+  }
+  if (!requireWalletMatch(req, res, walletAddress.toLowerCase(), 'walletAddress')) return;
+  // The iframe is embedded on the page that made the request — that host must be allowlisted in CDP.
+  const origin = req.get('origin') || '';
+  let domain = process.env.RAMP_IFRAME_DOMAIN || '';
+  try { if (!domain && origin) domain = new URL(origin).hostname; } catch { /* ignore */ }
+  if (!domain) domain = 'app.useclear.org';
+  try {
+    const order = await coinbaseOnrampService.createOnrampOrder({
+      amount,
+      email,
+      phoneNumber: phone,
+      destinationAddress: walletAddress,
+      domain,
+      partnerUserRef: walletAddress.toLowerCase(),
+      paymentMethod: String(b.paymentMethod || '').toUpperCase() === 'GUEST_CHECKOUT_CARD' ? 'GUEST_CHECKOUT_CARD' : 'GUEST_CHECKOUT_APPLE_PAY',
+    });
+    res.json({ paymentLinkUrl: order.paymentLinkUrl, paymentLinkType: order.paymentLinkType, orderId: order.orderId });
+  } catch (error: any) {
+    console.error('[ramp/buy/order]', error?.status, error?.message || error, error?.raw ?? '');
+    res.status(error?.status && error.status < 500 ? 400 : 502).json({ error: error?.message || 'Order failed' });
+  }
+});
+
 // GET /api/ramp/transactions/:wallet → recent ramp orders + status (from webhooks / status polling)
 router.get('/transactions/:wallet', async (req: Request, res: Response) => {
   const w = String(req.params.wallet || '').toLowerCase();

--- a/app/server/src/routes/ramp.ts
+++ b/app/server/src/routes/ramp.ts
@@ -208,6 +208,61 @@ router.post('/buy/order', async (req: Request, res: Response) => {
   }
 });
 
+// POST /api/ramp/sell/session { walletAddress, redirectUrl? } → { url, partnerUserRef }
+//   Opens the offramp cash-out flow. After the user confirms, poll /sell/status for the send instruction.
+router.post('/sell/session', async (req: Request, res: Response) => {
+  const b = (req.body || {}) as Record<string, unknown>;
+  const walletAddress = String(b.walletAddress || '');
+  if (!/^0x[a-fA-F0-9]{40}$/.test(walletAddress)) {
+    res.status(400).json({ error: 'a valid walletAddress is required' });
+    return;
+  }
+  if (!requireWalletMatch(req, res, walletAddress.toLowerCase(), 'walletAddress')) return;
+  const partnerUserRef = walletAddress.toLowerCase();
+  try {
+    if (provider() === 'coinbase') {
+      if (!coinbaseOnrampService.isConfigured()) {
+        res.status(503).json({ error: 'Coinbase Offramp not configured' });
+        return;
+      }
+      const { token } = await coinbaseOnrampService.createSessionToken({ address: walletAddress });
+      const url = coinbaseOnrampService.buildSellUrl({ token, partnerUserRef, redirectUrl: b.redirectUrl ? String(b.redirectUrl) : undefined });
+      res.json({ url, partnerUserRef });
+      return;
+    }
+    // Onramper fallback: a pure hosted sell (no send-back), so no partnerUserRef polling.
+    const amount = Number(b.amount) || 0;
+    const url = await onramperCheckout({ onramp: String(b.onramp || ''), amount, paymentMethod: 'creditcard', walletAddress, fiat: 'usd', crypto: 'usdc_base', type: 'sell' });
+    res.json({ url, partnerUserRef: null });
+  } catch (error: any) {
+    console.error('[ramp/sell/session]', error?.message || error);
+    res.status(502).json({ error: 'Cash-out failed to start' });
+  }
+});
+
+// GET /api/ramp/sell/status?partnerUserRef=0x.. → { status, toAddress, amount, currency, asset, network }
+//   When status is STARTED, the client sends `amount` of USDC to `toAddress` (Coinbase-managed) on Base.
+router.get('/sell/status', async (req: Request, res: Response) => {
+  const ref = String(req.query.partnerUserRef || '').toLowerCase();
+  if (!/^0x[a-fA-F0-9]{40}$/.test(ref)) {
+    res.status(400).json({ error: 'partnerUserRef required' });
+    return;
+  }
+  // Only the owner of that wallet may read its offramp status.
+  if (!requireWalletMatch(req, res, ref, 'partnerUserRef')) return;
+  if (provider() !== 'coinbase') {
+    res.json({ status: null });
+    return;
+  }
+  try {
+    const status = await coinbaseOnrampService.getSellStatus(ref);
+    res.json(status ?? { status: null });
+  } catch (error: any) {
+    console.error('[ramp/sell/status]', error?.message || error);
+    res.status(502).json({ error: 'Status check failed' });
+  }
+});
+
 // GET /api/ramp/transactions/:wallet → recent ramp orders + status (from webhooks / status polling)
 router.get('/transactions/:wallet', async (req: Request, res: Response) => {
   const w = String(req.params.wallet || '').toLowerCase();

--- a/app/server/src/services/coinbaseOnrampService.ts
+++ b/app/server/src/services/coinbaseOnrampService.ts
@@ -228,7 +228,50 @@ export const coinbaseOnrampService = {
     if (params.redirectUrl) q.set('redirectUrl', params.redirectUrl);
     return `${PAY_URL}/buy/select-asset?${q.toString()}`;
   },
+
+  // ---- OFF-RAMP (sell → fiat) --------------------------------------------------------------------
+  // Flow: open the offramp URL → user picks amount + cash-out destination on Coinbase → we poll the
+  // status API → when it's STARTED with a to_address, our app sends that USDC on-chain → Coinbase pays
+  // out. Docs: https://docs.cdp.coinbase.com/onramp/offramp/offramp-overview
+
+  /** Build the hosted offramp URL. `partnerUserRef` scopes the transaction so we can poll its status. */
+  buildSellUrl(params: { token: string; partnerUserRef: string; redirectUrl?: string }): string {
+    const q = new URLSearchParams({ sessionToken: params.token, partnerUserRef: params.partnerUserRef });
+    if (params.redirectUrl) q.set('redirectUrl', params.redirectUrl);
+    return `${PAY_URL}/v3/sell/input?${q.toString()}`;
+  },
+
+  /**
+   * Latest offramp transaction for a partnerUserRef. When status is STARTED it carries the Coinbase
+   * `to_address` + `sell_amount` we must send USDC to (within 30 min). Normalized for the app.
+   */
+  async getSellStatus(partnerUserRef: string): Promise<OfframpStatus | null> {
+    const path = `/onramp/v1/sell/user/${encodeURIComponent(partnerUserRef)}/transactions?page_size=1`;
+    const data = await this.apiFetch('GET', path);
+    const tx = Array.isArray(data?.transactions) ? data.transactions[0] : undefined;
+    if (!tx) return null;
+    const amt = tx.sell_amount || {};
+    return {
+      status: String(tx.status || ''),
+      toAddress: tx.to_address ? String(tx.to_address) : null,
+      amount: amt.value != null ? String(amt.value) : null,
+      currency: amt.currency ? String(amt.currency) : null,
+      asset: tx.asset ? String(tx.asset) : null,
+      network: tx.network ? String(tx.network) : null,
+      raw: tx,
+    };
+  },
 };
+
+export interface OfframpStatus {
+  status: string; // TRANSACTION_STATUS_STARTED | _SUCCESS | _FAILED
+  toAddress: string | null; // Coinbase-managed address to send the USDC to (when STARTED)
+  amount: string | null; // sell_amount.value
+  currency: string | null; // sell_amount.currency (e.g. USDC)
+  asset: string | null;
+  network: string | null;
+  raw?: unknown;
+}
 
 export interface NormalizedRampQuote {
   provider: string;

--- a/app/server/src/services/coinbaseOnrampService.ts
+++ b/app/server/src/services/coinbaseOnrampService.ts
@@ -154,6 +154,54 @@ export const coinbaseOnrampService = {
     };
   },
 
+  /**
+   * HEADLESS on-ramp (Guest Checkout) — create an order and get back a payment link (an Apple Pay
+   * button URL) we embed in an iframe, so the buy happens inside our own UI. US only, Apple Pay on web.
+   * Requires the user's verified email + phone (we source these from the authed Privy session). Docs:
+   * https://docs.cdp.coinbase.com/onramp/headless-onramp/overview
+   */
+  async createOnrampOrder(params: {
+    amount: number;
+    email: string;
+    phoneNumber: string; // E.164
+    destinationAddress: string;
+    domain: string; // where the iframe is embedded — must be allowlisted in the CDP portal
+    partnerUserRef: string;
+    fiat?: string;
+    asset?: string;
+    network?: string;
+    paymentMethod?: 'GUEST_CHECKOUT_APPLE_PAY' | 'GUEST_CHECKOUT_CARD';
+  }): Promise<{ paymentLinkUrl: string; paymentLinkType?: string; orderId?: string; raw: any }> {
+    const now = new Date().toISOString();
+    const data = await this.apiFetch('POST', '/v2/onramp/orders', {
+      paymentCurrency: (params.fiat ?? 'USD').toUpperCase(),
+      purchaseCurrency: params.asset ?? DEFAULT_ASSET,
+      destinationNetwork: params.network ?? DEFAULT_NETWORK,
+      destinationAddress: params.destinationAddress,
+      paymentMethod: params.paymentMethod ?? 'GUEST_CHECKOUT_APPLE_PAY',
+      paymentAmount: params.amount.toFixed(2), // fiat, inclusive of fees
+      email: params.email,
+      phoneNumber: params.phoneNumber,
+      // The user is verified via Privy at login; we attest the verification time (no separate SMS step).
+      phoneNumberVerifiedAt: now,
+      agreementAcceptedAt: now,
+      partnerUserRef: params.partnerUserRef,
+      domain: params.domain,
+    });
+    const url = data?.paymentLink?.url || data?.payment_link?.url;
+    if (!url) {
+      const err = new Error('Coinbase order payment link missing') as Error & { raw?: unknown };
+      err.raw = data;
+      throw err;
+    }
+    return {
+      paymentLinkUrl: String(url),
+      paymentLinkType: data?.paymentLink?.paymentLinkType || data?.payment_link?.paymentLinkType,
+      orderId: data?.order?.orderId ? String(data.order.orderId) : undefined,
+      raw: data,
+    };
+  },
+
   /** Build the hosted onramp URL to redirect the user to (session token carries the appId + wallet). */
   buildBuyUrl(params: {
     token: string;

--- a/app/server/src/services/coinbaseOnrampService.ts
+++ b/app/server/src/services/coinbaseOnrampService.ts
@@ -20,11 +20,24 @@ const PAY_URL = 'https://pay.coinbase.com';
 const DEFAULT_NETWORK = 'base';
 const DEFAULT_ASSET = 'USDC';
 
+// Resolve the CDP API key the same way the relayer does (SEND_CDP_* is what's set on Railway), with an
+// optional CDP_ONRAMP_* override — the same Secret API key works for all CDP APIs once Onramp is enabled.
 function keyId(): string | null {
-  return (process.env.CDP_ONRAMP_API_KEY_ID || process.env.CDP_API_KEY_ID || process.env.CDP_API_KEY_NAME || '').trim() || null;
+  return (
+    process.env.CDP_ONRAMP_API_KEY_ID ||
+    process.env.SEND_CDP_API_KEY_ID ||
+    process.env.CDP_API_KEY_ID ||
+    process.env.CDP_API_KEY_NAME ||
+    ''
+  ).trim() || null;
 }
 function keySecret(): string | null {
-  return (process.env.CDP_ONRAMP_API_KEY_SECRET || process.env.CDP_API_KEY_SECRET || '').trim() || null;
+  return (
+    process.env.CDP_ONRAMP_API_KEY_SECRET ||
+    process.env.SEND_CDP_API_KEY_SECRET ||
+    process.env.CDP_API_KEY_SECRET ||
+    ''
+  ).trim() || null;
 }
 
 /** Map the UI's payment-method id to Coinbase's enum. Guest checkout (no Coinbase login) is offered by

--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -6,7 +6,8 @@ import { useExternalAccounts } from '@/context/ExternalAccountsContext';
 import { useBridge } from '@/context/BridgeContext';
 import { useKyc } from '@/context/KycContext';
 import DepositInstructions from '@/components/app-ui/DepositInstructions';
-import { getRampBuyQuote, createRampBuySession, getRampConfig, type RampQuote } from '@/utils/apiClient';
+import { usePrivy } from '@privy-io/react-auth';
+import { getRampBuyQuote, createRampBuySession, createRampBuyOrder, getRampConfig, type RampQuote } from '@/utils/apiClient';
 import { cn } from '@/lib/utils';
 
 /*
@@ -64,7 +65,8 @@ const QUICK = [50, 100, 250, 500];
 const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
 export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
-  const [step, setStep] = useState<'amount' | 'review' | 'status'>('amount');
+  const [step, setStep] = useState<'amount' | 'review' | 'status' | 'pay'>('amount');
+  const [payUrl, setPayUrl] = useState<string | null>(null); // Coinbase Apple Pay iframe (headless)
   const [amountStr, setAmountStr] = useState('');
   const [methodId, setMethodId] = useState('card');
   const [walletId, setWalletId] = useState('');
@@ -86,6 +88,9 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
   const { accounts: banks, openManager: openBankManager } = useExternalAccounts();
   const { virtualAccount } = useBridge();
   const { verified, openKyc } = useKyc();
+  const { user } = usePrivy();
+  const buyerEmail = user?.email?.address || '';
+  const buyerPhone = user?.phone?.number || '';
   // Card / Apple Pay on-ramps KYC at the provider; a bank/ACH deposit needs our KYC.
   const proceed = () => {
     if (methodId === 'bank' && !verified) openKyc(() => setStep('status'));
@@ -104,6 +109,18 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
     }
     setCheckoutError(null);
     setCheckoutLoading(true);
+    // Apple Pay on Coinbase → headless order rendered in an in-app iframe (needs verified email + phone).
+    if (methodId === 'applepay' && selected.p.id === 'coinbase' && buyerEmail && buyerPhone) {
+      const { paymentLinkUrl } = await createRampBuyOrder({ amount, walletAddress: wallet.address, email: buyerEmail, phone: buyerPhone });
+      if (paymentLinkUrl) {
+        setPayUrl(paymentLinkUrl);
+        setStep('pay');
+        setCheckoutLoading(false);
+        return;
+      }
+      // else fall through to the hosted checkout below
+    }
+    // Card (or Apple Pay fallback): open the hosted Coinbase / provider checkout in a new tab.
     const { url } = await createRampBuySession({
       amount,
       paymentMethod: rampPM(methodId),
@@ -115,7 +132,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
       window.open(url, '_blank', 'noopener,noreferrer');
       setStep('status');
     } else {
-      setCheckoutError('Could not start checkout — try another provider or amount.');
+      setCheckoutError('Could not start checkout — try another amount or method.');
     }
   };
 
@@ -134,9 +151,23 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
     setDepositOpen(false);
     setApiQuotes([]);
     setQuoteId(undefined);
+    setPayUrl(null);
     setCheckoutError(null);
     setCheckoutLoading(false);
   }, [open]);
+
+  // Coinbase's Apple Pay iframe posts transaction-status events; treat a success/completion as done.
+  useEffect(() => {
+    if (step !== 'pay') return;
+    const onMsg = (e: MessageEvent) => {
+      if (!/\.coinbase\.com$/.test((() => { try { return new URL(e.origin).hostname; } catch { return ''; } })())) return;
+      const d = e.data;
+      const s = typeof d === 'string' ? d : JSON.stringify(d ?? '');
+      if (/success|completed|complete|finished|TRANSACTION_STATUS_SUCCESS/i.test(s)) setStep('status');
+    };
+    window.addEventListener('message', onMsg);
+    return () => window.removeEventListener('message', onMsg);
+  }, [step]);
 
   // Whether the ramp provider is actually configured — lets us explain an empty quote (setup pending
   // vs no coverage) instead of a vague "no providers".
@@ -539,6 +570,33 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
               {isBank
                 ? `Via your Clear USD account${virtualAccount.bankName ? ` (${virtualAccount.bankName})` : ''} · held as USDC on Base`
                 : 'Held as USDC, a regulated digital dollar, on Base'}
+            </p>
+          </div>
+        )}
+
+        {step === 'pay' && payUrl && (
+          <div className="flex flex-col px-4 pb-4 pt-2">
+            <div className="mb-3 flex items-center gap-2 px-2">
+              <button type="button" onClick={() => setStep('review')} className="text-muted-foreground transition-colors hover:text-foreground">
+                <ArrowLeft className="h-4 w-4" />
+              </button>
+              <div className="text-sm font-semibold text-foreground">Pay {fmt(amount)} with Apple Pay</div>
+            </div>
+            <iframe
+              title="Coinbase Pay"
+              src={payUrl}
+              allow="payment"
+              className="h-[420px] w-full rounded-xl border border-border bg-background"
+            />
+            <button
+              type="button"
+              onClick={() => setStep('status')}
+              className="mt-3 w-full rounded-xl border border-border py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+            >
+              I've completed payment
+            </button>
+            <p className="mt-2 flex items-center justify-center gap-1 text-center text-[11px] text-muted-foreground">
+              <ShieldCheck className="h-3 w-3" /> Secured by Coinbase · held as USDC on Base
             </p>
           </div>
         )}

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2484,6 +2484,19 @@ export async function getRampConfig(): Promise<{ provider: string; configured: b
   return r.error || !r.data ? { provider: 'coinbase', configured: false } : r.data;
 }
 
+/** Headless buy order (Coinbase Guest Checkout) → an Apple Pay payment-link URL to embed in an iframe. */
+export async function createRampBuyOrder(p: {
+  amount: number;
+  walletAddress: string;
+  email: string;
+  phone: string;
+  paymentMethod?: 'GUEST_CHECKOUT_APPLE_PAY' | 'GUEST_CHECKOUT_CARD';
+}): Promise<{ paymentLinkUrl: string | null; error?: string; code?: string }> {
+  const r = await apiRequest<{ paymentLinkUrl: string | null }>(`/api/ramp/buy/order`, { method: 'POST', body: JSON.stringify(p) });
+  if (r.error || !r.data) return { paymentLinkUrl: null, error: r.error || 'Order failed' };
+  return { paymentLinkUrl: r.data.paymentLinkUrl };
+}
+
 /** Create a buy session → hosted checkout URL to redirect the user to. */
 export async function createRampBuySession(p: {
   amount: number;

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2478,6 +2478,27 @@ export async function getRampBuyQuote(p: {
   return r.error || !r.data ? null : r.data.quote;
 }
 
+export interface RampSellStatus {
+  status: string | null; // TRANSACTION_STATUS_STARTED | _SUCCESS | _FAILED
+  toAddress?: string | null; // Coinbase address to send USDC to (when STARTED)
+  amount?: string | null; // sell_amount.value
+  currency?: string | null;
+  asset?: string | null;
+  network?: string | null;
+}
+
+/** Start an off-ramp cash-out → { url, partnerUserRef }. Poll getRampSellStatus after the user confirms. */
+export async function createRampSellSession(p: { walletAddress: string; redirectUrl?: string }): Promise<{ url: string | null; partnerUserRef: string | null }> {
+  const r = await apiRequest<{ url: string | null; partnerUserRef: string | null }>(`/api/ramp/sell/session`, { method: 'POST', body: JSON.stringify(p) });
+  return r.error || !r.data ? { url: null, partnerUserRef: null } : r.data;
+}
+
+/** Poll an off-ramp transaction's status. On STARTED it returns the toAddress + amount of USDC to send. */
+export async function getRampSellStatus(partnerUserRef: string): Promise<RampSellStatus> {
+  const r = await apiRequest<RampSellStatus>(`/api/ramp/sell/status?partnerUserRef=${encodeURIComponent(partnerUserRef)}`);
+  return r.error || !r.data ? { status: null } : r.data;
+}
+
 /** Which ramp provider is active + whether it's configured (so the UI can explain an empty quote). */
 export async function getRampConfig(): Promise<{ provider: string; configured: boolean }> {
   const r = await apiRequest<{ provider: string; configured: boolean }>(`/api/ramp/config`);


### PR DESCRIPTION
Builds on #327. Three things:

### 1. 503 fix (unblocks the live error)
The onramp service now resolves the CDP key from `SEND_CDP_API_KEY_ID/SECRET` (where Railway holds it, shared with the relayer), not just the bare `CDP_*` names. That's why `/api/ramp/buy/quote` was 503ing.

### 2. Headless on-ramp — Apple Pay in an in-app iframe (Part A)
`POST /v2/onramp/orders` (Guest Checkout) with the Privy-verified email + phone → returns an Apple Pay payment-link that `AddMoneyModal` embeds in an **iframe** (new `pay` step), finishing on a postMessage success. **Card stays on the hosted Coinbase surface** (PCI — can't be headless on web). Both fall back to the hosted redirect if the order can't be created. Domain for the iframe comes from the request origin (must be allowlisted in CDP).

### 3. Off-ramp backend scaffolding (Part B, safe half)
Sell session (`/v3/sell` URL) + status polling (`/onramp/v1/sell/user/{ref}/transactions` → `to_address` + `sell_amount`). **Withdraw still uses the Onramper redirect** until the fund-moving last mile lands.

### Still to do (fund-moving, next PR)
A gasless **send-USDC-to-arbitrary-address** primitive (EIP-3009) so we can auto-send to Coinbase's `to_address`, then flip Withdraw to the Coinbase off-ramp.

All defensive-parsed pending live verification. Backend + frontend `tsc` + `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)