### PR TITLE
Analytics: new-gen Plausible script + transformRequest PII scrub

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,6 +1,5 @@
-import { BrowserRouter, Routes, Route, Navigate, useLocation } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { useState, useEffect } from "react";
-import { trackPageview } from "@/lib/analytics";
 import { AnimatePresence } from "framer-motion";
 import LoginPage from "@/pages/auth/LoginPage";
 import ProtectedRoute from "@/components/ProtectedRoute";
@@ -27,15 +26,6 @@ import TransactionsPage from "@/pages/app/TransactionsPage";
 import SettingsPage from "@/pages/app/SettingsPage";
 import BorrowPage from "@/pages/app/BorrowPage";
 import AssurancePage from "@/pages/app/AssurancePage";
-
-/** Fires a sanitized Plausible pageview on every client-side route change (live app only; no-op else). */
-function RouteAnalytics() {
-  const location = useLocation();
-  useEffect(() => {
-    trackPageview(location.pathname);
-  }, [location.pathname]);
-  return null;
-}
 
 function App() {
   // Check if splash has been shown in this session
@@ -87,7 +77,6 @@ function App() {
                 <ModalProvider>
                   <GlobalModalsProvider>
                   <ScrollToTop />
-                  <RouteAnalytics />
                   <AnimatePresence>
                     {showSplash && <SplashScreen />}
                   </AnimatePresence>

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -4,21 +4,24 @@ import { IS_LIVE_APP } from './clearNetwork';
  * Plausible analytics — privacy-first, cookieless, and LIVE APP ONLY (app.useclear.org). Dev/preview
  * never load the script, so they can't pollute the dashboard.
  *
- * This is a money app, so PII safety is the priority:
- *   - We use the MANUAL script (no automatic pageviews) and send the URL ourselves, after stripping
- *     sensitive path segments (the claim token) AND all query/hash params — nothing identifying leaves
- *     the client.
- *   - Custom events carry coarse names + categories only. NEVER pass amounts, wallet addresses, emails,
- *     phone numbers, or claim tokens as props.
+ * Uses Plausible's site-specific script (pa-*.js) + plausible.init(). This is a money app, so PII
+ * safety is enforced in `transformRequest`, which runs on EVERY event (pageview + custom) before it's
+ * sent: we strip all query/hash params and collapse the /claim/:token segment out of the URL. Custom
+ * events must still carry coarse names + categories only — NEVER amounts, addresses, emails, phones,
+ * or claim tokens.
  *
  * Add `app.useclear.org` as its own site in the (shared) Plausible account — same install as the
  * marketing site, separate dashboard.
  */
-const DATA_DOMAIN = 'app.useclear.org';
-const SCRIPT_SRC = 'https://plausible.io/js/script.manual.js';
+const SCRIPT_SRC = 'https://plausible.io/js/pa-two8X6kl9uz0VKoszPaZO.js';
 
-type PlausibleOpts = { u?: string; props?: Record<string, string | number | boolean>; callback?: () => void };
-type PlausibleFn = ((event: string, opts?: PlausibleOpts) => void) & { q?: unknown[] };
+type PlausibleOpts = { props?: Record<string, string | number | boolean> };
+type TransformPayload = { u?: string; n?: string } & Record<string, unknown>;
+type PlausibleFn = ((event: string, opts?: PlausibleOpts) => void) & {
+  q?: unknown[];
+  o?: unknown;
+  init?: (opts?: unknown) => void;
+};
 
 declare global {
   interface Window {
@@ -28,7 +31,7 @@ declare global {
 
 let injected = false;
 
-/** Collapse dynamic/sensitive path segments and drop query + hash, so nothing identifying is sent. */
+/** Collapse dynamic/sensitive path segments so nothing identifying is sent. Query/hash are dropped separately. */
 export function sanitizePath(pathname: string): string {
   let p = (pathname || '/').split('?')[0].split('#')[0];
   // /claim/<token> → /claim/:token — never send the claim token to analytics.
@@ -36,32 +39,47 @@ export function sanitizePath(pathname: string): string {
   return p || '/';
 }
 
+/** Strip query/hash + sensitive path segments from an event's URL. Runs on every event before send. */
+function sanitizeRequest(payload: TransformPayload): TransformPayload {
+  if (typeof payload.u === 'string') {
+    try {
+      const url = new URL(payload.u);
+      url.search = '';
+      url.hash = '';
+      url.pathname = sanitizePath(url.pathname);
+      payload.u = url.toString();
+    } catch {
+      /* leave as-is if unparseable */
+    }
+  }
+  return payload;
+}
+
 /** Inject the Plausible script once, on the live app only. No-op elsewhere. Safe to call repeatedly. */
 export function initAnalytics(): void {
   if (injected || !IS_LIVE_APP || typeof document === 'undefined') return;
   injected = true;
-  // Queue stub so any track()/pageview fired before the script finishes loading is replayed, not lost.
+  // Queue stub (Plausible's official snippet) so calls before the script loads are replayed, not lost.
   window.plausible =
     window.plausible ||
     (function (...args: unknown[]) {
       (window.plausible!.q = window.plausible!.q || []).push(args);
     } as PlausibleFn);
+  window.plausible.init =
+    window.plausible.init ||
+    function (i?: unknown) {
+      window.plausible!.o = i || {};
+    };
   const s = document.createElement('script');
-  s.defer = true;
+  s.async = true;
   s.src = SCRIPT_SRC;
-  s.setAttribute('data-domain', DATA_DOMAIN);
   document.head.appendChild(s);
-}
-
-/** Send a sanitized pageview (manual script → we pass the URL ourselves). */
-export function trackPageview(pathname: string): void {
-  if (!IS_LIVE_APP || typeof window === 'undefined' || !window.plausible) return;
-  window.plausible('pageview', { u: `https://${DATA_DOMAIN}${sanitizePath(pathname)}` });
+  // Auto-captures pageviews (incl. SPA routing); transformRequest scrubs PII from every event's URL.
+  window.plausible.init({ transformRequest: sanitizeRequest });
 }
 
 /** Fire a custom event. Props must be non-identifying (names/categories only — never amounts/PII). */
 export function track(event: string, props?: Record<string, string | number | boolean>): void {
   if (!IS_LIVE_APP || typeof window === 'undefined' || !window.plausible) return;
-  const u = `https://${DATA_DOMAIN}${sanitizePath(window.location.pathname)}`;
-  window.plausible(event, props ? { u, props } : { u });
+  window.plausible(event, props ? { props } : undefined);
 }


### PR DESCRIPTION
Switches to the **new site-specific Plausible script** you pasted (`pa-*.js` + `plausible.init()`), replacing the classic `script.manual.js` + `data-domain`.

- PII stripping moved into `plausible.init({ transformRequest })` — runs on **every** event (pageview + custom) before send: drops all query/hash params and collapses `/claim/:token`.
- The new script **auto-captures SPA pageviews**, so the manual `<RouteAnalytics/>` route-tracker is removed.
- Still **live-app only** (`app.useclear.org`) so dev/preview don't pollute the dashboard.
- Custom funnel events (`send_completed`, `deposit_completed`, `withdraw_completed`, `kyc_started`/`kyc_verified`, `onboarding_completed`) unchanged.

Typecheck + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)