### PR TITLE
Ramp: 'canceled' notification when a user backs out

### DIFF
--- a/app/server/src/routes/ramp.ts
+++ b/app/server/src/routes/ramp.ts
@@ -296,7 +296,7 @@ router.post('/event', async (req: Request, res: Response) => {
   const status = String(b.status || '') as RampStatus;
   const walletAddress = String(b.walletAddress || '').toLowerCase();
   const ref = String(b.ref || '').trim();
-  if (!['buy', 'sell'].includes(type) || !['submitted', 'completed', 'failed'].includes(status) || !ref || !/^0x[a-fA-F0-9]{40}$/.test(walletAddress)) {
+  if (!['buy', 'sell'].includes(type) || !['submitted', 'completed', 'failed', 'canceled'].includes(status) || !ref || !/^0x[a-fA-F0-9]{40}$/.test(walletAddress)) {
     res.status(400).json({ error: 'type/status, ref and walletAddress are required' });
     return;
   }

--- a/app/server/src/services/rampNotifications.ts
+++ b/app/server/src/services/rampNotifications.ts
@@ -8,15 +8,17 @@ import { onramperStore } from './onramperStore.js';
  * same Coinbase transaction id as the ref, only one notification is created.
  */
 export type RampType = 'buy' | 'sell';
-export type RampStatus = 'submitted' | 'completed' | 'failed';
+export type RampStatus = 'submitted' | 'completed' | 'failed' | 'canceled';
 
 const RAMP_NOTIFS: Record<string, { kind: NotificationKind; title: string; body: (amt: string) => string }> = {
   'buy:submitted': { kind: 'pending', title: 'Deposit started', body: (a) => `Your ${a} top-up is processing.` },
   'buy:completed': { kind: 'received', title: 'Money added', body: (a) => `${a} landed in your balance.` },
   'buy:failed': { kind: 'system', title: 'Deposit didn’t go through', body: (a) => `Your ${a} top-up didn’t complete.` },
+  'buy:canceled': { kind: 'system', title: 'Deposit canceled', body: (a) => `Your ${a} deposit was canceled.` },
   'sell:submitted': { kind: 'sent', title: 'Cash-out on its way', body: (a) => `${a} is being sent to your card.` },
   'sell:completed': { kind: 'sent', title: 'Cash-out complete', body: (a) => `${a} has been paid out to your card.` },
   'sell:failed': { kind: 'system', title: 'Cash-out failed', body: (a) => `Your ${a} cash-out didn’t complete.` },
+  'sell:canceled': { kind: 'system', title: 'Cash-out canceled', body: (a) => `Your ${a} cash-out was canceled.` },
 };
 
 /** Record a ramp order's status + emit the matching notification (idempotent by ref+status). */

--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ArrowLeft, Check, ChevronDown, CreditCard, Landmark, Loader2, Smartphone, ShieldCheck, Sparkles, Wallet, Zap, Send, type LucideIcon } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { useLinkedWallets } from '@/context/LinkedWalletsContext';
@@ -69,6 +69,9 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
   const [step, setStep] = useState<'amount' | 'review' | 'status' | 'pay'>('amount');
   const [payUrl, setPayUrl] = useState<string | null>(null); // Coinbase Apple Pay iframe (headless)
   const [rampRef, setRampRef] = useState(''); // unique id per checkout attempt, for status notifications
+  // Snapshot of an in-flight buy; set when checkout starts, cleared on completion. If the user backs out
+  // before it completes, we fire a "Deposit canceled" notification from this.
+  const pendingBuyRef = useRef<{ ref: string; amount: number; wallet: string } | null>(null);
   const [amountStr, setAmountStr] = useState('');
   const [methodId, setMethodId] = useState('card');
   const [walletId, setWalletId] = useState('');
@@ -114,6 +117,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
     setCheckoutLoading(true);
     const ref = crypto.randomUUID();
     setRampRef(ref);
+    pendingBuyRef.current = { ref, amount, wallet: wallet.address };
     void rampEvent({ type: 'buy', status: 'submitted', amount, walletAddress: wallet.address, ref });
     // Apple Pay on Coinbase → headless order rendered in an in-app iframe (needs verified email + phone).
     if (methodId === 'applepay' && selected.p.id === 'coinbase' && buyerEmail && buyerPhone) {
@@ -141,6 +145,21 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
       setCheckoutError('Could not start checkout — try another amount or method.');
     }
   };
+
+  // Fire a "Deposit canceled" notification if the user backs out of an in-flight buy before it completes.
+  const cancelDeposit = () => {
+    const p = pendingBuyRef.current;
+    if (!p) return;
+    pendingBuyRef.current = null;
+    void rampEvent({ type: 'buy', status: 'canceled', amount: p.amount, walletAddress: p.wallet, ref: p.ref });
+  };
+
+  // Backing out (closing the modal) before a started deposit completes → notify it was canceled.
+  useEffect(() => {
+    if (open) return;
+    cancelDeposit();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -189,12 +208,14 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
         // Use Coinbase's tx id as the ref so this dedupes with the webhook's notification.
         const ref = s.id || rampRef || `${wallet.address}-buy`;
         if (s.status === 'TRANSACTION_STATUS_SUCCESS') {
+          pendingBuyRef.current = null; // completed → don't fire a cancel on close
           void rampEvent({ type: 'buy', status: 'completed', amount, walletAddress: wallet.address, ref });
           bal.refresh(); // USDC has landed on-chain → pull the real balance
           setDone(true);
           return;
         }
         if (s.status === 'TRANSACTION_STATUS_FAILED') {
+          pendingBuyRef.current = null;
           void rampEvent({ type: 'buy', status: 'failed', amount, walletAddress: wallet.address, ref });
           setCheckoutError('Your deposit didn’t go through — you weren’t charged.');
           return;
@@ -230,6 +251,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
       if (eventName === 'onramp_api.commit_success' || eventName === 'onramp_api.polling_success') {
         setStep('status');
       } else if (eventName === 'onramp_api.cancel') {
+        cancelDeposit();
         setPayUrl(null);
         setStep('review');
       } else if (eventName === 'onramp_api.load_error') {
@@ -642,7 +664,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
         {step === 'pay' && payUrl && (
           <div className="flex flex-col px-4 pb-4 pt-2">
             <div className="mb-3 flex items-center gap-2 px-2">
-              <button type="button" onClick={() => setStep('review')} className="text-muted-foreground transition-colors hover:text-foreground">
+              <button type="button" onClick={() => { cancelDeposit(); setStep('review'); }} className="text-muted-foreground transition-colors hover:text-foreground">
                 <ArrowLeft className="h-4 w-4" />
               </button>
               <div className="text-sm font-semibold text-foreground">Pay {fmt(amount)} with Apple Pay</div>

--- a/app/src/components/app-ui/WithdrawModal.tsx
+++ b/app/src/components/app-ui/WithdrawModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { ArrowLeft, Check, ChevronDown, Landmark, Loader2, ShieldCheck, Sparkles, TriangleAlert, Wallet, Zap, type LucideIcon } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { useLinkedWallets } from '@/context/LinkedWalletsContext';
@@ -96,6 +96,9 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
   const [done, setDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [offrampStage, setOfframpStage] = useState<'idle' | 'waiting' | 'sending'>('idle');
+  // Set while an off-ramp is awaiting the user's Coinbase confirmation; if they back out first, fire a
+  // "Cash-out canceled" notification from this.
+  const pendingSellRef = useRef<{ amount: number; wallet: string } | null>(null);
   // Source can be the Clear account OR a linked wallet. Withdrawing from a linked wallet first moves its
   // USDC into the smart wallet (gasless, EIP-3009), then Bridge off-ramps the smart wallet (below).
   const { wallets, primaryId, openManager } = useLinkedWallets();
@@ -107,6 +110,21 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
   const { address, embeddedWalletInfo } = useAppKitAccount();
   const { getClientForChain } = useSmartWallets();
   const bal = useClearBalances();
+
+  // Fire a "Cash-out canceled" notification if the user backs out of an off-ramp before confirming it.
+  const cancelWithdraw = () => {
+    const p = pendingSellRef.current;
+    if (!p) return;
+    pendingSellRef.current = null;
+    void rampEvent({ type: 'sell', status: 'canceled', amount: p.amount, walletAddress: p.wallet, ref: crypto.randomUUID() });
+  };
+
+  // Closing the modal mid-cash-out (before the Coinbase confirmation) → notify it was canceled.
+  useEffect(() => {
+    if (open) return;
+    cancelWithdraw();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
   // Sign an EIP-3009 authorization with a SPECIFIC linked wallet's own provider (for move-then-withdraw).
   const signWithLinkedWallet = async (fromAddr: string, typedData: Eip712TypedData): Promise<string> => {
@@ -177,11 +195,17 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
             setDone(true);
             return;
           }
-          // Wait for the user to confirm in Coinbase, then send the exact USDC they cashed out.
+          // Wait for the user to confirm in Coinbase, then send the exact USDC they cashed out. Track it
+          // as pending so backing out before confirming fires a "Cash-out canceled" notification.
           setOfframpStage('waiting');
+          pendingSellRef.current = { amount, wallet: address };
           const started = await pollForOfframpSend(partnerUserRef, () => cancelled);
           if (cancelled) return;
-          if (!started) throw new Error('Timed out waiting for your Coinbase cash-out. Reopen Withdraw to try again.');
+          if (!started) {
+            cancelWithdraw();
+            throw new Error('Timed out waiting for your Coinbase cash-out. Reopen Withdraw to try again.');
+          }
+          pendingSellRef.current = null; // confirmed → send it (not a cancel)
           setOfframpStage('sending');
           const c = clearContracts(ACTIVE_CHAIN_ID);
           if (!c) throw new Error('Instant cash-out is unavailable on this network.');

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2535,7 +2535,7 @@ export async function createRampBuyOrder(p: {
 /** Record a ramp order's status + fire a notification (deposit started/complete, cash-out sent, …). */
 export async function rampEvent(p: {
   type: 'buy' | 'sell';
-  status: 'submitted' | 'completed' | 'failed';
+  status: 'submitted' | 'completed' | 'failed' | 'canceled';
   amount: number;
   walletAddress: string;
   ref: string;


### PR DESCRIPTION
When a user **starts** a deposit/cash-out (they get the 'started' notification) but **backs out without finishing**, they now get a **canceled** notification for closure.

### On-ramp → "Deposit canceled"
Fires when the user:
- cancels the Apple Pay iframe (`onramp_api.cancel`),
- taps the back arrow out of the pay step, or
- closes the Add-money modal while a started deposit hasn't completed.

### Off-ramp → "Cash-out canceled"
Fires when the user abandons the Coinbase off-ramp (the confirmation poll times out) or closes the Withdraw modal before confirming.

### Safety
A pending-ref snapshot is set when checkout starts and **cleared on completion/failure**, so a cancel can never fire after a real success. Notifications use kind `system` (no web push — a cancellation isn't push-worthy).

One tradeoff on the hosted (new-tab) card flow: if someone completes on Coinbase's page and closes our modal in the ~seconds before the status poll/webhook confirms, they could briefly see "canceled" then "Money added" — self-correcting via the webhook. Explicit cancels (iframe/back) are always accurate.

Backend + frontend `tsc` + `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)