### PR TITLE
Withdraw: remove MoonPay placeholder provider

### DIFF
--- a/app/src/components/app-ui/WithdrawModal.tsx
+++ b/app/src/components/app-ui/WithdrawModal.tsx
@@ -50,10 +50,10 @@ interface Provider {
   feeRate: number;
   fixed: number;
 }
-// Instant-to-debit is a card rail — Bridge is ACH/bank only, so it's not an option here.
+// Instant-to-debit is a card rail routed through Coinbase. (Bridge = ACH/bank only; MoonPay was never
+// integrated — both were placeholder scaffolding.)
 const PROVIDERS: Provider[] = [
   { id: 'coinbase', name: 'Coinbase Pay', feeRate: 0.01, fixed: 0 },
-  { id: 'moonpay', name: 'MoonPay', feeRate: 0.02, fixed: 0 },
 ];
 
 const QUICK = [50, 100, 250, 500];


### PR DESCRIPTION
MoonPay was never a real integration (placeholder scaffolding from the original Withdraw modal build). Removed it from the instant-to-debit provider list — Coinbase is the only real rail. The selector/copy cleanup is still deferred per earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)