### PR TITLE
Notifications: poll the bell like balances (fix lag until refresh)

### DIFF
--- a/app/src/hooks/useNotifications.ts
+++ b/app/src/hooks/useNotifications.ts
@@ -43,6 +43,27 @@ export function useNotifications() {
     return () => window.removeEventListener('focus', onFocus);
   }, [refresh]);
 
+  // Poll like balances/transactions do. The WebSocket unsubscribes whenever the tab is hidden (and can
+  // drop), so `notification:new` isn't a reliable live channel — a steady poll while visible, plus a
+  // refresh the moment the tab becomes visible again, keeps the bell current even with no live socket.
+  // (When hidden/closed, timers are throttled/stopped, so Web Push remains the delivery path.)
+  useEffect(() => {
+    if (!address || !isConnected) return;
+    const POLL_MS = 20_000;
+    const id = setInterval(() => {
+      if (typeof document !== 'undefined' && document.hidden) return;
+      void refresh();
+    }, POLL_MS);
+    const onVisible = () => {
+      if (typeof document !== 'undefined' && !document.hidden) void refresh();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      clearInterval(id);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [address, isConnected, refresh]);
+
   // If permission is already granted, subscribe silently on mount (no gesture needed). The gesture path
   // (first-time grant) is the "Enable notifications" prime and the demo "Send test" button.
   useEffect(() => {


### PR DESCRIPTION
## Problem
Recipient "money received" (and other) notifications only showed **after a refresh** when the app was open, and not at all when closed — even though **balances and transactions updated in real time**.

## Root cause
- Balances/transactions **poll** (`setInterval`), so they refresh regardless of socket state or tab visibility.
- Notifications relied only on mount, window `focus`, and the WebSocket `notification:new` event. But the socket **unsubscribes whenever the tab is hidden** (`useWebSocket.ts`) and can drop — so live notifications only arrived while the tab was visible and the socket was healthy.
- `notificationStore.emit` delivers live/push **once**, at insert time; the deduped follow-up (on-chain watcher) never retries, so a missed live delivery = nothing until the next refresh.

## Fix
`useNotifications` now **polls every 20s while visible** and refreshes on `visibilitychange` (more reliable than `focus` for PWA resume) — matching how balances behave. This makes the bell current within the poll window even with no live socket.

## Closed-app (Web Push) — separate half
The emit → Web Push path and the service-worker `push` handler are sound. Closed-app delivery still depends on: the **recipient having granted notification permission** (so a subscription is saved) and **`VAPID_PRIVATE_KEY`/`VAPID_PUBLIC_KEY` being set** on the backend env. Polling can't help when the app is fully closed (timers stop) — that's what Web Push is for.

Typecheck + build pass; behind Privy auth so not exercisable in the sandbox preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)