### PR TITLE
Equity credits: 10% bill base, flat-200 rent, 1.5x Accelerated/streak (+ PWA anim polish)

### DIFF
--- a/app/server/src/services/memberStore.ts
+++ b/app/server/src/services/memberStore.ts
@@ -2316,6 +2316,23 @@ export class MemberStore {
     return result.rows[0]?.xmtp_address ?? null;
   }
 
+  /** Membership plan for any of a member's wallets (LIFETIME = Accelerated track, YEARLY = Standard). */
+  async getMembershipPlanByWallet(walletAddress: string): Promise<MemberMembershipPlan> {
+    await this.ensureReady();
+    const addr = normalizeWalletAddress(walletAddress);
+    const pool = this.mustPool();
+    const result = await withRetry(async () => {
+      return pool.query<{ membership_plan: MemberMembershipPlan }>(
+        `SELECT membership_plan FROM ${TABLE_MEMBERS}
+           WHERE primary_wallet = $1
+              OR id = (SELECT member_id FROM ${TABLE_WALLETS} WHERE wallet_address = $1 AND status = 'ACTIVE' LIMIT 1)
+           LIMIT 1`,
+        [addr],
+      );
+    });
+    return result.rows[0]?.membership_plan ?? null;
+  }
+
   private async resolveMemberByAuthInput(input: ResolveMemberAuthInput): Promise<MemberRecord | null> {
     const authSubject = normalizeOptionalString(input.authSubject ?? null, 255) ?? null;
     if (authSubject) {

--- a/app/server/src/services/payLedgerStore.ts
+++ b/app/server/src/services/payLedgerStore.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 import { getPayPool } from '../config/postgres.js';
 import { encryptSendContact, decryptSendContact } from '../utils/sendEncryption.js';
 import { notificationStore } from './notificationStore.js';
+import { memberStore } from './memberStore.js';
 
 /*
  * Clear Pay rent/bill → equity-credit ledger (off-chain, Railway Postgres). Append-only credit rows
@@ -18,9 +19,10 @@ export type EarnSource = 'in_app' | 'detected';
 
 const GRACE_DAYS = 3; // paid within N days of due_date still counts as on-time
 const VEST_DAYS = 30; // pending → vested clawback/settlement window
-const IN_APP_BONUS = 1.1; // paying through the app earns a 10% bonus
-const BILL_CREDIT_RATE = 0.5; // non-rent bills earn 1 equity credit per $2 paid
-const BILL_CREDIT_CAP = 500; // max BASE credits from a single non-rent bill (before streak/in-app bonus)
+const BILL_CREDIT_RATE = 0.1; // non-rent bills earn 10% of the payment as BASE credits
+const BILL_CREDIT_CAP = 500; // max BASE credits from a single non-rent bill (before the multiplier)
+const RENT_BASE_CREDITS = 200; // rent earns a flat base per on-time payment
+const MAX_MULTIPLIER = 1.5; // Accelerated-plan members + top on-time streaks
 const DEPOSIT_MATCH_PER_USD = 1; // equity credits matched per $1 deposited into the ESA vault
 const DEPOSIT_MATCH_MONTHLY_CAP = 1500; // max deposit-match credits awarded per calendar month
 
@@ -38,22 +40,24 @@ function num(v: unknown): number {
   return Number.isFinite(n) ? n : 0;
 }
 
-/** +5% per on-time month, capped at 12 (1.0×–1.6×). Mirrors the frontend streakMultiplier. */
-function streakMultiplier(streak: number): number {
-  return 1 + Math.min(Math.max(streak, 0), 12) * 0.05;
+/**
+ * Reward multiplier on the base credits. Accelerated-plan members (membershipPlan LIFETIME) get the full
+ * 1.5×; standard members ramp toward it with their on-time streak (+0.25× every 6 on-time months, capped
+ * at 1.5×). Mirrors the frontend rewardMultiplier.
+ */
+function rewardMultiplier(streak: number, accelerated: boolean): number {
+  if (accelerated) return MAX_MULTIPLIER;
+  return Math.min(1 + Math.floor(Math.max(streak, 0) / 6) * 0.25, MAX_MULTIPLIER);
 }
 
 /**
- * Equity credits for an on-time payment.
- *  - Rent: a flat 300 base × streak × in-app bonus, rounded to 5.
- *  - Non-rent bills: 1 credit per $2 paid, the BASE capped at 500, then × streak × in-app bonus
- *    (so a small dollar payment no longer earns the old flat 50). Rounded to the nearest credit.
+ * Equity credits for an on-time payment, rounded to the nearest credit:
+ *  - Rent: a flat 200 base (× multiplier → 300 for Accelerated / 12-month streaks).
+ *  - Non-rent bills: 10% of the payment, base capped at 500, × the multiplier.
  */
-function creditAmount(type: BillerType, streak: number, source: EarnSource, paidAmount: number): number {
-  const bonus = source === 'in_app' ? IN_APP_BONUS : 1;
-  const mult = streakMultiplier(streak) * bonus;
-  if (type === 'rent') return Math.round((300 * mult) / 5) * 5;
-  const base = Math.min(Math.max(paidAmount, 0) * BILL_CREDIT_RATE, BILL_CREDIT_CAP);
+function creditAmount(type: BillerType, streak: number, accelerated: boolean, paidAmount: number): number {
+  const mult = rewardMultiplier(streak, accelerated);
+  const base = type === 'rent' ? RENT_BASE_CREDITS : Math.min(Math.max(paidAmount, 0) * BILL_CREDIT_RATE, BILL_CREDIT_CAP);
   return Math.round(base * mult);
 }
 
@@ -176,14 +180,15 @@ function rowToBiller(r: Record<string, unknown>): Biller {
   };
 }
 
-/** Consecutive months (ending at the most recent) with an on-time rent payment. */
+/** Consecutive months (ending at the most recent) with an on-time payment of any kind (drives the reward
+ *  multiplier ramp). */
 async function computeStreak(wallet: string): Promise<number> {
   const pool = getPayPool();
   if (!pool) return 0;
   const r = await pool.query(
     `SELECT DISTINCT to_char(date_trunc('month', paid_at), 'YYYY-MM') AS m
        FROM pay_payments
-      WHERE wallet = $1 AND type = 'rent' AND on_time = true
+      WHERE wallet = $1 AND on_time = true
       ORDER BY m DESC`,
     [wallet],
   );
@@ -380,7 +385,8 @@ export const payLedgerStore = {
     if (!onTime) return { creditAwarded: 0, onTime, duplicate: false };
 
     const streak = await computeStreak(input.wallet);
-    const amount = creditAmount(input.type, streak, input.source, input.amount);
+    const accelerated = (await memberStore.getMembershipPlanByWallet(input.wallet).catch(() => null)) === 'LIFETIME';
+    const amount = creditAmount(input.type, streak, accelerated, input.amount);
     const vestUntil = new Date(paidAt);
     vestUntil.setDate(vestUntil.getDate() + VEST_DAYS);
     await pool.query(

--- a/app/src/components/PwaInstallTakeover.tsx
+++ b/app/src/components/PwaInstallTakeover.tsx
@@ -41,21 +41,21 @@ function detect(): { platform: Platform; standalone: boolean } {
 function GuideStep({ active, n, icon, children }: { active: boolean; n: number; icon: React.ReactNode; children: React.ReactNode }) {
   return (
     <motion.div
-      animate={{ scale: active ? 1.02 : 1 }}
-      transition={{ type: 'spring', stiffness: 300, damping: 22 }}
+      animate={{ scale: active ? 1.015 : 1 }}
+      transition={{ duration: 0.7, ease: [0.22, 1, 0.36, 1] }}
       className={cn(
-        'flex items-center gap-3 rounded-2xl border p-3 transition-colors',
+        'flex items-center gap-3 rounded-2xl border p-3 transition-colors duration-700',
         active ? 'border-info bg-info/10' : 'border-border bg-secondary/30',
       )}
     >
-      <span className={cn('relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl transition-colors', active ? 'bg-info text-white' : 'bg-secondary text-foreground')}>
+      <span className={cn('relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl transition-colors duration-700', active ? 'bg-info text-white' : 'bg-secondary text-foreground')}>
         {icon}
         {active && (
           <motion.span
             className="absolute inset-0 rounded-xl ring-2 ring-info"
-            initial={{ opacity: 0.6, scale: 1 }}
-            animate={{ opacity: 0, scale: 1.5 }}
-            transition={{ duration: 1.2, repeat: Infinity, ease: 'easeOut' }}
+            initial={{ opacity: 0.35, scale: 1 }}
+            animate={{ opacity: 0, scale: 1.28 }}
+            transition={{ duration: 2.6, repeat: Infinity, ease: 'easeInOut' }}
           />
         )}
       </span>
@@ -103,7 +103,7 @@ export default function PwaInstallTakeover() {
   // Drive the 2-step guide animation (~3s loop).
   useEffect(() => {
     if (!show || deferred) return;
-    const id = setInterval(() => setPhase((p) => (p + 1) % 2), 1600);
+    const id = setInterval(() => setPhase((p) => (p + 1) % 2), 3200);
     return () => clearInterval(id);
   }, [show, deferred]);
 

--- a/app/src/components/app-ui/PayModal.tsx
+++ b/app/src/components/app-ui/PayModal.tsx
@@ -4,7 +4,7 @@ import {
   Trash2, Wallet, Zap,
 } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
-import { usePay, creditsFor, streakMultiplier, BILL_TYPES, type Bill, type BillType } from '@/context/PayContext';
+import { usePay, creditsFor, rewardMultiplier, BILL_TYPES, type Bill, type BillType } from '@/context/PayContext';
 import { useExternalAccounts } from '@/context/ExternalAccountsContext';
 import { useClearBalances } from '@/hooks/useClearBalances';
 import { useMemberProfile } from '@/hooks/useMemberProfile';
@@ -52,7 +52,7 @@ export default function PayModal({
   const { bills, getBill, addBiller, updateBiller, removeBiller, setBillerPayout, payViaUsdc, streak, recordBillPayment } = usePay();
   const { accounts } = useExternalAccounts();
   const bal = useClearBalances();
-  const { email } = useMemberProfile();
+  const { email, accelerated } = useMemberProfile();
   const [va, setVa] = useState<BridgeVirtualAccount | null>(null);
   const sources: Source[] = [
     // Cash = USDC balance, exposed as a Bridge virtual account (account/routing) for ACH-style pulls.
@@ -177,8 +177,8 @@ export default function PayModal({
   const bill = billId ? getBill(billId) : undefined;
   const source = sources.find((s) => s.id === sourceId) ?? sources[0];
   const isRent = bill?.type === 'rent';
-  const credits = bill ? creditsFor(bill, streak, amount) : 0;
-  const mult = streakMultiplier(streak);
+  const credits = bill ? creditsFor(bill, streak, amount, accelerated) : 0;
+  const mult = rewardMultiplier(streak, accelerated);
 
   const saveBiller = () => {
     const amt = Number(draft.amount) || 0;
@@ -206,7 +206,7 @@ export default function PayModal({
 
   const creditsBadge = (b: Bill) => (
     <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-positive/10 px-1.5 py-0.5 text-[10px] font-medium text-positive">
-      <Sparkles className="h-3 w-3" /> +{fmtInt(creditsFor(b, streak))}
+      <Sparkles className="h-3 w-3" /> +{fmtInt(creditsFor(b, streak, 0, accelerated))}
     </span>
   );
 
@@ -483,7 +483,9 @@ export default function PayModal({
                 </span>
                 <div className="min-w-0 flex-1">
                   <div className="text-sm font-semibold text-foreground">+{fmtInt(credits)} Equity Credits</div>
-                  <div className="text-[11px] text-muted-foreground">Pay on time · {streak}-mo streak ({mult.toFixed(2)}×)</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    {accelerated ? `Accelerated track · ${mult.toFixed(2)}×` : `Pay on time · ${streak}-mo streak (${mult.toFixed(2)}×)`}
+                  </div>
                 </div>
                 <Award className="h-4 w-4 shrink-0 text-positive" />
               </div>

--- a/app/src/context/PayContext.tsx
+++ b/app/src/context/PayContext.tsx
@@ -52,25 +52,28 @@ export type BillerDraft = Omit<Bill, 'id' | 'icon' | 'source' | 'payable' | 'pay
 /** On-time streak fallback when no summary is loaded yet. */
 export const ON_TIME_STREAK = 0;
 
-/** Streak multiplier: +5% per on-time month, capped at 12 months (1.0×–1.6×). */
-export const streakMultiplier = (streak = ON_TIME_STREAK) => 1 + Math.min(Math.max(streak, 0), 12) * 0.05;
-
-/** Non-rent bills earn 1 equity credit per $2 paid, with the base capped here (before multipliers). */
-export const BILL_CREDIT_RATE = 0.5;
+/** Non-rent bills earn 10% of the payment as base credits (capped); rent earns a flat base. */
+export const BILL_CREDIT_RATE = 0.1;
 export const BILL_CREDIT_CAP = 500;
+export const RENT_BASE_CREDITS = 200;
+export const MAX_MULTIPLIER = 1.5;
 
 /**
- * Clear Pay equity credits for paying a bill ON TIME (preview of what the backend awards). Rent is a
- * flat 300 base; non-rent bills earn 1 credit per $2 paid (base capped at 500) — so a small dollar
- * payment no longer earns the old flat 50. Then × the on-time streak multiplier. NON-redeemable —
- * credits only count toward the Clear Deed milestone. Never interest/APY. Pass `amount` to price the
- * exact payment; otherwise the biller's default amount is used.
+ * Reward multiplier: Accelerated-track members get the full 1.5×; standard members ramp toward it with
+ * their on-time streak (+0.25× every 6 on-time months, capped at 1.5×). Mirrors the backend.
  */
-export const creditsFor = (bill: Pick<Bill, 'type' | 'amount'>, streak = ON_TIME_STREAK, amount = 0) => {
-  const mult = streakMultiplier(streak);
-  if (bill.type === 'rent') return Math.round((300 * mult) / 5) * 5;
-  const paid = amount > 0 ? amount : bill.amount || 0;
-  const base = Math.min(paid * BILL_CREDIT_RATE, BILL_CREDIT_CAP);
+export const rewardMultiplier = (streak = ON_TIME_STREAK, accelerated = false) =>
+  accelerated ? MAX_MULTIPLIER : Math.min(1 + Math.floor(Math.max(streak, 0) / 6) * 0.25, MAX_MULTIPLIER);
+
+/**
+ * Clear Pay equity credits for paying a bill ON TIME (preview of what the backend awards). Rent: flat
+ * 200 base. Non-rent bills: 10% of the payment (base capped at 500). Both × the reward multiplier
+ * (1.0–1.5, from the on-time streak or Accelerated track). NON-redeemable — credits only count toward
+ * the Clear Deed milestone. Never interest/APY. Pass `amount` for the exact payment; else the default.
+ */
+export const creditsFor = (bill: Pick<Bill, 'type' | 'amount'>, streak = ON_TIME_STREAK, amount = 0, accelerated = false) => {
+  const mult = rewardMultiplier(streak, accelerated);
+  const base = bill.type === 'rent' ? RENT_BASE_CREDITS : Math.min((amount > 0 ? amount : bill.amount || 0) * BILL_CREDIT_RATE, BILL_CREDIT_CAP);
   return Math.round(base * mult);
 };
 

--- a/app/src/hooks/useMemberProfile.ts
+++ b/app/src/hooks/useMemberProfile.ts
@@ -32,6 +32,8 @@ export interface MemberProfile {
   loading: boolean;
   /** Member lifecycle status; 'ONBOARDING' = brand-new, hasn't completed onboarding. null until loaded. */
   memberStatus: MemberStatus | null;
+  /** On the Accelerated track (membershipPlan LIFETIME) — earns the full 1.5× equity-credit multiplier. */
+  accelerated: boolean;
   refresh: () => void;
   /** Set/clear the local avatar (data URL); persists per-wallet in localStorage. */
   setAvatar: (dataUrl: string | null) => void;
@@ -40,7 +42,7 @@ export interface MemberProfile {
 
 const EMPTY: MemberProfile = {
   name: '', firstName: 'there', handle: '', email: '', phone: '', avatarUrl: null,
-  username: '', address: '', initials: 'CL', loading: false, memberStatus: null, refresh: () => {}, setAvatar: () => {}, raw: null,
+  username: '', address: '', initials: 'CL', loading: false, memberStatus: null, accelerated: false, refresh: () => {}, setAvatar: () => {}, raw: null,
 };
 
 const Ctx = createContext<MemberProfile | null>(null);
@@ -53,6 +55,7 @@ export function MemberProfileProvider({ children }: { children: ReactNode }) {
   const { address, isConnected } = useAppKitAccount();
   const [raw, setRaw] = useState<MemberProfileViewResponse | null>(null);
   const [memberStatus, setMemberStatus] = useState<MemberStatus | null>(null);
+  const [accelerated, setAccelerated] = useState(false);
   const [loading, setLoading] = useState(false);
   const [localAvatar, setLocalAvatar] = useState<string | null>(null);
 
@@ -72,6 +75,7 @@ export function MemberProfileProvider({ children }: { children: ReactNode }) {
     if (!isConnected) {
       setRaw(null);
       setMemberStatus(null);
+      setAccelerated(false);
       return;
     }
     setLoading(true);
@@ -83,9 +87,11 @@ export function MemberProfileProvider({ children }: { children: ReactNode }) {
       const r = await getMemberAccountCenter();
       setRaw(r?.profile ?? null);
       setMemberStatus(r?.member?.status ?? null);
+      setAccelerated(r?.member?.membershipPlan === 'LIFETIME');
     } catch {
       setRaw(null);
       setMemberStatus(null);
+      setAccelerated(false);
     } finally {
       setLoading(false);
     }
@@ -113,6 +119,7 @@ export function MemberProfileProvider({ children }: { children: ReactNode }) {
     initials: initialsOf(pub?.displayName || pub?.username || '', addr),
     loading,
     memberStatus,
+    accelerated,
     refresh: () => void load(),
     setAvatar,
     raw,


### PR DESCRIPTION
### New equity-credit reward model
Per the agreed spec:
- **Bills:** base = **10% of the payment**, capped at **500** (was 1 credit/$2).
- **Rent:** **flat 200** base (was flat 300).
- **Multiplier (1.0–1.5×):** **Accelerated-track** members (`membershipPlan = LIFETIME`) get **1.5× always**; standard members **ramp +0.25× every 6 on-time months**, capped at 1.5× (replaces the old streak + in-app bonus).
  - Rent = **200** standard / **300** Accelerated (or 12-month streak).
  - Bill $100 = 10 std / 15 accel; $1,000 = 100/150; $5,000 = 500(cap)/750.
- Streak now counts **any** on-time payment (not just rent).
- **Savings deposit match unchanged** — still 1:1 ("Every $1 you save earns $1").

Wires `memberStore.getMembershipPlanByWallet` into `recordPayment`, exposes `useMemberProfile.accelerated`, and updates the PayModal preview + the multiplier label ("Accelerated track · 1.50×" vs "N-mo streak").

### Also
- PWA install takeover animation is now **slower and gentler** (step switch 3.2s, 2.6s eased pulse, 700ms transitions).

Backend + frontend `tsc` + `vite build` green; new math verified numerically. (Existing credit rows keep their old values — this affects future payments only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)