### PR TITLE
Coinbase ramp webhook: reliable, app-closed-safe status notifications

### DIFF
--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -31,6 +31,7 @@ import notificationsRouter from './routes/notifications.js';
 import requestsRouter from './routes/requests.js';
 import onramperRouter from './routes/onramper.js';
 import onramperWebhookRouter from './routes/onramperWebhook.js';
+import coinbaseRampWebhookRouter from './routes/coinbaseRampWebhook.js';
 import rampRouter from './routes/ramp.js';
 import { startPriceUpdater } from './jobs/priceUpdater.js';
 import { startPortfolioSnapshotter } from './jobs/portfolioSnapshotter.js';
@@ -188,6 +189,7 @@ async function startServer() {
     app.use('/api/member-links', memberWalletLinksPublicRouter);
     app.use('/api/avatars', avatarRouter);
     app.use('/api/webhooks/onramper', onramperWebhookRouter); // public; verified via signature
+    app.use('/api/webhooks/coinbase-ramp', coinbaseRampWebhookRouter); // public; verified via X-Hook0-Signature
     app.use('/api/stripe', requireAuth, stripeRouter);
     app.use('/api/members', requireAuth, membersRouter);
     app.use('/api/plaid', requireAuth, requireMemberCapability('canUsePlaid'), plaidRouter);

--- a/app/server/src/routes/coinbaseRampWebhook.ts
+++ b/app/server/src/routes/coinbaseRampWebhook.ts
@@ -1,0 +1,87 @@
+import crypto from 'crypto';
+import { Router, type Request, type Response } from 'express';
+import { emitRampStatus, type RampType, type RampStatus } from '../services/rampNotifications.js';
+
+/*
+ * Coinbase Onramp/Offramp webhook (PUBLIC, signature-verified) — the reliable, app-closed-safe source of
+ * ramp status notifications. Coinbase POSTs onramp.transaction.* / offramp.transaction.* events; we verify
+ * the X-Hook0-Signature (v0 = HMAC-SHA256 over `${t}.${rawBody}`), then emit the matching notification via
+ * the shared emitRampStatus (deduped per Coinbase transaction id, so it never doubles the client poll).
+ *
+ * Point Coinbase at:  https://<backend-domain>/api/webhooks/coinbase-ramp
+ * Set the subscription's metadata.secret as CDP_RAMP_WEBHOOK_SECRET.
+ * Docs: https://docs.cdp.coinbase.com/webhooks/onramp
+ */
+const router = Router();
+type RawBodyRequest = Request & { rawBody?: Buffer };
+
+function safeEq(a: string, b: string): boolean {
+  try {
+    return a.length === b.length && crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  } catch {
+    return false;
+  }
+}
+
+/** Verify the X-Hook0-Signature v0 field: HMAC-SHA256(secret, `${timestamp}.${rawBody}`), hex. */
+function verifyHook0(rawBody: string, header: string, secret: string): boolean {
+  if (!secret) return true; // no secret configured (dev) — accept, like the Onramper webhook
+  if (!header) return false;
+  const fields = Object.fromEntries(
+    header.split(',').map((p) => {
+      const i = p.indexOf('=');
+      return [p.slice(0, i).trim(), p.slice(i + 1).trim()];
+    }),
+  );
+  const t = fields.t;
+  const v0 = fields.v0;
+  if (!t || !v0) return false;
+  // Reject stale timestamps (replay protection) — 5-minute tolerance.
+  const ts = Number(t);
+  if (Number.isFinite(ts) && Math.abs(Date.now() / 1000 - ts) > 300) return false;
+  const computed = crypto.createHmac('sha256', secret).update(`${t}.${rawBody}`, 'utf8').digest('hex');
+  return safeEq(computed, v0);
+}
+
+router.post('/', async (req: RawBodyRequest, res: Response) => {
+  const secret = (process.env.CDP_RAMP_WEBHOOK_SECRET || '').trim();
+  const sig = String(req.headers['x-hook0-signature'] || req.headers['X-Hook0-Signature'] || '');
+  const rawStr = req.rawBody ? req.rawBody.toString('utf8') : JSON.stringify(req.body ?? {});
+  if (!verifyHook0(rawStr, sig, secret)) {
+    console.warn('[coinbase/webhook] signature verification failed');
+    res.status(401).json({ error: 'invalid signature' });
+    return;
+  }
+
+  try {
+    const e = (req.body || {}) as Record<string, any>;
+    const eventType = String(e.eventType || e.event_type || '');
+    // Only act on terminal states; created/updated are informational.
+    const status: RampStatus | null = eventType.endsWith('.success')
+      ? 'completed'
+      : eventType.endsWith('.failed')
+        ? 'failed'
+        : null;
+    const type: RampType = eventType.startsWith('offramp') ? 'sell' : 'buy';
+    // Wallet: guest-checkout uses walletAddress; the headless order uses destinationAddress; both carry
+    // partnerUserRef (which we set to the lowercased wallet).
+    const wallet = String(e.walletAddress || e.destinationAddress || e.partnerUserRef || '').toLowerCase();
+    // Amount: guest payload is an object { value }, the headless order is a plain string.
+    const rawAmt = e.purchaseAmount ?? e.sellAmount ?? e.amount;
+    const amount = Number(typeof rawAmt === 'object' && rawAmt ? rawAmt.value : rawAmt) || 0;
+    const ref = String(e.transactionId || e.orderId || `${wallet}-${eventType}`);
+
+    if (status && /^0x[a-fA-F0-9]{40}$/.test(wallet)) {
+      await emitRampStatus({ wallet, type, status, amount, ref });
+    } else {
+      console.log('[coinbase/webhook] ignored event', { eventType, hasWallet: /^0x/.test(wallet) });
+    }
+    res.json({ received: true });
+  } catch (error) {
+    // 200 so Coinbase doesn't retry-storm on a parse issue.
+    console.error('[coinbase/webhook] handler error', error);
+    res.status(200).json({ received: true });
+  }
+});
+
+export default router;

--- a/app/server/src/routes/ramp.ts
+++ b/app/server/src/routes/ramp.ts
@@ -2,7 +2,7 @@ import { Router, type Request, type Response } from 'express';
 import { requireWalletMatch } from '../middleware/auth.js';
 import { coinbaseOnrampService, type NormalizedRampQuote } from '../services/coinbaseOnrampService.js';
 import { onramperStore } from '../services/onramperStore.js';
-import { notificationStore, type NotificationKind } from '../services/notificationStore.js';
+import { emitRampStatus, type RampStatus, type RampType } from '../services/rampNotifications.js';
 
 /*
  * Unified fiat↔crypto ramp API. One set of endpoints the frontend calls; the actual provider is chosen
@@ -290,40 +290,19 @@ router.get('/sell/status', async (req: Request, res: Response) => {
 //   Record a ramp order's status + fire a notification. Called by the client at the points it observes
 //   (checkout started, Apple Pay completed, cash-out sent). SEAM: a Coinbase webhook can call the same
 //   path later for provider-confirmed completed/failed even when the app is closed.
-const RAMP_NOTIFS: Record<string, { kind: NotificationKind; title: string; body: (amt: string) => string }> = {
-  'buy:submitted': { kind: 'pending', title: 'Deposit started', body: (a) => `Your ${a} top-up is processing.` },
-  'buy:completed': { kind: 'received', title: 'Money added', body: (a) => `${a} landed in your balance.` },
-  'buy:failed': { kind: 'system', title: 'Deposit didn’t go through', body: (a) => `Your ${a} top-up didn’t complete.` },
-  'sell:submitted': { kind: 'sent', title: 'Cash-out on its way', body: (a) => `${a} is being sent to your card.` },
-  'sell:completed': { kind: 'sent', title: 'Cash-out complete', body: (a) => `${a} has been paid out to your card.` },
-  'sell:failed': { kind: 'system', title: 'Cash-out failed', body: (a) => `Your ${a} cash-out didn’t complete.` },
-};
 router.post('/event', async (req: Request, res: Response) => {
   const b = (req.body || {}) as Record<string, unknown>;
-  const type = String(b.type || '');
-  const status = String(b.status || '');
-  const amount = Number(b.amount);
+  const type = String(b.type || '') as RampType;
+  const status = String(b.status || '') as RampStatus;
   const walletAddress = String(b.walletAddress || '').toLowerCase();
   const ref = String(b.ref || '').trim();
-  const spec = RAMP_NOTIFS[`${type}:${status}`];
-  if (!spec || !ref || !/^0x[a-fA-F0-9]{40}$/.test(walletAddress)) {
+  if (!['buy', 'sell'].includes(type) || !['submitted', 'completed', 'failed'].includes(status) || !ref || !/^0x[a-fA-F0-9]{40}$/.test(walletAddress)) {
     res.status(400).json({ error: 'type/status, ref and walletAddress are required' });
     return;
   }
   if (!requireWalletMatch(req, res, walletAddress, 'walletAddress')) return;
-  const amt = amount > 0 ? `$${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : 'Your';
   try {
-    await onramperStore
-      .upsert({ id: `cb:${ref}`, wallet: walletAddress, status, provider: 'coinbase', fiatAmount: amount || null, cryptoAmount: null, raw: { type, ref } })
-      .catch(() => {});
-    await notificationStore.emit({
-      wallet: walletAddress,
-      kind: spec.kind,
-      title: spec.title,
-      body: spec.body(amt),
-      data: { type, status, amount: amount || null, href: type === 'sell' ? '/transactions' : '/' },
-      dedupeKey: `ramp:${ref}:${status}`,
-    }).catch(() => {});
+    await emitRampStatus({ wallet: walletAddress, type, status, amount: Number(b.amount) || 0, ref });
     res.json({ ok: true });
   } catch (error) {
     console.error('[ramp/event]', error);

--- a/app/server/src/services/coinbaseOnrampService.ts
+++ b/app/server/src/services/coinbaseOnrampService.ts
@@ -240,6 +240,7 @@ export const coinbaseOnrampService = {
     if (!tx) return null;
     const amt = tx.purchase_amount || tx.purchaseAmount || {};
     return {
+      id: String(tx.transaction_id || tx.transactionId || tx.order_id || tx.orderId || ''),
       status: String(tx.status || ''),
       purchaseAmount: amt.value != null ? String(amt.value) : null,
       currency: amt.currency ? String(amt.currency) : null,
@@ -283,6 +284,7 @@ export const coinbaseOnrampService = {
 };
 
 export interface OnrampBuyStatus {
+  id: string; // Coinbase transaction/order id — used as the notification dedupe ref
   status: string; // TRANSACTION_STATUS_STARTED | _SUCCESS | _FAILED
   purchaseAmount: string | null; // USDC bought
   currency: string | null;

--- a/app/server/src/services/rampNotifications.ts
+++ b/app/server/src/services/rampNotifications.ts
@@ -1,0 +1,41 @@
+import { notificationStore, type NotificationKind } from './notificationStore.js';
+import { onramperStore } from './onramperStore.js';
+
+/*
+ * Shared ramp (on/off-ramp) status → notification mapping. Used by the client-driven /api/ramp/event
+ * endpoint AND the Coinbase webhook, so a deposit/cash-out reads the same regardless of source. Deduped
+ * per (ref, status) — when both the client poll and the webhook report the same terminal status with the
+ * same Coinbase transaction id as the ref, only one notification is created.
+ */
+export type RampType = 'buy' | 'sell';
+export type RampStatus = 'submitted' | 'completed' | 'failed';
+
+const RAMP_NOTIFS: Record<string, { kind: NotificationKind; title: string; body: (amt: string) => string }> = {
+  'buy:submitted': { kind: 'pending', title: 'Deposit started', body: (a) => `Your ${a} top-up is processing.` },
+  'buy:completed': { kind: 'received', title: 'Money added', body: (a) => `${a} landed in your balance.` },
+  'buy:failed': { kind: 'system', title: 'Deposit didn’t go through', body: (a) => `Your ${a} top-up didn’t complete.` },
+  'sell:submitted': { kind: 'sent', title: 'Cash-out on its way', body: (a) => `${a} is being sent to your card.` },
+  'sell:completed': { kind: 'sent', title: 'Cash-out complete', body: (a) => `${a} has been paid out to your card.` },
+  'sell:failed': { kind: 'system', title: 'Cash-out failed', body: (a) => `Your ${a} cash-out didn’t complete.` },
+};
+
+/** Record a ramp order's status + emit the matching notification (idempotent by ref+status). */
+export async function emitRampStatus(input: { wallet: string; type: RampType; status: RampStatus; amount: number; ref: string }): Promise<void> {
+  const wallet = String(input.wallet || '').toLowerCase();
+  const spec = RAMP_NOTIFS[`${input.type}:${input.status}`];
+  if (!spec || !input.ref || !/^0x[a-fA-F0-9]{40}$/.test(wallet)) return;
+  const amt = input.amount > 0 ? `$${input.amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : 'Your';
+  await onramperStore
+    .upsert({ id: `cb:${input.ref}`, wallet, status: input.status, provider: 'coinbase', fiatAmount: input.amount || null, cryptoAmount: null, raw: { type: input.type, ref: input.ref } })
+    .catch(() => {});
+  await notificationStore
+    .emit({
+      wallet,
+      kind: spec.kind,
+      title: spec.title,
+      body: spec.body(amt),
+      data: { type: input.type, status: input.status, amount: input.amount || null, href: input.type === 'sell' ? '/transactions' : '/' },
+      dedupeKey: `ramp:${input.ref}:${input.status}`,
+    })
+    .catch(() => {});
+}

--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -182,11 +182,12 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
     // Card / Apple Pay: poll Coinbase until the deposit actually lands, then notify + refresh the balance.
     let cancelled = false;
     const deadline = Date.now() + 5 * 60_000;
-    const ref = rampRef || `${wallet.address}-buy`;
     (async () => {
       while (!cancelled && Date.now() < deadline) {
-        const s = await getRampBuyStatus(wallet.address).catch(() => ({ status: null as string | null }));
+        const s = await getRampBuyStatus(wallet.address).catch(() => ({ status: null as string | null, id: undefined }));
         if (cancelled) return;
+        // Use Coinbase's tx id as the ref so this dedupes with the webhook's notification.
+        const ref = s.id || rampRef || `${wallet.address}-buy`;
         if (s.status === 'TRANSACTION_STATUS_SUCCESS') {
           void rampEvent({ type: 'buy', status: 'completed', amount, walletAddress: wallet.address, ref });
           bal.refresh(); // USDC has landed on-chain → pull the real balance

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2500,6 +2500,7 @@ export async function getRampSellStatus(partnerUserRef: string): Promise<RampSel
 }
 
 export interface RampBuyStatus {
+  id?: string; // Coinbase transaction id — used as the notification dedupe ref (matches the webhook)
   status: string | null; // TRANSACTION_STATUS_STARTED | _SUCCESS | _FAILED
   purchaseAmount?: string | null;
   currency?: string | null;


### PR DESCRIPTION
Wires the Coinbase Onramp/Offramp **webhook** so deposit/cash-out **completion & failure** notify reliably — even when the app is closed (the gap the client poll couldn't cover).

### What's added
- **`/api/webhooks/coinbase-ramp`** (public, signature-verified). Verifies **`X-Hook0-Signature`** — v0 = `HMAC-SHA256(secret, \`${t}.${rawBody}\`)`, hex, with a 5-min replay window. Maps `onramp.transaction.success/failed` + `offramp.transaction.success/failed` → notifications.
- **`services/rampNotifications.ts`** — one status→notification mapping shared by the webhook **and** `/api/ramp/event`, deduped per `(ref, status)`.
- `getBuyStatus` returns Coinbase's **transaction id**; the client poll now uses it as the ref, so **poll + webhook dedupe to a single notification** (no doubles).

### Setup (CDP dashboard)
1. Create an Onramp/Offramp webhook subscription pointing at `https://<backend>/api/webhooks/coinbase-ramp`.
2. Set the subscription's `metadata.secret` as **`CDP_RAMP_WEBHOOK_SECRET`** on the backend. (If unset, the endpoint accepts unsigned — dev only; set it for production.)

### Verified
- Hook0 HMAC: valid signature accepted, forged rejected, header parsing correct.
- Backend + frontend `tsc` + `vite build` green.

Now the full lifecycle (started → completed/failed) fires server-side for both on- and off-ramp, with web push, regardless of what the user does with the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)