### PR TITLE
Headless onramp: correct iframe attrs + real onramp_api events + sandbox mode

### DIFF
--- a/app/server/src/routes/coinbaseRampWebhook.ts
+++ b/app/server/src/routes/coinbaseRampWebhook.ts
@@ -65,7 +65,10 @@ router.post('/', async (req: RawBodyRequest, res: Response) => {
     const type: RampType = eventType.startsWith('offramp') ? 'sell' : 'buy';
     // Wallet: guest-checkout uses walletAddress; the headless order uses destinationAddress; both carry
     // partnerUserRef (which we set to the lowercased wallet).
-    const wallet = String(e.walletAddress || e.destinationAddress || e.partnerUserRef || '').toLowerCase();
+    // partnerUserRef may carry a `sandbox-` prefix (test mode); the wallet is what's after it.
+    const wallet = String(e.walletAddress || e.destinationAddress || e.partnerUserRef || '')
+      .replace(/^sandbox-/i, '')
+      .toLowerCase();
     // Amount: guest payload is an object { value }, the headless order is a plain string.
     const rawAmt = e.purchaseAmount ?? e.sellAmount ?? e.amount;
     const amount = Number(typeof rawAmt === 'object' && rawAmt ? rawAmt.value : rawAmt) || 0;

--- a/app/server/src/services/coinbaseOnrampService.ts
+++ b/app/server/src/services/coinbaseOnrampService.ts
@@ -40,6 +40,16 @@ function keySecret(): string | null {
   ).trim() || null;
 }
 
+/** Sandbox mode (RAMP_SANDBOX=true, set on dev/preview): transactions always succeed and the card is
+ *  never charged. Enabled by a `sandbox-` partnerUserRef prefix + a useApplePaySandbox=true URL param. */
+export function isRampSandbox(): boolean {
+  return /^(true|1|yes)$/i.test((process.env.RAMP_SANDBOX || '').trim());
+}
+/** Prefix a ref for sandbox so the order, the status poll and the webhook all agree on the same id. */
+export function sandboxRef(ref: string): string {
+  return isRampSandbox() && !ref.startsWith('sandbox-') ? `sandbox-${ref}` : ref;
+}
+
 /** Map the UI's payment-method id to Coinbase's enum. Guest checkout (no Coinbase login) is offered by
  *  the widget automatically when eligible, so we pass the plain method and let Coinbase pick the lane. */
 export function toCoinbasePaymentMethod(methodId?: string): string {
@@ -185,15 +195,16 @@ export const coinbaseOnrampService = {
       // The user is verified via Privy at login; we attest the verification time (no separate SMS step).
       phoneNumberVerifiedAt: now,
       agreementAcceptedAt: now,
-      partnerUserRef: params.partnerUserRef,
+      partnerUserRef: sandboxRef(params.partnerUserRef),
       domain: params.domain,
     });
-    const url = data?.paymentLink?.url || data?.payment_link?.url;
+    let url = data?.paymentLink?.url || data?.payment_link?.url;
     if (!url) {
       const err = new Error('Coinbase order payment link missing') as Error & { raw?: unknown };
       err.raw = data;
       throw err;
     }
+    if (isRampSandbox()) url = `${url}${String(url).includes('?') ? '&' : '?'}useApplePaySandbox=true`;
     return {
       paymentLinkUrl: String(url),
       paymentLinkType: data?.paymentLink?.paymentLinkType || data?.payment_link?.paymentLinkType,
@@ -234,7 +245,7 @@ export const coinbaseOnrampService = {
    * notify + refresh the balance) for both the hosted-redirect and the Apple Pay iframe flows.
    */
   async getBuyStatus(partnerUserRef: string): Promise<OnrampBuyStatus | null> {
-    const path = `/onramp/v1/buy/user/${encodeURIComponent(partnerUserRef)}/transactions?page_size=1`;
+    const path = `/onramp/v1/buy/user/${encodeURIComponent(sandboxRef(partnerUserRef))}/transactions?page_size=1`;
     const data = await this.apiFetch('GET', path);
     const tx = Array.isArray(data?.transactions) ? data.transactions[0] : undefined;
     if (!tx) return null;

--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -214,16 +214,29 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
   const amountValid = amount >= 5 && amount <= 10000;
   const isBank = methodId === 'bank';
 
-  // Coinbase's Apple Pay iframe posts transaction-status events; treat a success/completion as done.
+  // Coinbase's headless onramp iframe posts `onramp_api.*` events ({ eventName, data }). Once the user
+  // commits the payment we move to the status step, which polls Coinbase for the real on-chain completion
+  // (and fires the "Money added" notification + balance refresh). Cancel/error return to review.
   useEffect(() => {
     if (step !== 'pay') return;
     const onMsg = (e: MessageEvent) => {
-      if (!/\.coinbase\.com$/.test((() => { try { return new URL(e.origin).hostname; } catch { return ''; } })())) return;
-      const d = e.data;
-      const s = typeof d === 'string' ? d : JSON.stringify(d ?? '');
-      // The iframe reports the Apple Pay press succeeded → move to the status step, which polls Coinbase
-      // for the real on-chain completion (and fires the "Money added" notification + balance refresh).
-      if (/success|completed|complete|finished|TRANSACTION_STATUS_SUCCESS/i.test(s)) setStep('status');
+      const host = (() => { try { return new URL(e.origin).hostname; } catch { return ''; } })();
+      if (!/\.coinbase\.com$/.test(host)) return;
+      let eventName = '';
+      try {
+        const obj = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+        eventName = String(obj?.eventName || obj?.event || '');
+      } catch { /* non-JSON message — ignore */ }
+      if (eventName === 'onramp_api.commit_success' || eventName === 'onramp_api.polling_success') {
+        setStep('status');
+      } else if (eventName === 'onramp_api.cancel') {
+        setPayUrl(null);
+        setStep('review');
+      } else if (eventName === 'onramp_api.commit_error' || eventName === 'onramp_api.load_error' || eventName === 'onramp_api.polling_error') {
+        setPayUrl(null);
+        setCheckoutError('Payment couldn’t be completed — try again or use another method.');
+        setStep('review');
+      }
     };
     window.addEventListener('message', onMsg);
     return () => window.removeEventListener('message', onMsg);
@@ -624,6 +637,8 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
               title="Coinbase Pay"
               src={payUrl}
               allow="payment"
+              sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+              referrerPolicy="no-referrer"
               className="h-[420px] w-full rounded-xl border border-border bg-background"
             />
             <button


### PR DESCRIPTION
Validated the headless Apple Pay implementation against the [headless onramp docs](https://docs.cdp.coinbase.com/onramp/headless-onramp/overview) and fixed three things:

### 1. iframe attributes (required to load)
Added `sandbox="allow-scripts allow-same-origin allow-forms allow-popups"` and `referrerPolicy="no-referrer"` (docs mandate these), kept `allow="payment"`.

### 2. Real postMessage events
My handler was regex-guessing. It now parses the actual `onramp_api.*` events (`{ eventName, data }`):
- `commit_success` / `polling_success` → status step (then the buy-status poll confirms the on-chain completion).
- `cancel` → back to review.
- `commit_error` / `load_error` / `polling_error` → surface an error + back to review.

### 3. Sandbox test mode (`RAMP_SANDBOX=true`)
Set it on dev/preview to test onramps **without charging a real card** — transactions always succeed. Implemented per the docs: `sandbox-` `partnerUserRef` prefix + `useApplePaySandbox=true` on the payment link. `getBuyStatus` polls the same prefixed ref; the webhook strips it to recover the wallet.

### Setup note (Apple Pay web)
Per the docs, production Apple Pay in an iframe also needs the **domain verified** in the CDP portal (host their verification file), and the domain **must not be registered to another Apple Merchant ID**.

Backend + frontend `tsc` + `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)