### PR TITLE
Resilient balances: fail over Alchemy → public RPC during outages

### DIFF
--- a/app/server/src/services/balanceService.ts
+++ b/app/server/src/services/balanceService.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import { getRpcUrl, getAlchemyRestUrl } from '../utils/rpc.js';
+import { getRpcUrl, getRpcUrls, getAlchemyRestUrl } from '../utils/rpc.js';
 import { computeUnitTracker } from '../utils/computeUnitTracker.js';
 import { withRetry, createRetryProvider } from '../utils/rpcRetry.js';
 import { getRedisClient, CacheService, CacheKeys } from '../config/redis.js';
@@ -97,17 +97,12 @@ export async function getBalance(
 /**
  * Get ERC20 token balance for an address
  */
-export async function getTokenBalance(
+async function readTokenBalanceOnce(
+  rpcUrl: string,
   chainId: number,
   tokenAddress: string,
   userAddress: string
 ): Promise<TokenBalanceData | null> {
-  try {
-    const rpcUrl = getRpcUrl(chainId);
-    if (!rpcUrl) {
-      return null;
-    }
-
     // Use retry provider to handle rate limits and network issues
     const provider = createRetryProvider(rpcUrl, chainId);
     
@@ -182,13 +177,34 @@ export async function getTokenBalance(
       balance: ethers.formatUnits(balance, decimals),
       balanceRaw: balance.toString(),
     };
-  } catch (error) {
-    // Only log non-BAD_DATA errors to avoid spam
-    if (error && typeof error === 'object' && 'code' in error && error.code !== 'BAD_DATA') {
-      console.error(`Error fetching token balance for ${tokenAddress} on chain ${chainId}:`, error);
+}
+
+/**
+ * Read an ERC20 balance, failing over across RPC endpoints (custom → Alchemy → public node). During an
+ * Alchemy outage / regional maintenance the primary read throws, and we retry on the public Base RPC —
+ * so USDC/CLRUSD balances keep loading. A deterministic "not an ERC20" (BAD_DATA) returns null without
+ * trying others.
+ */
+export async function getTokenBalance(
+  chainId: number,
+  tokenAddress: string,
+  userAddress: string
+): Promise<TokenBalanceData | null> {
+  const urls = getRpcUrls(chainId);
+  if (urls.length === 0) return null;
+  for (let i = 0; i < urls.length; i++) {
+    try {
+      return await readTokenBalanceOnce(urls[i], chainId, tokenAddress, userAddress);
+    } catch (error: any) {
+      if (error?.code === 'BAD_DATA' || error?.shortMessage?.includes('could not decode')) return null;
+      if (i === urls.length - 1) {
+        console.error(`Error fetching token balance for ${tokenAddress} on chain ${chainId} (all RPCs failed):`, error?.message || error);
+        return null;
+      }
+      // RPC/network failure on this endpoint — try the next (e.g. Alchemy down → public node).
     }
-    return null;
   }
+  return null;
 }
 
 /**

--- a/app/server/src/utils/rpc.ts
+++ b/app/server/src/utils/rpc.ts
@@ -91,6 +91,39 @@ export function getRpcUrl(chainId: number): string {
 }
 
 /**
+ * All RPC URLs for a chain in failover order (custom → Alchemy → public fallback), deduped. Reads can
+ * try these in sequence so an Alchemy outage/region-maintenance falls back to the public node instead of
+ * failing. `getRpcUrl` (single) stays the default for writes; this is for resilient read paths.
+ */
+export function getRpcUrls(chainId: number): string[] {
+  const alchemyApiKey = process.env.ALCHEMY_API_KEY;
+  const custom: Record<number, string | undefined> = {
+    1: process.env.ETHEREUM_RPC_URL,
+    10: process.env.OPTIMISM_RPC_URL,
+    8453: process.env.BASE_RPC_URL,
+    100: process.env.GNOSIS_RPC_URL,
+    137: process.env.POLYGON_RPC_URL,
+    42161: process.env.ARBITRUM_RPC_URL,
+    11155111: process.env.SEPOLIA_RPC_URL,
+    84532: process.env.BASE_SEPOLIA_RPC_URL,
+    80001: process.env.MUMBAI_RPC_URL,
+  };
+  const publicFallback: Record<number, string> = {
+    1: 'https://eth.llamarpc.com',
+    10: 'https://mainnet.optimism.io',
+    8453: 'https://mainnet.base.org',
+    100: 'https://rpc.gnosischain.com',
+    137: 'https://polygon-rpc.com',
+    42161: 'https://arb1.arbitrum.io/rpc',
+    11155111: 'https://rpc.sepolia.org',
+    84532: 'https://sepolia.base.org',
+    80001: 'https://rpc-mumbai.maticvigil.com',
+  };
+  const alchemy = alchemyApiKey ? getAlchemyUrl(chainId, alchemyApiKey) : undefined;
+  return [...new Set([custom[chainId], alchemy, publicFallback[chainId]].filter(Boolean) as string[])];
+}
+
+/**
  * Check if RPC URL is available for a chain
  */
 export function hasRpcUrl(chainId: number): boolean {


### PR DESCRIPTION
### Why
The live balances went blank because of an **Alchemy incident** (Jul 3: *Degraded Data API Endpoints* + **US-West region maintenance** — the reporter is in California → routed to US-West). Our balance code is chain-agnostic and unchanged by the ramp work; it simply had **no failover** when Alchemy is down.

### Fix
- New `getRpcUrls(chainId)` returns an ordered failover list: **custom → Alchemy → public node**.
- `getTokenBalance` now tries each in turn: when Alchemy throws (region/network error), it retries on the **public Base RPC** (`https://mainnet.base.org`), so USDC/CLRUSD keep loading during an Alchemy outage. A deterministic `BAD_DATA` (not an ERC20) still returns null immediately.
- Pairs with the `POST /api/token-balances/batch` route added earlier so the client's "Alchemy Data API returned empty" fallback actually has a route to hit.

### Verified
- `getRpcUrls(8453)` ordering correct; on the server it'll be `[Alchemy, mainnet.base.org]`.
- A raw `balanceOf` against the public Base RPC returns real balances — the failover target works.

Backend `tsc` green. **Note:** transactions use Alchemy's Transfers (Data) API, which has no eth_call equivalent — those stay degraded until Alchemy recovers (offer to add a graceful-degrade there too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)