### PR TITLE
Send status/notifications: sent · received · claimed · expired

### DIFF
--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -38,6 +38,7 @@ import { startPortfolioSnapshotter } from './jobs/portfolioSnapshotter.js';
 import { startAutopayRunner } from './jobs/autopayRunner.js';
 import { startDueBillNotifier } from './jobs/dueBillNotifier.js';
 import { startGreetingNotifier } from './jobs/greetingNotifier.js';
+import { startSendExpiryNotifier } from './jobs/sendExpiryNotifier.js';
 import { websocketService } from './services/websocketService.js';
 import { eventListenerService } from './services/eventListenerService.js';
 
@@ -261,6 +262,9 @@ async function startServer() {
     });
     startGreetingNotifier().catch((error) => {
       console.error('⚠️ Greeting notifier failed to start:', error);
+    });
+    startSendExpiryNotifier().catch((error) => {
+      console.error('⚠️ Send-expiry notifier failed to start:', error);
     });
 
     // Start HTTP server (Express + WebSocket)

--- a/app/server/src/jobs/sendExpiryNotifier.ts
+++ b/app/server/src/jobs/sendExpiryNotifier.ts
@@ -1,0 +1,38 @@
+import { sendTransferStore } from '../services/sendTransferStore.js';
+import { notificationStore } from '../services/notificationStore.js';
+
+/*
+ * Hourly scheduled producer: flips past-expiry unclaimed send transfers to EXPIRED and notifies each
+ * sender exactly once that their claim-link went unclaimed. The DB UPDATE ... RETURNING sweep is the
+ * idempotency guard (a transfer only flips once), and the notification dedupe key is a second guard.
+ * See services/sendTransferStore.ts (expireStaleTransfers) and routes/send.ts (the lazy per-claim
+ * expiry check that this backstops for links no recipient ever revisits).
+ */
+const CHECK_MS = 60 * 60 * 1000; // hourly
+
+async function run(): Promise<void> {
+  if (!sendTransferStore.isConfigured()) return;
+  try {
+    const expired = await sendTransferStore.expireStaleTransfers();
+    for (const t of expired) {
+      const usd = Number(t.principalUsdc) / 1_000_000;
+      await notificationStore
+        .emit({
+          wallet: t.senderWallet,
+          kind: 'system',
+          title: 'Payment expired',
+          body: `Your $${usd.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} payment wasn't claimed in time`,
+          data: { transferId: t.id, href: '/transactions' },
+          dedupeKey: `send:${t.id}:expired`,
+        })
+        .catch(() => {});
+    }
+  } catch (e) {
+    console.error('[sendExpiryNotifier] error', e);
+  }
+}
+
+export async function startSendExpiryNotifier(): Promise<void> {
+  await run();
+  setInterval(() => void run(), CHECK_MS);
+}

--- a/app/server/src/routes/send.ts
+++ b/app/server/src/routes/send.ts
@@ -39,6 +39,44 @@ async function notifyRecipientOfSend(updatedTransfer: {
     console.error('Recipient in-app notification error:', error);
   }
 }
+
+const fmtUsd = (n: number) => n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+/** Notify the SENDER their payment went out (offline-safe confirmation, independent of the on-chain watcher). */
+async function notifySenderSent(transfer: { id: number; senderWallet: string; principalUsdc: string }): Promise<void> {
+  try {
+    const usd = Number(transfer.principalUsdc) / 1_000_000;
+    await notificationStore.emit({
+      wallet: transfer.senderWallet,
+      kind: 'sent',
+      title: 'Payment sent',
+      body: `You sent $${fmtUsd(usd)}`,
+      data: { transferId: transfer.id, href: '/transactions' },
+      dedupeKey: `send:${transfer.id}:sent`,
+    });
+  } catch (error) {
+    console.error('Sender sent notification error:', error);
+  }
+}
+
+/** Notify the SENDER when the recipient claims their payment. */
+async function notifySenderClaimed(transferRowId: number): Promise<void> {
+  try {
+    const transfer = await sendTransferStore.getTransferById(transferRowId);
+    if (!transfer) return;
+    const usd = Number(transfer.principalUsdc) / 1_000_000;
+    await notificationStore.emit({
+      wallet: transfer.senderWallet,
+      kind: 'sent',
+      title: 'Payment claimed',
+      body: `Your $${fmtUsd(usd)} payment was claimed`,
+      data: { transferId: transfer.id, href: '/transactions' },
+      dedupeKey: `send:${transfer.id}:claimed`,
+    });
+  } catch (error) {
+    console.error('Sender claimed notification error:', error);
+  }
+}
 import { sendBridgeWebhookVerifier } from '../services/sendBridgeWebhookVerifier.js';
 import { sendPayoutService } from '../services/sendPayoutService.js';
 import { sendStripePayoutService } from '../services/sendStripePayoutService.js';
@@ -252,17 +290,10 @@ async function markTransferClaimedFromMethod(
   transferRowId: number,
   method: 'DEBIT' | 'BANK' | 'WALLET'
 ): Promise<void> {
-  if (method === 'DEBIT') {
-    await sendTransferStore.markTransferClaimed(transferRowId, 'CLAIMED_DEBIT');
-    return;
-  }
-
-  if (method === 'BANK') {
-    await sendTransferStore.markTransferClaimed(transferRowId, 'CLAIMED_BANK');
-    return;
-  }
-
-  await sendTransferStore.markTransferClaimed(transferRowId, 'CLAIMED_WALLET');
+  const status = method === 'DEBIT' ? 'CLAIMED_DEBIT' : method === 'BANK' ? 'CLAIMED_BANK' : 'CLAIMED_WALLET';
+  await sendTransferStore.markTransferClaimed(transferRowId, status);
+  // Let the sender know their payment landed (idempotent via the dedupe key).
+  await notifySenderClaimed(transferRowId);
 }
 
 async function ensureSendStoreReady(res: Response): Promise<boolean> {
@@ -344,6 +375,37 @@ const payoutRateLimiter = createLocalRateLimiter({
 });
 
 const senderRouter = Router();
+
+/**
+ * Record a direct (non-escrow) wallet→wallet transfer the client executed itself, so both parties get
+ * an immediate in-app notification without waiting on the on-chain watcher. The sender is always the
+ * authenticated wallet (no spoofing). Deduped on the tx hash with the SAME keys the watcher uses
+ * (tx:<hash>:out / :in), so whichever fires first wins and the other is a no-op.
+ */
+senderRouter.post('/notify-direct', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const from = req.auth?.walletAddress;
+    if (!from) return res.status(401).json({ error: 'Unauthorized' });
+    const body = (req.body ?? {}) as { to?: string; amount?: number | string; txHash?: string; chainId?: number };
+    if (!body.to || !isAddress(body.to)) {
+      return res.status(400).json({ error: 'Invalid recipient address' });
+    }
+    const amount = Number(body.amount);
+    const label = Number.isFinite(amount) && amount > 0 ? `$${fmtUsd(amount)}` : 'funds';
+    const hashKey = typeof body.txHash === 'string' && body.txHash ? body.txHash : `${from}-${body.to}-${Date.now()}`;
+    const data = { txHash: body.txHash ?? null, chainId: body.chainId ?? null, href: '/transactions' };
+    await notificationStore
+      .emit({ wallet: from, kind: 'sent', title: 'Payment sent', body: `You sent ${label}`, data, dedupeKey: `tx:${hashKey}:out` })
+      .catch(() => {});
+    await notificationStore
+      .emit({ wallet: body.to, kind: 'received', title: 'Money received', body: `You received ${label}`, data, dedupeKey: `tx:${hashKey}:in` })
+      .catch(() => {});
+    return res.json({ ok: true });
+  } catch (error) {
+    console.error('notify-direct error:', error);
+    return res.status(500).json({ error: 'Failed to record notification' });
+  }
+});
 
 senderRouter.post('/transfers/prepare', requireAuth, async (req: Request, res: Response) => {
   if (!(await ensureSendStoreReady(res))) return;
@@ -625,8 +687,9 @@ senderRouter.post('/transfers/:id/confirm-lock', requireAuth, async (req: Reques
       console.error('Claim link notification error:', error);
     }
 
-    // Our own send event → notify the recipient in-app (offline-safe, no watcher dependency).
+    // Our own send event → notify both parties in-app (offline-safe, no watcher dependency).
     await notifyRecipientOfSend(updatedTransfer);
+    await notifySenderSent(updatedTransfer);
 
     return res.json({
       transfer: publicTransferView(updatedTransfer),
@@ -781,8 +844,9 @@ senderRouter.post('/transfers/:id/submit-authorization', requireAuth, async (req
       console.error('Claim link notification error:', error);
     }
 
-    // Our own send event → notify the recipient in-app (offline-safe, no watcher dependency).
+    // Our own send event → notify both parties in-app (offline-safe, no watcher dependency).
     await notifyRecipientOfSend(updatedTransfer);
+    await notifySenderSent(updatedTransfer);
 
     return res.json({
       transfer: publicTransferView(updatedTransfer),

--- a/app/server/src/services/sendTransferStore.ts
+++ b/app/server/src/services/sendTransferStore.ts
@@ -617,6 +617,34 @@ class SendTransferStore {
     });
   }
 
+  /**
+   * Atomically mark every past-expiry unclaimed transfer as EXPIRED and return the ones that just
+   * flipped, so the expiry-notifier can alert each sender exactly once (UPDATE ... RETURNING is the
+   * idempotency guard — a transfer already EXPIRED won't be returned again).
+   */
+  async expireStaleTransfers(): Promise<Array<{ id: number; senderWallet: string; principalUsdc: string }>> {
+    await this.ensureReady();
+    const pool = this.mustPool();
+
+    const result = await withRetry(async () => {
+      return pool.query<{ id: number; sender_wallet: string; principal_usdc: string }>(
+        `
+        UPDATE ${TABLE_SEND_TRANSFERS}
+        SET status = 'EXPIRED', updated_at = NOW()
+        WHERE status IN ('LOCK_CONFIRMED', 'CLAIM_STARTED')
+          AND expires_at < NOW()
+        RETURNING id, sender_wallet, principal_usdc
+        `
+      );
+    });
+
+    return result.rows.map((r) => ({
+      id: r.id,
+      senderWallet: r.sender_wallet,
+      principalUsdc: r.principal_usdc,
+    }));
+  }
+
   async getSenderPrincipalTotalInWindow(senderWallet: string, windowStart: Date, windowEnd: Date): Promise<bigint> {
     await this.ensureReady();
     const pool = this.mustPool();

--- a/app/src/components/app-ui/SendModal.tsx
+++ b/app/src/components/app-ui/SendModal.tsx
@@ -12,7 +12,7 @@ import { useContacts, contactInitials } from '@/context/ContactsContext';
 import { useLinkedWallets } from '@/context/LinkedWalletsContext';
 import { useClearBalances } from '@/hooks/useClearBalances';
 import { useLinkedWalletBalances } from '@/hooks/useLinkedWalletBalances';
-import { prepareSendTransfer, confirmSendTransferLock } from '@/utils/apiClient';
+import { prepareSendTransfer, confirmSendTransferLock, notifyDirectSend } from '@/utils/apiClient';
 import { gaslessSendLock } from '@/lib/gaslessMoney';
 import { scSendLock, scTransferToken } from '@/lib/sendCalls';
 import { linkedWalletTokenTransfer } from '@/lib/linkedWalletTransfer';
@@ -122,17 +122,20 @@ export default function SendModal({ open, onOpenChange }: { open: boolean; onOpe
         //    from the Clear smart wallet OR a linked wallet, and avoids the escrow's testnet BigInt issue.
         if (recipientWallet) {
           const to = recipientWallet as `0x${string}`;
+          let txHash: string | undefined;
           if (source.kind === 'linked') {
             const provider = await getLinkedProvider(source.address);
-            await linkedWalletTokenTransfer({ provider, from: source.address as `0x${string}`, token: tokenAddr, to, amount: amountStr, chainId });
+            txHash = await linkedWalletTokenTransfer({ provider, from: source.address as `0x${string}`, token: tokenAddr, to, amount: amountStr, chainId });
           } else {
             const chainClient = isSmartAccount ? await getClientForChain({ id: chainId }) : undefined;
-            await scTransferToken({ smartWalletClient: chainClient, ownerWallet: address, token: tokenAddr, to, amount: amountStr, chainId });
+            txHash = await scTransferToken({ smartWalletClient: chainClient, ownerWallet: address, token: tokenAddr, to, amount: amountStr, chainId });
           }
           if (cancelled) return;
           setClaimUrl(null);
           setDone(true);
           if (source.kind === 'clear') bal.applyOptimistic(token === 'usdc' ? -sent : 0, token === 'clrusd' ? -sent : 0);
+          // Immediate in-app "sent"/"received" for both parties (deduped with the on-chain watcher).
+          void notifyDirectSend({ to, amount: sent, txHash, chainId });
           return;
         }
 

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -1127,6 +1127,23 @@ export async function prepareSendTransfer(
   return response.data;
 }
 
+/**
+ * Record a direct (non-escrow) wallet→wallet send so both parties get an immediate in-app
+ * notification without waiting on the on-chain watcher. Best-effort — the watcher is the fallback.
+ */
+export async function notifyDirectSend(input: {
+  to: string;
+  amount: number;
+  txHash?: string;
+  chainId?: number;
+}): Promise<void> {
+  try {
+    await apiRequest('/api/send/notify-direct', { method: 'POST', body: JSON.stringify(input) });
+  } catch {
+    // non-fatal; the transfer already happened on-chain
+  }
+}
+
 export async function confirmSendTransferLock(
   id: number,
   payload: ConfirmSendTransferLockRequest


### PR DESCRIPTION
Adds a consistent notification lifecycle across every send path so both parties always know where a payment stands.

## What
- **Sender "Payment sent"** + **Recipient "Money received"** — for both the escrow (email/phone claim-link) path and direct wallet→wallet sends.
- **Sender "Payment claimed"** — when the recipient claims (any payout method: debit/bank/wallet).
- **Sender "Payment expired"** — new hourly job sweeps past-expiry unclaimed transfers and alerts the sender once.

## How
- `notifySenderSent` / `notifySenderClaimed` in `routes/send.ts`; wired into both confirm sites and `markTransferClaimedFromMethod`.
- New `POST /api/send/notify-direct` (authed; sender = the JWT wallet, no spoofing) gives direct wallet sends an **immediate** in-app notification for both parties, **deduped on `tx:<hash>:out/:in`** so it never doubles with the on-chain watcher. Called from `SendModal` with the returned tx hash.
- New `sendExpiryNotifier` job + `sendTransferStore.expireStaleTransfers()` (atomic `UPDATE ... RETURNING` = fire-once), backstopping the lazy per-claim expiry check for links no recipient revisits.

## Notes
- Expiry copy is honest ("wasn't claimed in time") — there is no auto-reclaim of funds yet; a sender-reclaim flow is a separate follow-up.
- Card/Apple-Pay-funded **auto-send** (deposit → send) is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)