### PR TITLE
On-ramp: poll for real deposit completion (notify + refresh balance)

### DIFF
--- a/app/server/src/routes/ramp.ts
+++ b/app/server/src/routes/ramp.ts
@@ -209,6 +209,28 @@ router.post('/buy/order', async (req: Request, res: Response) => {
   }
 });
 
+// GET /api/ramp/buy/status?partnerUserRef=0x.. → { status, purchaseAmount, currency, txHash }
+//   Poll after checkout to confirm a deposit landed (works for both the hosted redirect and the iframe).
+router.get('/buy/status', async (req: Request, res: Response) => {
+  const ref = String(req.query.partnerUserRef || '').toLowerCase();
+  if (!/^0x[a-fA-F0-9]{40}$/.test(ref)) {
+    res.status(400).json({ error: 'partnerUserRef required' });
+    return;
+  }
+  if (!requireWalletMatch(req, res, ref, 'partnerUserRef')) return;
+  if (provider() !== 'coinbase') {
+    res.json({ status: null });
+    return;
+  }
+  try {
+    const status = await coinbaseOnrampService.getBuyStatus(ref);
+    res.json(status ?? { status: null });
+  } catch (error: any) {
+    console.error('[ramp/buy/status]', error?.message || error);
+    res.status(502).json({ error: 'Status check failed' });
+  }
+});
+
 // POST /api/ramp/sell/session { walletAddress, redirectUrl? } → { url, partnerUserRef }
 //   Opens the offramp cash-out flow. After the user confirms, poll /sell/status for the send instruction.
 router.post('/sell/session', async (req: Request, res: Response) => {

--- a/app/server/src/services/coinbaseOnrampService.ts
+++ b/app/server/src/services/coinbaseOnrampService.ts
@@ -229,6 +229,25 @@ export const coinbaseOnrampService = {
     return `${PAY_URL}/buy/select-asset?${q.toString()}`;
   },
 
+  /**
+   * Latest ON-ramp (buy) transaction for a partnerUserRef — used to confirm a deposit landed (so we can
+   * notify + refresh the balance) for both the hosted-redirect and the Apple Pay iframe flows.
+   */
+  async getBuyStatus(partnerUserRef: string): Promise<OnrampBuyStatus | null> {
+    const path = `/onramp/v1/buy/user/${encodeURIComponent(partnerUserRef)}/transactions?page_size=1`;
+    const data = await this.apiFetch('GET', path);
+    const tx = Array.isArray(data?.transactions) ? data.transactions[0] : undefined;
+    if (!tx) return null;
+    const amt = tx.purchase_amount || tx.purchaseAmount || {};
+    return {
+      status: String(tx.status || ''),
+      purchaseAmount: amt.value != null ? String(amt.value) : null,
+      currency: amt.currency ? String(amt.currency) : null,
+      txHash: tx.tx_hash ? String(tx.tx_hash) : null,
+      raw: tx,
+    };
+  },
+
   // ---- OFF-RAMP (sell → fiat) --------------------------------------------------------------------
   // Flow: open the offramp URL → user picks amount + cash-out destination on Coinbase → we poll the
   // status API → when it's STARTED with a to_address, our app sends that USDC on-chain → Coinbase pays
@@ -262,6 +281,14 @@ export const coinbaseOnrampService = {
     };
   },
 };
+
+export interface OnrampBuyStatus {
+  status: string; // TRANSACTION_STATUS_STARTED | _SUCCESS | _FAILED
+  purchaseAmount: string | null; // USDC bought
+  currency: string | null;
+  txHash: string | null;
+  raw?: unknown;
+}
 
 export interface OfframpStatus {
   status: string; // TRANSACTION_STATUS_STARTED | _SUCCESS | _FAILED

--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -7,7 +7,8 @@ import { useBridge } from '@/context/BridgeContext';
 import { useKyc } from '@/context/KycContext';
 import DepositInstructions from '@/components/app-ui/DepositInstructions';
 import { usePrivy } from '@privy-io/react-auth';
-import { getRampBuyQuote, createRampBuySession, createRampBuyOrder, getRampConfig, rampEvent, type RampQuote } from '@/utils/apiClient';
+import { getRampBuyQuote, createRampBuySession, createRampBuyOrder, getRampConfig, getRampBuyStatus, rampEvent, type RampQuote } from '@/utils/apiClient';
+import { useClearBalances } from '@/hooks/useClearBalances';
 import { cn } from '@/lib/utils';
 
 /*
@@ -92,6 +93,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
   const { user } = usePrivy();
   const buyerEmail = user?.email?.address || '';
   const buyerPhone = user?.phone?.number || '';
+  const bal = useClearBalances();
   // Card / Apple Pay on-ramps KYC at the provider; a bank/ACH deposit needs our KYC.
   const proceed = () => {
     if (methodId === 'bank' && !verified) openKyc(() => setStep('status'));
@@ -172,8 +174,37 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
   useEffect(() => {
     if (step !== 'status') return;
     setDone(false);
-    const t = setTimeout(() => setDone(true), 1700);
-    return () => clearTimeout(t);
+    // Bank transfers settle via Bridge separately — keep the optimistic confirmation.
+    if (isBank || !wallet.address) {
+      const t = setTimeout(() => setDone(true), 1700);
+      return () => clearTimeout(t);
+    }
+    // Card / Apple Pay: poll Coinbase until the deposit actually lands, then notify + refresh the balance.
+    let cancelled = false;
+    const deadline = Date.now() + 5 * 60_000;
+    const ref = rampRef || `${wallet.address}-buy`;
+    (async () => {
+      while (!cancelled && Date.now() < deadline) {
+        const s = await getRampBuyStatus(wallet.address).catch(() => ({ status: null as string | null }));
+        if (cancelled) return;
+        if (s.status === 'TRANSACTION_STATUS_SUCCESS') {
+          void rampEvent({ type: 'buy', status: 'completed', amount, walletAddress: wallet.address, ref });
+          bal.refresh(); // USDC has landed on-chain → pull the real balance
+          setDone(true);
+          return;
+        }
+        if (s.status === 'TRANSACTION_STATUS_FAILED') {
+          void rampEvent({ type: 'buy', status: 'failed', amount, walletAddress: wallet.address, ref });
+          setCheckoutError('Your deposit didn’t go through — you weren’t charged.');
+          return;
+        }
+        await new Promise((r) => setTimeout(r, 5000));
+      }
+      // Timed out still pending — show "on its way"; the balance poll will pick it up when it lands.
+      if (!cancelled) setDone(true);
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [step]);
 
   const amount = Number(amountStr) || 0;
@@ -189,14 +220,13 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
       if (!/\.coinbase\.com$/.test((() => { try { return new URL(e.origin).hostname; } catch { return ''; } })())) return;
       const d = e.data;
       const s = typeof d === 'string' ? d : JSON.stringify(d ?? '');
-      if (/success|completed|complete|finished|TRANSACTION_STATUS_SUCCESS/i.test(s)) {
-        if (rampRef && wallet.address) void rampEvent({ type: 'buy', status: 'completed', amount, walletAddress: wallet.address, ref: rampRef });
-        setStep('status');
-      }
+      // The iframe reports the Apple Pay press succeeded → move to the status step, which polls Coinbase
+      // for the real on-chain completion (and fires the "Money added" notification + balance refresh).
+      if (/success|completed|complete|finished|TRANSACTION_STATUS_SUCCESS/i.test(s)) setStep('status');
     };
     window.addEventListener('message', onMsg);
     return () => window.removeEventListener('message', onMsg);
-  }, [step, rampRef, amount, wallet.address]);
+  }, [step]);
   const quotes = isBank ? [] : apiQuotes;
   const best = quotes[0];
   const selected =

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2499,6 +2499,19 @@ export async function getRampSellStatus(partnerUserRef: string): Promise<RampSel
   return r.error || !r.data ? { status: null } : r.data;
 }
 
+export interface RampBuyStatus {
+  status: string | null; // TRANSACTION_STATUS_STARTED | _SUCCESS | _FAILED
+  purchaseAmount?: string | null;
+  currency?: string | null;
+  txHash?: string | null;
+}
+
+/** Poll an on-ramp (buy) transaction's status to confirm a deposit landed (both redirect + iframe paths). */
+export async function getRampBuyStatus(partnerUserRef: string): Promise<RampBuyStatus> {
+  const r = await apiRequest<RampBuyStatus>(`/api/ramp/buy/status?partnerUserRef=${encodeURIComponent(partnerUserRef)}`);
+  return r.error || !r.data ? { status: null } : r.data;
+}
+
 /** Which ramp provider is active + whether it's configured (so the UI can explain an empty quote). */
 export async function getRampConfig(): Promise<{ provider: string; configured: boolean }> {
   const r = await apiRequest<{ provider: string; configured: boolean }>(`/api/ramp/config`);


### PR DESCRIPTION
### The gap you hit
You got the "deposit started" notification but never a completion one, and the balance didn't move. Cause: we only had a best-effort **iframe postMessage** (Apple Pay) and **nothing** for the card new-tab flow, and the status screen just faked success after 1.7s — so nothing actually confirmed the deposit or refreshed the balance.

### Fix
The status step now **polls Coinbase's buy-transaction status** (works for both card and Apple Pay):
- `getBuyStatus` (`/onramp/v1/buy/user/{ref}/transactions`) + `GET /api/ramp/buy/status`.
- `TRANSACTION_STATUS_SUCCESS` → fires the **"Money added"** notification + `bal.refresh()` so the balance reflects the landed USDC.
- `FAILED` → surfaces it; 5-min timeout → "on its way" (the balance poll catches it when it lands).
- Removed the premature iframe-postMessage "completed" emit — the poll is the source of truth.

### Honest limitation
This is reliable **while the Add-money modal is open**. If you close the app before the deposit lands (on-ramps can take minutes), no completion notification fires. The bulletproof fix is a **Coinbase webhook** → the existing `/api/ramp/event` endpoint → notification + web push even when closed. Want me to wire that next? (Needs the webhook URL set in the CDP dashboard.)

Backend + frontend `tsc` + `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)