### PR TITLE
Analytics: privacy-safe Plausible on the app + funnel events

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,6 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { useState, useEffect } from "react";
+import { trackPageview } from "@/lib/analytics";
 import { AnimatePresence } from "framer-motion";
 import LoginPage from "@/pages/auth/LoginPage";
 import ProtectedRoute from "@/components/ProtectedRoute";
@@ -26,6 +27,15 @@ import TransactionsPage from "@/pages/app/TransactionsPage";
 import SettingsPage from "@/pages/app/SettingsPage";
 import BorrowPage from "@/pages/app/BorrowPage";
 import AssurancePage from "@/pages/app/AssurancePage";
+
+/** Fires a sanitized Plausible pageview on every client-side route change (live app only; no-op else). */
+function RouteAnalytics() {
+  const location = useLocation();
+  useEffect(() => {
+    trackPageview(location.pathname);
+  }, [location.pathname]);
+  return null;
+}
 
 function App() {
   // Check if splash has been shown in this session
@@ -77,6 +87,7 @@ function App() {
                 <ModalProvider>
                   <GlobalModalsProvider>
                   <ScrollToTop />
+                  <RouteAnalytics />
                   <AnimatePresence>
                     {showSplash && <SplashScreen />}
                   </AnimatePresence>

--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Check, ChevronDown, CreditCard, Landmark, Loader2, Smartphon
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { useLinkedWallets } from '@/context/LinkedWalletsContext';
 import { useExternalAccounts } from '@/context/ExternalAccountsContext';
+import { track } from '@/lib/analytics';
 import { useBridge } from '@/context/BridgeContext';
 import { useKyc } from '@/context/KycContext';
 import DepositInstructions from '@/components/app-ui/DepositInstructions';
@@ -229,6 +230,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
           void rampEvent({ type: 'buy', status: 'completed', amount, walletAddress: wallet.address, ref });
           bal.refresh(); // USDC has landed on-chain → pull the real balance
           setDone(true);
+          track('deposit_completed', { method: methodId }); // no amounts/PII
           return;
         }
         if (s.status === 'TRANSACTION_STATUS_FAILED') {

--- a/app/src/components/app-ui/SendModal.tsx
+++ b/app/src/components/app-ui/SendModal.tsx
@@ -13,6 +13,7 @@ import { useLinkedWallets } from '@/context/LinkedWalletsContext';
 import { useClearBalances } from '@/hooks/useClearBalances';
 import { useLinkedWalletBalances } from '@/hooks/useLinkedWalletBalances';
 import { useCardDeposit } from '@/hooks/useCardDeposit';
+import { track } from '@/lib/analytics';
 import { prepareSendTransfer, confirmSendTransferLock, notifyDirectSend } from '@/utils/apiClient';
 import { gaslessSendLock } from '@/lib/gaslessMoney';
 import { scSendLock, scTransferToken } from '@/lib/sendCalls';
@@ -161,6 +162,7 @@ export default function SendModal({ open, onOpenChange }: { open: boolean; onOpe
           if (source.kind === 'card') window.dispatchEvent(new Event('clear:activity'));
           // Immediate in-app "sent"/"received" for both parties (deduped with the on-chain watcher).
           void notifyDirectSend({ to, amount: sent, txHash, chainId });
+          track('send_completed', { type: 'wallet', token, source: source.kind }); // no amounts/PII
           return;
         }
 
@@ -220,6 +222,7 @@ export default function SendModal({ open, onOpenChange }: { open: boolean; onOpe
         setClaimUrl(claim);
         setDone(true);
         bal.applyOptimistic(-sent, 0);
+        track('send_completed', { type: 'claim_link', token }); // no amounts/PII
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : 'Send failed.');
       }

--- a/app/src/components/app-ui/WithdrawModal.tsx
+++ b/app/src/components/app-ui/WithdrawModal.tsx
@@ -12,6 +12,7 @@ import { createWalletClient, custom } from 'viem';
 import { useAppKitAccount } from '@/lib/walletCompat';
 import { ACTIVE_CHAIN_ID, clearContracts } from '@/lib/clearNetwork';
 import { gaslessWalletTransfer } from '@/lib/gaslessMoney';
+import { track } from '@/lib/analytics';
 import { scTransferToken } from '@/lib/sendCalls';
 import { withdrawToBank, createRampSellSession, getRampSellStatus, rampEvent, type RampSellStatus, type Eip712TypedData } from '@/utils/apiClient';
 import { cn } from '@/lib/utils';
@@ -222,6 +223,7 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
           if (cancelled) return;
           void rampEvent({ type: 'sell', status: 'submitted', amount: Number(started.amount), walletAddress: address, ref: crypto.randomUUID() });
           setDone(true);
+          track('withdraw_completed', { method: 'instant' }); // no amounts/PII
           if (!sourceWallet?.external) bal.applyOptimistic(-Number(started.amount), 0);
           return;
         }
@@ -232,6 +234,7 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
         if (cancelled) return;
         if (!res.success) throw new Error(res.message || 'Withdrawal failed.');
         setDone(true);
+        track('withdraw_completed', { method: 'bank' }); // no amounts/PII
         // Optimistic: USDC leaves Cash now; reconciles when the off-ramp debit indexes. A linked-wallet
         // withdraw just passed THROUGH Cash (move in, off-ramp out ≈ net 0), so skip the overlay there.
         if (!sourceWallet?.external) bal.applyOptimistic(-amount, 0);

--- a/app/src/context/KycContext.tsx
+++ b/app/src/context/KycContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useRef, useState, type ReactNode } from 'react';
 import KycModal from '@/components/app-ui/KycModal';
+import { track } from '@/lib/analytics';
 
 export type KycStatus = 'unverified' | 'verified';
 
@@ -43,6 +44,7 @@ export function KycProvider({ children }: { children: ReactNode }) {
   const openKyc = (onVerified?: () => void) => {
     cbRef.current = onVerified ?? null;
     setOpen(true);
+    track('kyc_started');
   };
   const gate = (action: () => void) => {
     if (status === 'verified') action();
@@ -50,6 +52,7 @@ export function KycProvider({ children }: { children: ReactNode }) {
   };
   const handleVerified = (personaInquiryId?: string) => {
     setStatus('verified');
+    track('kyc_verified');
     setInquiryId(personaInquiryId ?? `inq_${Date.now().toString(36)}`);
     setOpen(false);
     const cb = cbRef.current;

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -1,0 +1,67 @@
+import { IS_LIVE_APP } from './clearNetwork';
+
+/*
+ * Plausible analytics — privacy-first, cookieless, and LIVE APP ONLY (app.useclear.org). Dev/preview
+ * never load the script, so they can't pollute the dashboard.
+ *
+ * This is a money app, so PII safety is the priority:
+ *   - We use the MANUAL script (no automatic pageviews) and send the URL ourselves, after stripping
+ *     sensitive path segments (the claim token) AND all query/hash params — nothing identifying leaves
+ *     the client.
+ *   - Custom events carry coarse names + categories only. NEVER pass amounts, wallet addresses, emails,
+ *     phone numbers, or claim tokens as props.
+ *
+ * Add `app.useclear.org` as its own site in the (shared) Plausible account — same install as the
+ * marketing site, separate dashboard.
+ */
+const DATA_DOMAIN = 'app.useclear.org';
+const SCRIPT_SRC = 'https://plausible.io/js/script.manual.js';
+
+type PlausibleOpts = { u?: string; props?: Record<string, string | number | boolean>; callback?: () => void };
+type PlausibleFn = ((event: string, opts?: PlausibleOpts) => void) & { q?: unknown[] };
+
+declare global {
+  interface Window {
+    plausible?: PlausibleFn;
+  }
+}
+
+let injected = false;
+
+/** Collapse dynamic/sensitive path segments and drop query + hash, so nothing identifying is sent. */
+export function sanitizePath(pathname: string): string {
+  let p = (pathname || '/').split('?')[0].split('#')[0];
+  // /claim/<token> → /claim/:token — never send the claim token to analytics.
+  p = p.replace(/^\/claim\/[^/]+.*$/, '/claim/:token');
+  return p || '/';
+}
+
+/** Inject the Plausible script once, on the live app only. No-op elsewhere. Safe to call repeatedly. */
+export function initAnalytics(): void {
+  if (injected || !IS_LIVE_APP || typeof document === 'undefined') return;
+  injected = true;
+  // Queue stub so any track()/pageview fired before the script finishes loading is replayed, not lost.
+  window.plausible =
+    window.plausible ||
+    (function (...args: unknown[]) {
+      (window.plausible!.q = window.plausible!.q || []).push(args);
+    } as PlausibleFn);
+  const s = document.createElement('script');
+  s.defer = true;
+  s.src = SCRIPT_SRC;
+  s.setAttribute('data-domain', DATA_DOMAIN);
+  document.head.appendChild(s);
+}
+
+/** Send a sanitized pageview (manual script → we pass the URL ourselves). */
+export function trackPageview(pathname: string): void {
+  if (!IS_LIVE_APP || typeof window === 'undefined' || !window.plausible) return;
+  window.plausible('pageview', { u: `https://${DATA_DOMAIN}${sanitizePath(pathname)}` });
+}
+
+/** Fire a custom event. Props must be non-identifying (names/categories only — never amounts/PII). */
+export function track(event: string, props?: Record<string, string | number | boolean>): void {
+  if (!IS_LIVE_APP || typeof window === 'undefined' || !window.plausible) return;
+  const u = `https://${DATA_DOMAIN}${sanitizePath(window.location.pathname)}`;
+  window.plausible(event, props ? { u, props } : { u });
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -2,6 +2,10 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import { registerServiceWorker } from './utils/serviceWorker'
+import { initAnalytics } from './lib/analytics'
+
+// Plausible analytics — injects only on the live app (app.useclear.org); no-op in dev/preview.
+initAnalytics();
 
 // Buffer polyfill for XMTP — must be set before App/AppKit/XMTP modules load, so App and
 // AppKitProvider are imported dynamically below (after this runs).

--- a/app/src/pages/auth/UserOnboarding.tsx
+++ b/app/src/pages/auth/UserOnboarding.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { track } from '@/lib/analytics';
 import {
   acceptMemberTerms,
   bootstrapMemberAccount,
@@ -76,6 +77,7 @@ export default function UserOnboarding() {
       const account = await submitMemberOnboarding();
       if (!account) throw new Error("We couldn't complete onboarding.");
 
+      track('onboarding_completed', { access: r.accessTrack }); // plan category only, no PII
       window.dispatchEvent(new Event('wallet-connected'));
       setTimeout(() => navigate('/', { replace: true }), 100);
     } catch (e) {


### PR DESCRIPTION
Wires Plausible into the app — **same Plausible account** as the marketing site, but its **own site** (`app.useclear.org`).

## Privacy (it's a money app)
- **Live-app only**: the script injects only on `app.useclear.org`; dev/preview never load it.
- **Manual script** (no auto pageviews) — we send the URL ourselves after stripping the `/claim/:token` segment and **all query/hash params** (`lib/analytics.ts`).
- **Cookieless**, no consent banner needed.
- Custom events carry **coarse names + categories only** — never amounts, wallet addresses, emails, phones, or claim tokens.

## What's tracked
- Sanitized **pageviews** on every route change (`<RouteAnalytics/>`).
- Funnel events: `onboarding_completed`, `kyc_started` / `kyc_verified`, `deposit_completed` (method), `withdraw_completed` (method), `send_completed` (type/token/source).

## To activate
Add **`app.useclear.org`** as a new site in your Plausible dashboard. No backend env — only the public `data-domain` is used. (If you'd rather roll it into the marketing site's dashboard, set `data-domain=useclear.org` on both instead — say the word and I'll switch it.)

Typecheck + build pass; behind Privy/live-gate so not exercisable in the sandbox preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)