### PR TITLE
Offline indicator: floating auto-dismissing pill

### DIFF
--- a/app/src/components/OfflineIndicator.tsx
+++ b/app/src/components/OfflineIndicator.tsx
@@ -1,43 +1,67 @@
-import { WifiOff, Wifi } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { WifiOff, Wifi, Loader2 } from 'lucide-react';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useOffline } from '@/hooks/useOffline';
-import { Alert, AlertDescription } from '@/components/ui/alert';
+import { cn } from '@/lib/utils';
 
 /**
- * Component to display offline status and queued actions
+ * Connectivity toast: a small floating pill that slides in when the connection state flips (or if the
+ * app opens offline) and auto-dismisses after a few seconds — instead of a persistent full-width banner.
+ * It lingers while queued actions are actively syncing, then hides itself.
  */
 export function OfflineIndicator() {
   const { isOffline, queuedActions } = useOffline();
+  const [show, setShow] = useState(false);
+  const prevOffline = useRef(isOffline);
 
-  if (!isOffline && queuedActions.length === 0) {
-    return null;
-  }
+  useEffect(() => {
+    const flipped = prevOffline.current !== isOffline;
+    prevOffline.current = isOffline;
+    // Nothing to say when we're online and nothing changed (e.g. a normal mount).
+    if (!flipped && !isOffline) return;
+    setShow(true);
+    const t = setTimeout(() => setShow(false), isOffline ? 6000 : 3500);
+    return () => clearTimeout(t);
+  }, [isOffline]);
+
+  const syncing = !isOffline && queuedActions.length > 0;
+  const open = show || syncing; // keep it up until the queue drains
+
+  if (!open) return null;
+
+  const Icon = isOffline ? WifiOff : syncing ? Loader2 : Wifi;
+  const label = isOffline
+    ? "You're offline"
+    : syncing
+      ? `Syncing ${queuedActions.length} action${queuedActions.length > 1 ? 's' : ''}…`
+      : 'Back online';
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-50">
-      <Alert
-        variant={isOffline ? 'destructive' : 'default'}
-        className="rounded-none border-x-0 border-t-0"
-      >
-        <div className="flex items-center gap-2">
-          {isOffline ? (
-            <>
-              <WifiOff className="h-4 w-4" />
-              <AlertDescription>
-                You're offline. Some features may be limited.
-              </AlertDescription>
-            </>
-          ) : (
-            <>
-              <Wifi className="h-4 w-4" />
-              <AlertDescription>
-                {queuedActions.length > 0
-                  ? `Syncing ${queuedActions.length} queued action${queuedActions.length > 1 ? 's' : ''}...`
-                  : 'Back online'}
-              </AlertDescription>
-            </>
-          )}
+    <AnimatePresence>
+      {open && (
+        <div className="pointer-events-none fixed inset-x-0 top-[max(1rem,env(safe-area-inset-top))] z-[60] flex justify-center px-4">
+          <motion.div
+            role="status"
+            aria-live="polite"
+            initial={{ opacity: 0, y: -16, scale: 0.96 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -16, scale: 0.96 }}
+            transition={{ type: 'spring', stiffness: 420, damping: 30 }}
+            className="pointer-events-auto flex items-center gap-2 rounded-full border border-border bg-popover/95 px-4 py-2 shadow-lg backdrop-blur"
+          >
+            <Icon
+              className={cn(
+                'h-4 w-4 shrink-0',
+                isOffline ? 'text-amber-500' : syncing ? 'animate-spin text-muted-foreground' : 'text-positive',
+              )}
+            />
+            <span className="text-sm font-medium text-foreground">{label}</span>
+            {isOffline && (
+              <span className="hidden text-xs text-muted-foreground sm:inline">· some features are limited</span>
+            )}
+          </motion.div>
         </div>
-      </Alert>
-    </div>
+      )}
+    </AnimatePresence>
   );
 }


### PR DESCRIPTION
The offline state was a persistent full-width top `Alert` that collapsed into an awkward narrow text column (see report).

Now it's a small **floating pill toast**:
- Slides in (framer-motion spring) when connectivity flips, or if the app opens offline.
- **Auto-dismisses** — ~6s offline (long enough to notice), ~3.5s on "Back online".
- Lingers while queued actions are actively **syncing**, then hides.
- Centered, rounded, `backdrop-blur`, colored icon (amber offline / green online / spinner syncing); respects the top safe-area inset.
- `role="status"` + `aria-live="polite"`.

Typecheck + build pass; needs the authed shell + a real offline event to observe, so not exercisable in the sandbox preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)