### PR TITLE
Ramp: $1 minimum + on/off-ramp status notifications

### DIFF
--- a/app/server/src/routes/ramp.ts
+++ b/app/server/src/routes/ramp.ts
@@ -2,6 +2,7 @@ import { Router, type Request, type Response } from 'express';
 import { requireWalletMatch } from '../middleware/auth.js';
 import { coinbaseOnrampService, type NormalizedRampQuote } from '../services/coinbaseOnrampService.js';
 import { onramperStore } from '../services/onramperStore.js';
+import { notificationStore, type NotificationKind } from '../services/notificationStore.js';
 
 /*
  * Unified fiat↔crypto ramp API. One set of endpoints the frontend calls; the actual provider is chosen
@@ -260,6 +261,51 @@ router.get('/sell/status', async (req: Request, res: Response) => {
   } catch (error: any) {
     console.error('[ramp/sell/status]', error?.message || error);
     res.status(502).json({ error: 'Status check failed' });
+  }
+});
+
+// POST /api/ramp/event { type: 'buy'|'sell', status, amount, walletAddress, ref }
+//   Record a ramp order's status + fire a notification. Called by the client at the points it observes
+//   (checkout started, Apple Pay completed, cash-out sent). SEAM: a Coinbase webhook can call the same
+//   path later for provider-confirmed completed/failed even when the app is closed.
+const RAMP_NOTIFS: Record<string, { kind: NotificationKind; title: string; body: (amt: string) => string }> = {
+  'buy:submitted': { kind: 'pending', title: 'Deposit started', body: (a) => `Your ${a} top-up is processing.` },
+  'buy:completed': { kind: 'received', title: 'Money added', body: (a) => `${a} landed in your balance.` },
+  'buy:failed': { kind: 'system', title: 'Deposit didn’t go through', body: (a) => `Your ${a} top-up didn’t complete.` },
+  'sell:submitted': { kind: 'sent', title: 'Cash-out on its way', body: (a) => `${a} is being sent to your card.` },
+  'sell:completed': { kind: 'sent', title: 'Cash-out complete', body: (a) => `${a} has been paid out to your card.` },
+  'sell:failed': { kind: 'system', title: 'Cash-out failed', body: (a) => `Your ${a} cash-out didn’t complete.` },
+};
+router.post('/event', async (req: Request, res: Response) => {
+  const b = (req.body || {}) as Record<string, unknown>;
+  const type = String(b.type || '');
+  const status = String(b.status || '');
+  const amount = Number(b.amount);
+  const walletAddress = String(b.walletAddress || '').toLowerCase();
+  const ref = String(b.ref || '').trim();
+  const spec = RAMP_NOTIFS[`${type}:${status}`];
+  if (!spec || !ref || !/^0x[a-fA-F0-9]{40}$/.test(walletAddress)) {
+    res.status(400).json({ error: 'type/status, ref and walletAddress are required' });
+    return;
+  }
+  if (!requireWalletMatch(req, res, walletAddress, 'walletAddress')) return;
+  const amt = amount > 0 ? `$${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : 'Your';
+  try {
+    await onramperStore
+      .upsert({ id: `cb:${ref}`, wallet: walletAddress, status, provider: 'coinbase', fiatAmount: amount || null, cryptoAmount: null, raw: { type, ref } })
+      .catch(() => {});
+    await notificationStore.emit({
+      wallet: walletAddress,
+      kind: spec.kind,
+      title: spec.title,
+      body: spec.body(amt),
+      data: { type, status, amount: amount || null, href: type === 'sell' ? '/transactions' : '/' },
+      dedupeKey: `ramp:${ref}:${status}`,
+    }).catch(() => {});
+    res.json({ ok: true });
+  } catch (error) {
+    console.error('[ramp/event]', error);
+    res.json({ ok: false });
   }
 });
 

--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -7,7 +7,7 @@ import { useBridge } from '@/context/BridgeContext';
 import { useKyc } from '@/context/KycContext';
 import DepositInstructions from '@/components/app-ui/DepositInstructions';
 import { usePrivy } from '@privy-io/react-auth';
-import { getRampBuyQuote, createRampBuySession, createRampBuyOrder, getRampConfig, type RampQuote } from '@/utils/apiClient';
+import { getRampBuyQuote, createRampBuySession, createRampBuyOrder, getRampConfig, rampEvent, type RampQuote } from '@/utils/apiClient';
 import { cn } from '@/lib/utils';
 
 /*
@@ -67,6 +67,7 @@ const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits
 export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
   const [step, setStep] = useState<'amount' | 'review' | 'status' | 'pay'>('amount');
   const [payUrl, setPayUrl] = useState<string | null>(null); // Coinbase Apple Pay iframe (headless)
+  const [rampRef, setRampRef] = useState(''); // unique id per checkout attempt, for status notifications
   const [amountStr, setAmountStr] = useState('');
   const [methodId, setMethodId] = useState('card');
   const [walletId, setWalletId] = useState('');
@@ -109,6 +110,9 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
     }
     setCheckoutError(null);
     setCheckoutLoading(true);
+    const ref = crypto.randomUUID();
+    setRampRef(ref);
+    void rampEvent({ type: 'buy', status: 'submitted', amount, walletAddress: wallet.address, ref });
     // Apple Pay on Coinbase → headless order rendered in an in-app iframe (needs verified email + phone).
     if (methodId === 'applepay' && selected.p.id === 'coinbase' && buyerEmail && buyerPhone) {
       const { paymentLinkUrl } = await createRampBuyOrder({ amount, walletAddress: wallet.address, email: buyerEmail, phone: buyerPhone });
@@ -156,19 +160,6 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
     setCheckoutLoading(false);
   }, [open]);
 
-  // Coinbase's Apple Pay iframe posts transaction-status events; treat a success/completion as done.
-  useEffect(() => {
-    if (step !== 'pay') return;
-    const onMsg = (e: MessageEvent) => {
-      if (!/\.coinbase\.com$/.test((() => { try { return new URL(e.origin).hostname; } catch { return ''; } })())) return;
-      const d = e.data;
-      const s = typeof d === 'string' ? d : JSON.stringify(d ?? '');
-      if (/success|completed|complete|finished|TRANSACTION_STATUS_SUCCESS/i.test(s)) setStep('status');
-    };
-    window.addEventListener('message', onMsg);
-    return () => window.removeEventListener('message', onMsg);
-  }, [step]);
-
   // Whether the ramp provider is actually configured — lets us explain an empty quote (setup pending
   // vs no coverage) instead of a vague "no providers".
   useEffect(() => {
@@ -188,8 +179,24 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
   const amount = Number(amountStr) || 0;
   const method = METHODS.find((m) => m.id === methodId) ?? METHODS[0];
   const wallet = wallets.find((w) => w.id === walletId) ?? wallets[0] ?? { id: '', label: 'No wallet linked', address: '' };
-  const amountValid = amount >= 10 && amount <= 10000;
+  const amountValid = amount >= 1 && amount <= 10000;
   const isBank = methodId === 'bank';
+
+  // Coinbase's Apple Pay iframe posts transaction-status events; treat a success/completion as done.
+  useEffect(() => {
+    if (step !== 'pay') return;
+    const onMsg = (e: MessageEvent) => {
+      if (!/\.coinbase\.com$/.test((() => { try { return new URL(e.origin).hostname; } catch { return ''; } })())) return;
+      const d = e.data;
+      const s = typeof d === 'string' ? d : JSON.stringify(d ?? '');
+      if (/success|completed|complete|finished|TRANSACTION_STATUS_SUCCESS/i.test(s)) {
+        if (rampRef && wallet.address) void rampEvent({ type: 'buy', status: 'completed', amount, walletAddress: wallet.address, ref: rampRef });
+        setStep('status');
+      }
+    };
+    window.addEventListener('message', onMsg);
+    return () => window.removeEventListener('message', onMsg);
+  }, [step, rampRef, amount, wallet.address]);
   const quotes = isBank ? [] : apiQuotes;
   const best = quotes[0];
   const selected =
@@ -322,7 +329,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
             >
               Review
             </button>
-            <p className="mt-2 text-center text-[11px] text-muted-foreground">{amount > 10000 ? 'Max $10,000 per transaction' : 'Add $10–$10,000'}</p>
+            <p className="mt-2 text-center text-[11px] text-muted-foreground">{amount > 10000 ? 'Max $10,000 per transaction' : 'Add $1–$10,000'}</p>
           </div>
         )}
 

--- a/app/src/components/app-ui/WithdrawModal.tsx
+++ b/app/src/components/app-ui/WithdrawModal.tsx
@@ -13,7 +13,7 @@ import { useAppKitAccount } from '@/lib/walletCompat';
 import { ACTIVE_CHAIN_ID, clearContracts } from '@/lib/clearNetwork';
 import { gaslessWalletTransfer } from '@/lib/gaslessMoney';
 import { scTransferToken } from '@/lib/sendCalls';
-import { withdrawToBank, createRampSellSession, getRampSellStatus, type RampSellStatus, type Eip712TypedData } from '@/utils/apiClient';
+import { withdrawToBank, createRampSellSession, getRampSellStatus, rampEvent, type RampSellStatus, type Eip712TypedData } from '@/utils/apiClient';
 import { cn } from '@/lib/utils';
 
 /*
@@ -196,6 +196,7 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
             chainId: ACTIVE_CHAIN_ID,
           });
           if (cancelled) return;
+          void rampEvent({ type: 'sell', status: 'submitted', amount: Number(started.amount), walletAddress: address, ref: crypto.randomUUID() });
           setDone(true);
           if (!sourceWallet?.external) bal.applyOptimistic(-Number(started.amount), 0);
           return;
@@ -227,7 +228,7 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
   const selected = (providerId ? quotes.find((q) => q.p.id === providerId) : null) ?? best;
   const wallet = wallets.find((w) => w.id === walletId) ?? wallets[0] ?? { id: '', label: 'No wallet linked', address: '' };
   const bank = banks.find((b) => b.id === bankId) ?? banks[0] ?? { id: '', label: 'No bank linked' };
-  const amountValid = amount >= 10 && amount <= 10000;
+  const amountValid = amount >= 1 && amount <= 10000;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -317,7 +318,7 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
                 Review
               </button>
             )}
-            <p className="mt-2 text-center text-[11px] text-muted-foreground">{amount > 10000 ? 'Max $10,000 per transaction' : 'Withdraw $10–$10,000'}</p>
+            <p className="mt-2 text-center text-[11px] text-muted-foreground">{amount > 10000 ? 'Max $10,000 per transaction' : 'Withdraw $1–$10,000'}</p>
           </div>
         )}
 

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2512,10 +2512,21 @@ export async function createRampBuyOrder(p: {
   email: string;
   phone: string;
   paymentMethod?: 'GUEST_CHECKOUT_APPLE_PAY' | 'GUEST_CHECKOUT_CARD';
-}): Promise<{ paymentLinkUrl: string | null; error?: string; code?: string }> {
-  const r = await apiRequest<{ paymentLinkUrl: string | null }>(`/api/ramp/buy/order`, { method: 'POST', body: JSON.stringify(p) });
+}): Promise<{ paymentLinkUrl: string | null; orderId?: string; error?: string; code?: string }> {
+  const r = await apiRequest<{ paymentLinkUrl: string | null; orderId?: string }>(`/api/ramp/buy/order`, { method: 'POST', body: JSON.stringify(p) });
   if (r.error || !r.data) return { paymentLinkUrl: null, error: r.error || 'Order failed' };
-  return { paymentLinkUrl: r.data.paymentLinkUrl };
+  return { paymentLinkUrl: r.data.paymentLinkUrl, orderId: r.data.orderId };
+}
+
+/** Record a ramp order's status + fire a notification (deposit started/complete, cash-out sent, …). */
+export async function rampEvent(p: {
+  type: 'buy' | 'sell';
+  status: 'submitted' | 'completed' | 'failed';
+  amount: number;
+  walletAddress: string;
+  ref: string;
+}): Promise<void> {
+  await apiRequest(`/api/ramp/event`, { method: 'POST', body: JSON.stringify(p) }).catch(() => {});
 }
 
 /** Create a buy session → hosted checkout URL to redirect the user to. */


### PR DESCRIPTION
### $1 minimum
On-ramp and off-ramp now allow **$1–$10,000** (was $10). Note: Coinbase may enforce its own floor (~$2 is typical); if small buys get rejected live, say the word and I'll bump the UI min to $5.

### On/off-ramp status notifications (new — we had none)
`POST /api/ramp/event` records the order in `onramp_transactions` and fires a notification. Wired at the points the client observes:
- **Deposit started** when checkout opens → **Money added** on the Apple Pay iframe success.
- **Cash-out on its way** after the off-ramp auto-send lands.

Notification kinds: `pending` / `received` / `sent` / `system`, deduped per `ref:status`.

**Follow-up for provider-confirmed final status:** a Coinbase **webhook** (or a status poller) can call the same `/event` endpoint to emit `completed`/`failed` even when the app is closed — the mapping (`buy:completed`, `sell:failed`, …) is already in place. Right now we emit what we can observe client-side.

Backend + frontend `tsc` + `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)