### PR TITLE
Clear Pay: bill-portal directory + Clear card panel (P1)

### DIFF
--- a/app/src/components/app-ui/BillPortalsModal.tsx
+++ b/app/src/components/app-ui/BillPortalsModal.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from 'react';
+import { Search, ExternalLink, ShieldCheck, CreditCard, Info, ChevronDown } from 'lucide-react';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+import {
+  BILL_PORTALS,
+  PORTAL_CATEGORIES,
+  US_STATES,
+  rankPortals,
+  type PortalCategory,
+} from '@/data/billPortals';
+
+/*
+ * "Pay a bill" via the biller's own portal, using the member's Clear card (Bridge / Stripe Issuing,
+ * funded just-in-time from their Base USDC). The web app can't autofill a third-party site (cross-origin),
+ * so the flow is: reveal + copy the Clear card, open the provider's portal in a new tab, paste to pay.
+ *
+ * P1 (this): directory + card wallet panel scaffold. P2 drops the PCI-compliant Stripe Issuing Element
+ * into <CardPanel/> so the real PAN/CVV render + copy; the card status comes from the Bridge cardholder.
+ */
+export default function BillPortalsModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState<PortalCategory | 'all'>('all');
+  const [state, setState] = useState<string>('');
+
+  const portals = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const filtered = BILL_PORTALS.filter(
+      (p) =>
+        (category === 'all' || p.category === category) &&
+        (!q || `${p.name} ${p.hint ?? ''}`.toLowerCase().includes(q)),
+    );
+    return rankPortals(filtered, state || undefined);
+  }, [query, category, state]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[520px]">
+        <div className="flex max-h-[86vh] flex-col">
+          {/* header */}
+          <div className="px-5 pt-5">
+            <div className="text-base font-semibold text-foreground">Pay a bill</div>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Open your provider and pay with your Clear card — funded from your Cash balance.
+            </p>
+          </div>
+
+          {/* Clear card panel (P2 renders the live Stripe Issuing element here) */}
+          <div className="px-5 pt-4">
+            <CardPanel />
+          </div>
+
+          {/* controls */}
+          <div className="space-y-2.5 px-5 pb-3 pt-4">
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search providers"
+                className="w-full rounded-xl border border-border bg-background py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-foreground/30 focus:outline-none"
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="flex flex-1 items-center gap-1 overflow-x-auto">
+                <Chip active={category === 'all'} onClick={() => setCategory('all')}>All</Chip>
+                {PORTAL_CATEGORIES.map((c) => (
+                  <Chip key={c.id} active={category === c.id} onClick={() => setCategory(c.id)}>
+                    {c.emoji} {c.label}
+                  </Chip>
+                ))}
+              </div>
+              <div className="relative shrink-0">
+                <select
+                  value={state}
+                  onChange={(e) => setState(e.target.value)}
+                  className="appearance-none rounded-full border border-border bg-background py-1.5 pl-3 pr-7 text-xs font-medium text-foreground focus:border-foreground/30 focus:outline-none"
+                  aria-label="Filter by state"
+                >
+                  <option value="">All states</option>
+                  {US_STATES.map((s) => (
+                    <option key={s.code} value={s.code}>{s.code}</option>
+                  ))}
+                </select>
+                <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              </div>
+            </div>
+          </div>
+
+          {/* portal list */}
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-5">
+            <div className="space-y-1.5">
+              {portals.map((p) => {
+                const cat = PORTAL_CATEGORIES.find((c) => c.id === p.category);
+                return (
+                  <a
+                    key={p.id}
+                    href={p.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-3 rounded-xl border border-border p-2.5 text-left transition-colors hover:bg-secondary/50"
+                  >
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-secondary text-base">
+                      {cat?.emoji}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium text-foreground">{p.name}</span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {p.hint}
+                        {p.states && state && p.states.includes(state) ? ' · in your area' : ''}
+                      </span>
+                    </span>
+                    <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  </a>
+                );
+              })}
+              {portals.length === 0 && (
+                <div className="py-10 text-center text-sm text-muted-foreground">
+                  No providers match. Try a different category or search.
+                </div>
+              )}
+            </div>
+
+            <p className="mt-3 flex items-start gap-1.5 text-[11px] text-muted-foreground">
+              <Info className="mt-0.5 h-3 w-3 shrink-0" />
+              Don't see your biller? You can still add it manually and pay by bank transfer from “Pay a bill”.
+            </p>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Chip({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'shrink-0 whitespace-nowrap rounded-full border px-2.5 py-1.5 text-xs font-medium transition-colors',
+        active ? 'border-foreground bg-foreground text-background' : 'border-border text-muted-foreground hover:bg-secondary',
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * The Clear card. P1 shows an "activating" placeholder; P2 replaces the masked digits with a Stripe
+ * Issuing Element (PCI-compliant iframe) plus tap-to-copy, gated behind a passkey reveal.
+ */
+function CardPanel() {
+  return (
+    <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-neutral-900 to-neutral-700 p-4 text-white shadow-sm dark:from-neutral-800 dark:to-neutral-950">
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="text-[11px] font-medium uppercase tracking-wide text-white/60">Clear card</div>
+          <div className="mt-3 font-mono text-lg tracking-[0.2em] text-white/90">•••• •••• •••• ••••</div>
+        </div>
+        <CreditCard className="h-5 w-5 text-white/70" />
+      </div>
+      <div className="mt-3 flex items-center justify-between">
+        <span className="inline-flex items-center gap-1 rounded-full bg-white/15 px-2 py-0.5 text-[11px] font-medium text-white/90">
+          <ShieldCheck className="h-3 w-3" /> Activating soon
+        </span>
+        <span className="text-[11px] text-white/60">Pays from Cash · USDC</span>
+      </div>
+    </div>
+  );
+}

--- a/app/src/context/PayContext.tsx
+++ b/app/src/context/PayContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useRef, useState, ty
 import { Home, Zap, Repeat, CreditCard, Smartphone, Receipt, type LucideIcon } from 'lucide-react';
 import { useAppKitAccount } from '@/lib/walletCompat';
 import PayModal from '@/components/app-ui/PayModal';
+import BillPortalsModal from '@/components/app-ui/BillPortalsModal';
 import { useKyc } from '@/context/KycContext';
 import {
   getPlaidRecurringTransactions,
@@ -141,6 +142,8 @@ interface PayValue {
   refresh: () => void;
   /** Open the Pay flow; pass a bill id to go straight to that payment (e.g. "Pay rent"). */
   openPay: (billId?: string) => void;
+  /** Open the bill-portal directory (pay on the biller's own site with the Clear card). */
+  openPortals: () => void;
 }
 
 const Ctx = createContext<PayValue | null>(null);
@@ -162,6 +165,7 @@ export function usePay(): PayValue {
       streak: ON_TIME_STREAK,
       refresh: () => {},
       openPay: () => {},
+      openPortals: () => {},
     }
   );
 }
@@ -178,6 +182,7 @@ export function PayProvider({ children }: { children: ReactNode }) {
   const [summary, setSummary] = useState<PaySummary | null>(null);
   const [loading, setLoading] = useState(false);
   const [payOpen, setPayOpen] = useState(false);
+  const [portalsOpen, setPortalsOpen] = useState(false);
   const [initialBillId, setInitialBillId] = useState<string | undefined>(undefined);
 
   const load = useCallback(async () => {
@@ -374,12 +379,14 @@ export function PayProvider({ children }: { children: ReactNode }) {
         setInitialBillId(billId);
         setPayOpen(true);
       }),
+    openPortals: () => gate(() => setPortalsOpen(true)),
   };
 
   return (
     <Ctx.Provider value={value}>
       {children}
       <PayModal open={payOpen} onOpenChange={setPayOpen} initialBillId={initialBillId} />
+      <BillPortalsModal open={portalsOpen} onOpenChange={setPortalsOpen} />
     </Ctx.Provider>
   );
 }

--- a/app/src/data/billPortals.ts
+++ b/app/src/data/billPortals.ts
@@ -1,0 +1,93 @@
+/*
+ * Bill-portal directory for Clear Pay. Users can't be given most billers' ACH details (utilities/rent
+ * pull from you), so instead we send them to the biller's own portal to pay with their Clear card
+ * (Bridge / Stripe Issuing, funded just-in-time from their Base USDC). This is the verified list of
+ * provider login/pay URLs, grouped by category and tagged by the US states they serve so we can bubble
+ * the likely ones to the top. National providers (telecom, rent platforms) carry no `states`.
+ */
+export type PortalCategory = 'electric' | 'utilities' | 'rent' | 'telecom';
+
+export interface BillPortal {
+  id: string;
+  name: string;
+  category: PortalCategory;
+  url: string;
+  hint?: string;
+  /** US state codes served; omit for national providers. */
+  states?: string[];
+}
+
+export const PORTAL_CATEGORIES: { id: PortalCategory; label: string; emoji: string }[] = [
+  { id: 'electric', label: 'Electric', emoji: '⚡️' },
+  { id: 'utilities', label: 'Utilities', emoji: '💧' },
+  { id: 'rent', label: 'Rent', emoji: '🏠' },
+  { id: 'telecom', label: 'Telecom', emoji: '📱' },
+];
+
+export const US_STATES: { code: string; name: string }[] = [
+  { code: 'AL', name: 'Alabama' }, { code: 'AK', name: 'Alaska' }, { code: 'AZ', name: 'Arizona' },
+  { code: 'AR', name: 'Arkansas' }, { code: 'CA', name: 'California' }, { code: 'CO', name: 'Colorado' },
+  { code: 'CT', name: 'Connecticut' }, { code: 'DE', name: 'Delaware' }, { code: 'FL', name: 'Florida' },
+  { code: 'GA', name: 'Georgia' }, { code: 'HI', name: 'Hawaii' }, { code: 'ID', name: 'Idaho' },
+  { code: 'IL', name: 'Illinois' }, { code: 'IN', name: 'Indiana' }, { code: 'IA', name: 'Iowa' },
+  { code: 'KS', name: 'Kansas' }, { code: 'KY', name: 'Kentucky' }, { code: 'LA', name: 'Louisiana' },
+  { code: 'ME', name: 'Maine' }, { code: 'MD', name: 'Maryland' }, { code: 'MA', name: 'Massachusetts' },
+  { code: 'MI', name: 'Michigan' }, { code: 'MN', name: 'Minnesota' }, { code: 'MS', name: 'Mississippi' },
+  { code: 'MO', name: 'Missouri' }, { code: 'MT', name: 'Montana' }, { code: 'NE', name: 'Nebraska' },
+  { code: 'NV', name: 'Nevada' }, { code: 'NH', name: 'New Hampshire' }, { code: 'NJ', name: 'New Jersey' },
+  { code: 'NM', name: 'New Mexico' }, { code: 'NY', name: 'New York' }, { code: 'NC', name: 'North Carolina' },
+  { code: 'ND', name: 'North Dakota' }, { code: 'OH', name: 'Ohio' }, { code: 'OK', name: 'Oklahoma' },
+  { code: 'OR', name: 'Oregon' }, { code: 'PA', name: 'Pennsylvania' }, { code: 'RI', name: 'Rhode Island' },
+  { code: 'SC', name: 'South Carolina' }, { code: 'SD', name: 'South Dakota' }, { code: 'TN', name: 'Tennessee' },
+  { code: 'TX', name: 'Texas' }, { code: 'UT', name: 'Utah' }, { code: 'VT', name: 'Vermont' },
+  { code: 'VA', name: 'Virginia' }, { code: 'WA', name: 'Washington' }, { code: 'WV', name: 'West Virginia' },
+  { code: 'WI', name: 'Wisconsin' }, { code: 'WY', name: 'Wyoming' }, { code: 'DC', name: 'Washington, D.C.' },
+];
+
+export const BILL_PORTALS: BillPortal[] = [
+  // ── Electric (investor-owned utilities) ─────────────────────────────────────
+  { id: 'pge', name: 'PG&E', category: 'electric', hint: 'Gas & electric', url: 'https://www.pge.com/', states: ['CA'] },
+  { id: 'sce', name: 'Southern California Edison', category: 'electric', hint: 'Electric', url: 'https://www.sce.com/', states: ['CA'] },
+  { id: 'sdge', name: 'San Diego Gas & Electric', category: 'electric', hint: 'Gas & electric', url: 'https://www.sdge.com/', states: ['CA'] },
+  { id: 'coned', name: 'Con Edison', category: 'electric', hint: 'Gas & electric', url: 'https://www.coned.com/', states: ['NY'] },
+  { id: 'comed', name: 'ComEd', category: 'electric', hint: 'Electric', url: 'https://www.comed.com/', states: ['IL'] },
+  { id: 'duke', name: 'Duke Energy', category: 'electric', hint: 'Electric', url: 'https://www.duke-energy.com/', states: ['NC', 'SC', 'FL', 'OH', 'IN', 'KY'] },
+  { id: 'fpl', name: 'Florida Power & Light', category: 'electric', hint: 'Electric', url: 'https://www.fpl.com/', states: ['FL'] },
+  { id: 'georgiapower', name: 'Georgia Power', category: 'electric', hint: 'Electric', url: 'https://www.georgiapower.com/', states: ['GA'] },
+  { id: 'oncor', name: 'Oncor / TXU Energy', category: 'electric', hint: 'Electric', url: 'https://www.txu.com/', states: ['TX'] },
+  { id: 'dominion', name: 'Dominion Energy', category: 'electric', hint: 'Electric', url: 'https://www.dominionenergy.com/', states: ['VA', 'NC', 'SC', 'OH'] },
+  { id: 'xcel', name: 'Xcel Energy', category: 'electric', hint: 'Gas & electric', url: 'https://www.xcelenergy.com/', states: ['CO', 'MN', 'TX', 'NM', 'WI', 'MI', 'ND', 'SD'] },
+  { id: 'aps', name: 'Arizona Public Service', category: 'electric', hint: 'Electric', url: 'https://www.aps.com/', states: ['AZ'] },
+  { id: 'nvenergy', name: 'NV Energy', category: 'electric', hint: 'Electric', url: 'https://www.nvenergy.com/', states: ['NV'] },
+  { id: 'pse', name: 'Puget Sound Energy', category: 'electric', hint: 'Gas & electric', url: 'https://www.pse.com/', states: ['WA'] },
+
+  // ── Utilities (gas / water) ────────────────────────────────────────────────
+  { id: 'socalgas', name: 'SoCalGas', category: 'utilities', hint: 'Natural gas', url: 'https://www.socalgas.com/', states: ['CA'] },
+  { id: 'nationalgrid', name: 'National Grid', category: 'utilities', hint: 'Gas & electric', url: 'https://www.nationalgridus.com/', states: ['NY', 'MA', 'RI'] },
+  { id: 'atmos', name: 'Atmos Energy', category: 'utilities', hint: 'Natural gas', url: 'https://www.atmosenergy.com/', states: ['TX', 'LA', 'MS', 'CO', 'KS', 'KY', 'TN'] },
+  { id: 'amwater', name: 'American Water', category: 'utilities', hint: 'Water', url: 'https://www.amwater.com/', states: ['NJ', 'PA', 'IL', 'MO', 'CA', 'IN', 'WV'] },
+  { id: 'nicor', name: 'Nicor Gas', category: 'utilities', hint: 'Natural gas', url: 'https://www.nicorgas.com/', states: ['IL'] },
+
+  // ── Rent (landlord payment platforms — national) ───────────────────────────
+  { id: 'rentcafe', name: 'RentCafe', category: 'rent', hint: 'Resident portal', url: 'https://www.rentcafe.com/' },
+  { id: 'appfolio', name: 'AppFolio', category: 'rent', hint: 'Online portal', url: 'https://www.appfolio.com/online-portal-login' },
+  { id: 'buildium', name: 'Buildium', category: 'rent', hint: 'Resident portal', url: 'https://www.buildium.com/' },
+  { id: 'zillow', name: 'Zillow Rental Manager', category: 'rent', hint: 'Pay rent online', url: 'https://www.zillow.com/rental-manager/' },
+  { id: 'payyourrent', name: 'PayYourRent', category: 'rent', hint: 'Pay rent online', url: 'https://www.payyourrent.com/' },
+  { id: 'entrata', name: 'Entrata / ResidentPortal', category: 'rent', hint: 'Resident portal', url: 'https://www.residentportal.com/' },
+
+  // ── Telecom (national) ─────────────────────────────────────────────────────
+  { id: 'att', name: 'AT&T', category: 'telecom', hint: 'Wireless & internet', url: 'https://www.att.com/my/' },
+  { id: 'verizon', name: 'Verizon', category: 'telecom', hint: 'Wireless & Fios', url: 'https://www.verizon.com/pay-bill/' },
+  { id: 'tmobile', name: 'T-Mobile', category: 'telecom', hint: 'Wireless', url: 'https://www.t-mobile.com/' },
+  { id: 'xfinity', name: 'Xfinity / Comcast', category: 'telecom', hint: 'Internet & TV', url: 'https://www.xfinity.com/bill' },
+  { id: 'spectrum', name: 'Spectrum', category: 'telecom', hint: 'Internet & TV', url: 'https://www.spectrum.net/pay-bill' },
+  { id: 'cox', name: 'Cox Communications', category: 'telecom', hint: 'Internet & TV', url: 'https://www.cox.com/residential/pay-bill.html' },
+];
+
+/** Rank portals for a state: in-state regional providers first, then national, then the rest. */
+export function rankPortals(portals: BillPortal[], state?: string): BillPortal[] {
+  if (!state) return portals;
+  const score = (p: BillPortal) => (p.states?.includes(state) ? 0 : !p.states ? 1 : 2);
+  return [...portals].sort((a, b) => score(a) - score(b));
+}

--- a/app/src/pages/app/PayPage.tsx
+++ b/app/src/pages/app/PayPage.tsx
@@ -12,7 +12,7 @@ const fmtUsd = (n: number) => `$${n.toLocaleString(undefined, { minimumFractionD
 
 /** Pay — Clear Pay's rent/bill core, send/request, card, and rent-to-equity viz. */
 export default function PayPage() {
-  const { bills, summary, openPay, reconcile } = usePay();
+  const { bills, summary, openPay, openPortals, reconcile } = usePay();
   const { openSend, openRequest, openAutoSave } = useMoneyActions();
   const timelineBills: TimelineBill[] = bills.map((b) => ({ id: b.id, name: b.name, dateLabel: b.dueLabel, amount: b.amount, icon: b.icon }));
   const streak = summary?.streak ?? 0;
@@ -49,7 +49,7 @@ export default function PayPage() {
           <h3 className="mb-3 text-xs font-medium text-muted-foreground">Make a payment</h3>
           <div className="grid grid-cols-2 gap-3">
             <ActionTile icon={Home} label="Pay rent" hint="Schedule or pay now" primary onClick={() => openPay('rent')} />
-            <ActionTile icon={FileText} label="Pay a bill" hint="Utilities, cards & more" onClick={() => openPay()} />
+            <ActionTile icon={FileText} label="Pay a bill" hint="Utilities, rent & more" onClick={openPortals} />
             <ActionTile icon={SendHorizontal} label="Send" hint="To anyone" onClick={openSend} />
             <ActionTile icon={ArrowDownLeft} label="Request" hint="Get paid" onClick={openRequest} />
             <ActionTile icon={Repeat} label="Auto-save" hint="Sign once, build equity" onClick={openAutoSave} />


### PR DESCRIPTION
First slice of the Clear Pay bill-pay overhaul. For billers the user has no ACH details for (rent/utilities/telecom), instead of needing the vendor's bank info, they open the biller's own portal and pay with their **Clear card** (Bridge / Stripe Issuing, funded just-in-time from their Base USDC). The existing vendor-ACH "direct add" stays as the fallback.

## Why this shape
- The app is a **web PWA**, so it **cannot** embed a third-party portal and autofill it (cross-origin SOP + `X-Frame-Options`). The realistic flow is: reveal/copy the Clear card → open the portal in a new tab → paste to pay. (Autofill would need a native app or extension.)
- Bridge **virtual accounts are receive-only**, so they can't pay billers who pull — the pushable instrument is the **card**.

## What's in P1
- `data/billPortals.ts` — curated US directory (⚡ electric / 💧 utilities / 🏠 rent / 📱 telecom), tagged by state, with `rankPortals()` to bubble in-state providers.
- `BillPortalsModal.tsx` — search + category chips + state filter + ranked list (opens portals in a new tab) + a Clear card panel scaffold.
- `PayContext.openPortals()` (KYC-gated) + modal mount; the **"Pay a bill"** tile now opens the directory. Rent + timeline bills keep the ACH flow.

## Next (not in this PR)
- **P2** (needs Bridge "cards" endorsement access): backend Bridge cardholder → Stripe card create → ephemeral-key endpoint + **Stripe Issuing Element** in `CardPanel` for the live PAN/CVV + copy.
- **P3** (deferred): earn equity credit via Stripe Issuing auth webhooks + optional MCC spending controls.

On your side: ask Bridge to enable the **"cards" endorsement** (+ confirm Stripe Issuing connection / region eligibility). Typecheck + build pass; behind the KYC gate so not exercisable in the sandbox preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)