### PR TITLE
Instant balance refresh on money notifications

### DIFF
--- a/app/src/hooks/useClearBalances.ts
+++ b/app/src/hooks/useClearBalances.ts
@@ -111,6 +111,17 @@ export function ClearBalancesProvider({ children }: { children: ReactNode }) {
     return () => window.removeEventListener('focus', onFocus);
   }, [refreshTokens]);
 
+  // Refresh on a money action (send/transfer/deposit landed) — refetch now and again shortly, since the
+  // on-chain deposit can lag the confirmation by a few seconds.
+  useEffect(() => {
+    const onActivity = () => {
+      void refreshTokens(true);
+      setTimeout(() => void refreshTokens(true), 4000);
+    };
+    window.addEventListener('clear:activity', onActivity);
+    return () => window.removeEventListener('clear:activity', onActivity);
+  }, [refreshTokens]);
+
   // Reconcile: drop the optimistic overlay once the chain moves off the baseline or the TTL elapses.
   useEffect(() => {
     if (!pending) return;

--- a/app/src/hooks/useNotifications.ts
+++ b/app/src/hooks/useNotifications.ts
@@ -62,6 +62,8 @@ export function useNotifications() {
     const onNew = (n: ApiNotification) => {
       setNotifications((prev) => (prev.some((x) => x.id === n.id) ? prev : [n, ...prev].slice(0, 40)));
       setUnreadCount((c) => c + 1);
+      // Money moved (deposit landed / cash-out sent) → refresh balances + activity right away.
+      if (n.kind === 'received' || n.kind === 'sent') window.dispatchEvent(new Event('clear:activity'));
     };
     socket.on('notification:new', onNew);
     return () => {


### PR DESCRIPTION
When a `received`/`sent` notification arrives over WebSocket (e.g. the Coinbase webhook firing "Money added"), dispatch `clear:activity`. `useClearBalances` now listens to it (refetch now + again after 4s for indexer lag), like the linked-wallet and transaction hooks already do. So a landed deposit shows in the balance immediately instead of on the next poll.

`tsc` + `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)