### PR TITLE
Withdraw: remove Bridge from instant-to-debit providers

### DIFF
--- a/app/src/components/app-ui/WithdrawModal.tsx
+++ b/app/src/components/app-ui/WithdrawModal.tsx
@@ -50,8 +50,8 @@ interface Provider {
   feeRate: number;
   fixed: number;
 }
+// Instant-to-debit is a card rail — Bridge is ACH/bank only, so it's not an option here.
 const PROVIDERS: Provider[] = [
-  { id: 'bridge', name: 'Bridge', feeRate: 0.005, fixed: 0 },
   { id: 'coinbase', name: 'Coinbase Pay', feeRate: 0.01, fixed: 0 },
   { id: 'moonpay', name: 'MoonPay', feeRate: 0.02, fixed: 0 },
 ];


### PR DESCRIPTION
Bridge does ACH/bank withdrawals via the virtual account — not instant-to-debit card cash-outs — so it no longer shows up as an instant-debit "provider" option in Withdraw. (The list is cosmetic; the real instant rail is Coinbase, decided by method.) Card deposit already only surfaces the real ramp provider, so nothing to change there.

Leaving the rest of that legacy for later per your call (the fake multi-provider selector + the bank-centric copy on the instant card path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)