### PR TITLE
Clear Pay: in-app browser for billers + card out of the directory

### DIFF
--- a/app/src/components/app-ui/BillPortalBrowser.tsx
+++ b/app/src/components/app-ui/BillPortalBrowser.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useRef, useState } from 'react';
+import { X, ExternalLink, Lock, CreditCard, ChevronUp, ShieldCheck } from 'lucide-react';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+import type { BillPortal } from '@/data/billPortals';
+
+/*
+ * In-app "browser" for a bill portal: loads the biller's own page in an iframe with a read-only URL bar,
+ * and a floating Clear card overlay to copy while paying. Many billers block framing (X-Frame-Options),
+ * which fires no error event, so we use a load timeout: if the frame hasn't loaded in time we assume it's
+ * blocked and show a branded launch screen that opens the site in a new tab instead.
+ *
+ * P2: <CardOverlay/> gets the live Stripe Issuing Element (PAN/CVV) + real tap-to-copy behind a passkey.
+ */
+const LOAD_TIMEOUT_MS = 3500;
+
+export default function BillPortalBrowser({ portal, onClose }: { portal: BillPortal | null; onClose: () => void }) {
+  const [blocked, setBlocked] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!portal) return;
+    setBlocked(false);
+    setLoaded(false);
+    timer.current = setTimeout(() => setBlocked(true), LOAD_TIMEOUT_MS);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [portal]);
+
+  if (!portal) return null;
+  const host = (() => {
+    try {
+      return new URL(portal.url).host;
+    } catch {
+      return portal.url;
+    }
+  })();
+
+  const openExternal = () => window.open(portal.url, '_blank', 'noopener,noreferrer');
+
+  return (
+    <Dialog open={!!portal} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="flex h-[92vh] w-[96vw] max-w-[960px] flex-col gap-0 overflow-hidden p-0">
+        {/* browser chrome */}
+        <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+          <button type="button" onClick={onClose} aria-label="Close" className="rounded-lg p-1.5 text-muted-foreground hover:bg-secondary hover:text-foreground">
+            <X className="h-4 w-4" />
+          </button>
+          <div className="flex min-w-0 flex-1 items-center gap-1.5 rounded-lg bg-secondary/60 px-2.5 py-1.5">
+            <Lock className="h-3 w-3 shrink-0 text-muted-foreground" />
+            <span className="truncate text-xs text-muted-foreground">{host}</span>
+          </div>
+          <button
+            type="button"
+            onClick={openExternal}
+            className="inline-flex shrink-0 items-center gap-1 rounded-lg px-2 py-1.5 text-xs font-medium text-muted-foreground hover:bg-secondary hover:text-foreground"
+          >
+            <ExternalLink className="h-3.5 w-3.5" /> <span className="hidden sm:inline">Open in new tab</span>
+          </button>
+        </div>
+
+        {/* content: iframe, or a branded launch screen if framing is blocked */}
+        <div className="relative min-h-0 flex-1 bg-background">
+          {!blocked ? (
+            <iframe
+              title={portal.name}
+              src={portal.url}
+              onLoad={() => {
+                if (timer.current) clearTimeout(timer.current);
+                setLoaded(true);
+              }}
+              className="h-full w-full border-0"
+              referrerPolicy="no-referrer"
+              sandbox="allow-forms allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
+            />
+          ) : (
+            <div className="flex h-full flex-col items-center justify-center px-6 text-center">
+              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-secondary text-2xl">🔒</div>
+              <div className="mt-4 text-base font-semibold text-foreground">{portal.name} opens in a new tab</div>
+              <p className="mt-1 max-w-[320px] text-sm text-muted-foreground">
+                For your security, {portal.name} doesn’t allow embedding. It’ll open in a new tab — keep your Clear card handy to pay.
+              </p>
+              <button
+                type="button"
+                onClick={openExternal}
+                className="mt-5 inline-flex items-center gap-2 rounded-xl bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.99]"
+              >
+                <ExternalLink className="h-4 w-4" /> Open {portal.name}
+              </button>
+            </div>
+          )}
+          {!blocked && !loaded && (
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-background/60 text-sm text-muted-foreground">
+              Loading {portal.name}…
+            </div>
+          )}
+        </div>
+
+        {/* floating Clear card overlay (P2 renders the live card here) */}
+        <CardOverlay />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Floating wallet to copy the Clear card while paying. P1: an "activating" state (no live digits yet).
+ * P2: expands to a Stripe Issuing Element with the real PAN/CVV/expiry + tap-to-copy behind a passkey.
+ */
+function CardOverlay() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border-t border-border bg-card px-3 py-2">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2.5 rounded-lg px-1 py-1 text-left"
+      >
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
+          <CreditCard className="h-4 w-4" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-sm font-medium text-foreground">Pay with your Clear card</span>
+          <span className="block text-xs text-muted-foreground">Funded from your Cash balance · USDC</span>
+        </span>
+        <ChevronUp className={cn('h-4 w-4 text-muted-foreground transition-transform', open && 'rotate-180')} />
+      </button>
+      {open && (
+        <div className="mt-2 flex items-center gap-2 rounded-xl border border-dashed border-border px-3 py-3 text-sm text-muted-foreground">
+          <ShieldCheck className="h-4 w-4 shrink-0 text-amber-500" />
+          Your Clear card is activating — card details to copy will appear here once it’s live.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/app-ui/BillPortalsModal.tsx
+++ b/app/src/components/app-ui/BillPortalsModal.tsx
@@ -1,12 +1,14 @@
 import { useMemo, useState } from 'react';
-import { Search, ExternalLink, ShieldCheck, CreditCard, Info, ChevronDown } from 'lucide-react';
+import { Search, ChevronRight, Info, ChevronDown } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
+import BillPortalBrowser from '@/components/app-ui/BillPortalBrowser';
 import {
   BILL_PORTALS,
   PORTAL_CATEGORIES,
   US_STATES,
   rankPortals,
+  type BillPortal,
   type PortalCategory,
 } from '@/data/billPortals';
 
@@ -22,6 +24,7 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<PortalCategory | 'all'>('all');
   const [state, setState] = useState<string>('');
+  const [active, setActive] = useState<BillPortal | null>(null);
 
   const portals = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -43,11 +46,6 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
             <p className="mt-0.5 text-xs text-muted-foreground">
               Open your provider and pay with your Clear card — funded from your Cash balance.
             </p>
-          </div>
-
-          {/* Clear card panel (P2 renders the live Stripe Issuing element here) */}
-          <div className="px-5 pt-4">
-            <CardPanel />
           </div>
 
           {/* controls */}
@@ -93,12 +91,11 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
               {portals.map((p) => {
                 const cat = PORTAL_CATEGORIES.find((c) => c.id === p.category);
                 return (
-                  <a
+                  <button
                     key={p.id}
-                    href={p.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-3 rounded-xl border border-border p-2.5 text-left transition-colors hover:bg-secondary/50"
+                    type="button"
+                    onClick={() => setActive(p)}
+                    className="flex w-full items-center gap-3 rounded-xl border border-border p-2.5 text-left transition-colors hover:bg-secondary/50"
                   >
                     <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-secondary text-base">
                       {cat?.emoji}
@@ -110,8 +107,8 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
                         {p.states && state && p.states.includes(state) ? ' · in your area' : ''}
                       </span>
                     </span>
-                    <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground" />
-                  </a>
+                    <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  </button>
                 );
               })}
               {portals.length === 0 && (
@@ -128,6 +125,9 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
           </div>
         </div>
       </DialogContent>
+
+      {/* In-app browser sheet for the selected biller (opens over the directory) */}
+      <BillPortalBrowser portal={active} onClose={() => setActive(null)} />
     </Dialog>
   );
 }
@@ -144,29 +144,5 @@ function Chip({ active, onClick, children }: { active: boolean; onClick: () => v
     >
       {children}
     </button>
-  );
-}
-
-/**
- * The Clear card. P1 shows an "activating" placeholder; P2 replaces the masked digits with a Stripe
- * Issuing Element (PCI-compliant iframe) plus tap-to-copy, gated behind a passkey reveal.
- */
-function CardPanel() {
-  return (
-    <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-neutral-900 to-neutral-700 p-4 text-white shadow-sm dark:from-neutral-800 dark:to-neutral-950">
-      <div className="flex items-start justify-between">
-        <div>
-          <div className="text-[11px] font-medium uppercase tracking-wide text-white/60">Clear card</div>
-          <div className="mt-3 font-mono text-lg tracking-[0.2em] text-white/90">•••• •••• •••• ••••</div>
-        </div>
-        <CreditCard className="h-5 w-5 text-white/70" />
-      </div>
-      <div className="mt-3 flex items-center justify-between">
-        <span className="inline-flex items-center gap-1 rounded-full bg-white/15 px-2 py-0.5 text-[11px] font-medium text-white/90">
-          <ShieldCheck className="h-3 w-3" /> Activating soon
-        </span>
-        <span className="text-[11px] text-white/60">Pays from Cash · USDC</span>
-      </div>
-    </div>
   );
 }


### PR DESCRIPTION
Reworks the P1 flow per feedback ("the modal sucks; open the page in the app; card doesn't belong in the directory").

- **Directory = just the list** — the card panel is removed.
- **Tap a biller → in-app browser sheet**: loads the biller's page in an iframe with a read-only URL bar + "open in new tab". Since many billers block framing (`X-Frame-Options`, which fires no error event), a **load timeout auto-falls-back** to a branded launch screen that opens the site in a new tab.
- **Floating Clear card overlay** in that sheet — the right home for the card (copy it while on the biller's page). P1 "activating" placeholder now; **P2 drops the live Stripe Issuing Element into `<CardOverlay/>`**.

Note: a web app genuinely can't autofill or read a cross-origin biller page — this is the honest "open hosted link in-app" version, with graceful fallback where framing is blocked.

Typecheck + build pass; behind the KYC gate so not exercisable in the sandbox preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)