### PR TITLE
Fix blank balances (missing /token-balances/batch route) + $5 ramp min

### DIFF
--- a/app/server/src/routes/tokenBalances.ts
+++ b/app/server/src/routes/tokenBalances.ts
@@ -143,6 +143,30 @@ router.get('/:chainId/:userAddress/:tokenAddress', async (req: Request, res: Res
 
 
 /**
+ * POST /api/token-balances/batch
+ * Per-token balance lookups for many { chainId, tokenAddress, userAddress } in one request. This is the
+ * fallback the client uses when Alchemy's "all tokens" discovery returns nothing — so USDC/CLRUSD still
+ * load via direct balanceOf. (The route was missing, so that fallback 404'd and balances went blank.)
+ * Body: { requests: [{ chainId, tokenAddress, userAddress }] } → { results: [...] }
+ */
+router.post('/batch', async (req: Request, res: Response) => {
+  try {
+    const { requests } = req.body as {
+      requests: Array<{ chainId: number; tokenAddress: string; userAddress: string }>;
+    };
+    if (!Array.isArray(requests) || requests.length === 0) {
+      return res.status(400).json({ error: 'Invalid request', message: 'requests must be a non-empty array' });
+    }
+    if (!requireWalletArrayMatch(req, res, requests.map((r) => r.userAddress), 'requests[].userAddress')) return;
+    const batch = await getTokenBalancesBatch(requests);
+    res.json({ results: batch.map((r) => ({ ...r, cached: false })) });
+  } catch (error) {
+    console.error('Token balances batch error:', error);
+    res.status(500).json({ error: 'Internal server error', message: error instanceof Error ? error.message : 'Unknown error' });
+  }
+});
+
+/**
  * POST /api/token-balances/all/batch
  * Get ALL token balances for multiple chains in one request
  * Body: { requests: [{ chainId, userAddress }] }

--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -179,7 +179,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
   const amount = Number(amountStr) || 0;
   const method = METHODS.find((m) => m.id === methodId) ?? METHODS[0];
   const wallet = wallets.find((w) => w.id === walletId) ?? wallets[0] ?? { id: '', label: 'No wallet linked', address: '' };
-  const amountValid = amount >= 1 && amount <= 10000;
+  const amountValid = amount >= 5 && amount <= 10000;
   const isBank = methodId === 'bank';
 
   // Coinbase's Apple Pay iframe posts transaction-status events; treat a success/completion as done.
@@ -329,7 +329,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
             >
               Review
             </button>
-            <p className="mt-2 text-center text-[11px] text-muted-foreground">{amount > 10000 ? 'Max $10,000 per transaction' : 'Add $1–$10,000'}</p>
+            <p className="mt-2 text-center text-[11px] text-muted-foreground">{amount > 10000 ? 'Max $10,000 per transaction' : 'Add $5–$10,000'}</p>
           </div>
         )}
 

--- a/app/src/components/app-ui/WithdrawModal.tsx
+++ b/app/src/components/app-ui/WithdrawModal.tsx
@@ -228,7 +228,7 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
   const selected = (providerId ? quotes.find((q) => q.p.id === providerId) : null) ?? best;
   const wallet = wallets.find((w) => w.id === walletId) ?? wallets[0] ?? { id: '', label: 'No wallet linked', address: '' };
   const bank = banks.find((b) => b.id === bankId) ?? banks[0] ?? { id: '', label: 'No bank linked' };
-  const amountValid = amount >= 1 && amount <= 10000;
+  const amountValid = amount >= 5 && amount <= 10000;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -318,7 +318,7 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
                 Review
               </button>
             )}
-            <p className="mt-2 text-center text-[11px] text-muted-foreground">{amount > 10000 ? 'Max $10,000 per transaction' : 'Withdraw $1–$10,000'}</p>
+            <p className="mt-2 text-center text-[11px] text-muted-foreground">{amount > 10000 ? 'Max $10,000 per transaction' : 'Withdraw $5–$10,000'}</p>
           </div>
         )}
 


### PR DESCRIPTION
### Balances
The `useMultichainBalances` hook falls back to `getTokenBalancesBatch` → `POST /api/token-balances/batch` when Alchemy's *all-tokens* discovery returns empty. **That route never existed** (the backend only had `/all/batch`), so the fallback 404'd and USDC/CLRUSD went blank.

**This is pre-existing, not the Coinbase work:**
- `git diff` of the ramp commits touched **zero** balance/token/alchemy files.
- The coinbase service **loads cleanly at runtime** (verified with bun).
- The preview backend is **healthy** (`/health` 200) and `/all/batch` responds — only `/batch` 404s.

Fix: add `POST /batch`, exposing the existing `balanceService.getTokenBalancesBatch` (per-token `balanceOf`), auth-matched, returning `{ results }`. Now the fallback works and balances load even when Alchemy's discovery hiccups.

### Ramp minimum
Bumped $1 → **$5** (Coinbase's own floor), per your call.

Backend + frontend `tsc` + `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)