### PR TITLE
On-ramp: auto-fallback to hosted checkout on Apple Pay iframe load_error

### DIFF
--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -232,7 +232,21 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
       } else if (eventName === 'onramp_api.cancel') {
         setPayUrl(null);
         setStep('review');
-      } else if (eventName === 'onramp_api.commit_error' || eventName === 'onramp_api.load_error' || eventName === 'onramp_api.polling_error') {
+      } else if (eventName === 'onramp_api.load_error') {
+        // The iframe couldn't initialize (commonly: domain not yet verified with Coinbase) → fall back to
+        // the hosted Coinbase checkout so the user isn't stuck on a blank Apple Pay sheet.
+        setPayUrl(null);
+        void (async () => {
+          const { url } = await createRampBuySession({ amount, paymentMethod: rampPM(methodId), walletAddress: wallet.address, quoteId });
+          if (url) {
+            window.open(url, '_blank', 'noopener,noreferrer');
+            setStep('status');
+          } else {
+            setCheckoutError('Couldn’t start checkout — try another amount or method.');
+            setStep('review');
+          }
+        })();
+      } else if (eventName === 'onramp_api.commit_error' || eventName === 'onramp_api.polling_error') {
         setPayUrl(null);
         setCheckoutError('Payment couldn’t be completed — try again or use another method.');
         setStep('review');


### PR DESCRIPTION
If the headless Apple Pay iframe reports `onramp_api.load_error` (it can't initialize — most commonly because the domain isn't yet verified with Coinbase), we now **automatically open the hosted Coinbase checkout** instead of showing an error and dead-ending on a blank Apple Pay sheet.

- `load_error` → hosted fallback (`createRampBuySession` → new tab → status poll).
- `commit_error` / `polling_error` → still surfaced as errors (those are real payment failures at pay-time, not a setup gap — falling back would just loop).

No new env var. So card + Apple Pay both work today via the hosted flow, and the in-app iframe takes over cleanly once the Coinbase domain-verification call is done.

`tsc` + `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)