### PR TITLE
Clear Pay: fix blank portal screens + deep-link login/pay pages

### DIFF
--- a/app/src/components/app-ui/BillPortalBrowser.tsx
+++ b/app/src/components/app-ui/BillPortalBrowser.tsx
@@ -1,36 +1,20 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { X, ExternalLink, Lock, CreditCard, ChevronUp, ShieldCheck, Loader2 } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 import { useClearCard } from '@/hooks/useClearCard';
 import StripeCardDetails, { stripeCardsConfigured } from '@/components/app-ui/StripeCardDetails';
-import type { BillPortal } from '@/data/billPortals';
+import { PORTAL_CATEGORIES, type BillPortal } from '@/data/billPortals';
 
 /*
- * In-app "browser" for a bill portal: loads the biller's own page in an iframe with a read-only URL bar,
- * and a floating Clear card overlay to copy while paying. Many billers block framing (X-Frame-Options),
- * which fires no error event, so we use a load timeout: if the frame hasn't loaded in time we assume it's
- * blocked and show a branded launch screen that opens the site in a new tab instead.
+ * In-app portal view. Billers overwhelmingly block iframing (X-Frame-Options) — and that can't be
+ * detected cross-origin, so a blocked frame just renders blank. Rather than gamble on a blank screen,
+ * the default is a branded launch screen that opens the biller's login/pay page in a new tab, with a
+ * floating Clear card overlay to copy while paying. Only portals explicitly flagged `frameable` embed.
  *
- * P2: <CardOverlay/> gets the live Stripe Issuing Element (PAN/CVV) + real tap-to-copy behind a passkey.
+ * P2: <CardOverlay/> shows the live Stripe Issuing card (PAN/CVV) when active.
  */
-const LOAD_TIMEOUT_MS = 3500;
-
 export default function BillPortalBrowser({ portal, onClose }: { portal: BillPortal | null; onClose: () => void }) {
-  const [blocked, setBlocked] = useState(false);
-  const [loaded, setLoaded] = useState(false);
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    if (!portal) return;
-    setBlocked(false);
-    setLoaded(false);
-    timer.current = setTimeout(() => setBlocked(true), LOAD_TIMEOUT_MS);
-    return () => {
-      if (timer.current) clearTimeout(timer.current);
-    };
-  }, [portal]);
-
   if (!portal) return null;
   const host = (() => {
     try {
@@ -39,7 +23,6 @@ export default function BillPortalBrowser({ portal, onClose }: { portal: BillPor
       return portal.url;
     }
   })();
-
   const openExternal = () => window.open(portal.url, '_blank', 'noopener,noreferrer');
 
   return (
@@ -63,40 +46,17 @@ export default function BillPortalBrowser({ portal, onClose }: { portal: BillPor
           </button>
         </div>
 
-        {/* content: iframe, or a branded launch screen if framing is blocked */}
         <div className="relative min-h-0 flex-1 bg-background">
-          {!blocked ? (
+          {portal.frameable ? (
             <iframe
               title={portal.name}
               src={portal.url}
-              onLoad={() => {
-                if (timer.current) clearTimeout(timer.current);
-                setLoaded(true);
-              }}
               className="h-full w-full border-0"
               referrerPolicy="no-referrer"
               sandbox="allow-forms allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
             />
           ) : (
-            <div className="flex h-full flex-col items-center justify-center px-6 text-center">
-              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-secondary text-2xl">🔒</div>
-              <div className="mt-4 text-base font-semibold text-foreground">{portal.name} opens in a new tab</div>
-              <p className="mt-1 max-w-[320px] text-sm text-muted-foreground">
-                For your security, {portal.name} doesn’t allow embedding. It’ll open in a new tab — keep your Clear card handy to pay.
-              </p>
-              <button
-                type="button"
-                onClick={openExternal}
-                className="mt-5 inline-flex items-center gap-2 rounded-xl bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.99]"
-              >
-                <ExternalLink className="h-4 w-4" /> Open {portal.name}
-              </button>
-            </div>
-          )}
-          {!blocked && !loaded && (
-            <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-background/60 text-sm text-muted-foreground">
-              Loading {portal.name}…
-            </div>
+            <LaunchScreen portal={portal} onOpen={openExternal} />
           )}
         </div>
 
@@ -104,6 +64,27 @@ export default function BillPortalBrowser({ portal, onClose }: { portal: BillPor
         <CardOverlay />
       </DialogContent>
     </Dialog>
+  );
+}
+
+/** Branded "open the biller's login/pay page" screen — the default, so users never hit a blank iframe. */
+function LaunchScreen({ portal, onOpen }: { portal: BillPortal; onOpen: () => void }) {
+  const cat = PORTAL_CATEGORIES.find((c) => c.id === portal.category);
+  return (
+    <div className="flex h-full flex-col items-center justify-center px-6 text-center">
+      <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-secondary text-3xl">{cat?.emoji}</div>
+      <div className="mt-4 text-lg font-semibold text-foreground">Pay your {portal.name} bill</div>
+      <p className="mt-1 max-w-[340px] text-sm text-muted-foreground">
+        For your security, {portal.name} opens in a new tab. Sign in there and pay with your Clear card — it’s at the bottom to copy.
+      </p>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="mt-5 inline-flex items-center gap-2 rounded-xl bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.99]"
+      >
+        <ExternalLink className="h-4 w-4" /> Open {portal.name} login
+      </button>
+    </div>
   );
 }
 

--- a/app/src/data/billPortals.ts
+++ b/app/src/data/billPortals.ts
@@ -11,10 +11,13 @@ export interface BillPortal {
   id: string;
   name: string;
   category: PortalCategory;
+  /** Deep link to the provider's login / pay-bill page (not the marketing home). */
   url: string;
   hint?: string;
   /** US state codes served; omit for national providers. */
   states?: string[];
+  /** Rare: the site permits iframing, so we can embed it in-app. Default (undefined) → opens in a new tab. */
+  frameable?: boolean;
 }
 
 export const PORTAL_CATEGORIES: { id: PortalCategory; label: string; emoji: string }[] = [
@@ -46,42 +49,42 @@ export const US_STATES: { code: string; name: string }[] = [
 
 export const BILL_PORTALS: BillPortal[] = [
   // ── Electric (investor-owned utilities) ─────────────────────────────────────
-  { id: 'pge', name: 'PG&E', category: 'electric', hint: 'Gas & electric', url: 'https://www.pge.com/', states: ['CA'] },
-  { id: 'sce', name: 'Southern California Edison', category: 'electric', hint: 'Electric', url: 'https://www.sce.com/', states: ['CA'] },
-  { id: 'sdge', name: 'San Diego Gas & Electric', category: 'electric', hint: 'Gas & electric', url: 'https://www.sdge.com/', states: ['CA'] },
-  { id: 'coned', name: 'Con Edison', category: 'electric', hint: 'Gas & electric', url: 'https://www.coned.com/', states: ['NY'] },
-  { id: 'comed', name: 'ComEd', category: 'electric', hint: 'Electric', url: 'https://www.comed.com/', states: ['IL'] },
-  { id: 'duke', name: 'Duke Energy', category: 'electric', hint: 'Electric', url: 'https://www.duke-energy.com/', states: ['NC', 'SC', 'FL', 'OH', 'IN', 'KY'] },
-  { id: 'fpl', name: 'Florida Power & Light', category: 'electric', hint: 'Electric', url: 'https://www.fpl.com/', states: ['FL'] },
-  { id: 'georgiapower', name: 'Georgia Power', category: 'electric', hint: 'Electric', url: 'https://www.georgiapower.com/', states: ['GA'] },
-  { id: 'oncor', name: 'Oncor / TXU Energy', category: 'electric', hint: 'Electric', url: 'https://www.txu.com/', states: ['TX'] },
-  { id: 'dominion', name: 'Dominion Energy', category: 'electric', hint: 'Electric', url: 'https://www.dominionenergy.com/', states: ['VA', 'NC', 'SC', 'OH'] },
-  { id: 'xcel', name: 'Xcel Energy', category: 'electric', hint: 'Gas & electric', url: 'https://www.xcelenergy.com/', states: ['CO', 'MN', 'TX', 'NM', 'WI', 'MI', 'ND', 'SD'] },
-  { id: 'aps', name: 'Arizona Public Service', category: 'electric', hint: 'Electric', url: 'https://www.aps.com/', states: ['AZ'] },
-  { id: 'nvenergy', name: 'NV Energy', category: 'electric', hint: 'Electric', url: 'https://www.nvenergy.com/', states: ['NV'] },
-  { id: 'pse', name: 'Puget Sound Energy', category: 'electric', hint: 'Gas & electric', url: 'https://www.pse.com/', states: ['WA'] },
+  { id: 'pge', name: 'PG&E', category: 'electric', hint: 'Gas & electric', url: 'https://m.pge.com/', states: ['CA'] },
+  { id: 'sce', name: 'Southern California Edison', category: 'electric', hint: 'Electric', url: 'https://www.sce.com/mysce/login', states: ['CA'] },
+  { id: 'sdge', name: 'San Diego Gas & Electric', category: 'electric', hint: 'Gas & electric', url: 'https://myaccount.sdge.com/', states: ['CA'] },
+  { id: 'coned', name: 'Con Edison', category: 'electric', hint: 'Gas & electric', url: 'https://www.coned.com/en/login', states: ['NY'] },
+  { id: 'comed', name: 'ComEd', category: 'electric', hint: 'Electric', url: 'https://secure.comed.com/MyAccount/Pages/Login.aspx', states: ['IL'] },
+  { id: 'duke', name: 'Duke Energy', category: 'electric', hint: 'Electric', url: 'https://www.duke-energy.com/my-account/sign-in', states: ['NC', 'SC', 'FL', 'OH', 'IN', 'KY'] },
+  { id: 'fpl', name: 'Florida Power & Light', category: 'electric', hint: 'Electric', url: 'https://www.fpl.com/my-account/login.html', states: ['FL'] },
+  { id: 'georgiapower', name: 'Georgia Power', category: 'electric', hint: 'Electric', url: 'https://www.georgiapower.com/sign-in.html', states: ['GA'] },
+  { id: 'oncor', name: 'Oncor / TXU Energy', category: 'electric', hint: 'Electric', url: 'https://www.txu.com/en/residential/login', states: ['TX'] },
+  { id: 'dominion', name: 'Dominion Energy', category: 'electric', hint: 'Electric', url: 'https://www.dominionenergy.com/sign-in', states: ['VA', 'NC', 'SC', 'OH'] },
+  { id: 'xcel', name: 'Xcel Energy', category: 'electric', hint: 'Gas & electric', url: 'https://my.xcelenergy.com/MyAccount/s/login/', states: ['CO', 'MN', 'TX', 'NM', 'WI', 'MI', 'ND', 'SD'] },
+  { id: 'aps', name: 'Arizona Public Service', category: 'electric', hint: 'Electric', url: 'https://www.aps.com/en/Account-Login', states: ['AZ'] },
+  { id: 'nvenergy', name: 'NV Energy', category: 'electric', hint: 'Electric', url: 'https://www.nvenergy.com/account/login', states: ['NV'] },
+  { id: 'pse', name: 'Puget Sound Energy', category: 'electric', hint: 'Gas & electric', url: 'https://myaccount.pse.com/', states: ['WA'] },
 
   // ── Utilities (gas / water) ────────────────────────────────────────────────
-  { id: 'socalgas', name: 'SoCalGas', category: 'utilities', hint: 'Natural gas', url: 'https://www.socalgas.com/', states: ['CA'] },
-  { id: 'nationalgrid', name: 'National Grid', category: 'utilities', hint: 'Gas & electric', url: 'https://www.nationalgridus.com/', states: ['NY', 'MA', 'RI'] },
-  { id: 'atmos', name: 'Atmos Energy', category: 'utilities', hint: 'Natural gas', url: 'https://www.atmosenergy.com/', states: ['TX', 'LA', 'MS', 'CO', 'KS', 'KY', 'TN'] },
-  { id: 'amwater', name: 'American Water', category: 'utilities', hint: 'Water', url: 'https://www.amwater.com/', states: ['NJ', 'PA', 'IL', 'MO', 'CA', 'IN', 'WV'] },
-  { id: 'nicor', name: 'Nicor Gas', category: 'utilities', hint: 'Natural gas', url: 'https://www.nicorgas.com/', states: ['IL'] },
+  { id: 'socalgas', name: 'SoCalGas', category: 'utilities', hint: 'Natural gas', url: 'https://myaccount.socalgas.com/', states: ['CA'] },
+  { id: 'nationalgrid', name: 'National Grid', category: 'utilities', hint: 'Gas & electric', url: 'https://www.nationalgridus.com/login', states: ['NY', 'MA', 'RI'] },
+  { id: 'atmos', name: 'Atmos Energy', category: 'utilities', hint: 'Natural gas', url: 'https://www.atmosenergy.com/accountcenter/logon/login.html', states: ['TX', 'LA', 'MS', 'CO', 'KS', 'KY', 'TN'] },
+  { id: 'amwater', name: 'American Water', category: 'utilities', hint: 'Water', url: 'https://www.amwater.com/mywater/login', states: ['NJ', 'PA', 'IL', 'MO', 'CA', 'IN', 'WV'] },
+  { id: 'nicor', name: 'Nicor Gas', category: 'utilities', hint: 'Natural gas', url: 'https://www.nicorgas.com/sign-in', states: ['IL'] },
 
   // ── Rent (landlord payment platforms — national) ───────────────────────────
-  { id: 'rentcafe', name: 'RentCafe', category: 'rent', hint: 'Resident portal', url: 'https://www.rentcafe.com/' },
+  { id: 'rentcafe', name: 'RentCafe', category: 'rent', hint: 'Resident portal', url: 'https://www.rentcafe.com/residentservices/apartmentsforrent/userlogin.aspx' },
   { id: 'appfolio', name: 'AppFolio', category: 'rent', hint: 'Online portal', url: 'https://www.appfolio.com/online-portal-login' },
-  { id: 'buildium', name: 'Buildium', category: 'rent', hint: 'Resident portal', url: 'https://www.buildium.com/' },
-  { id: 'zillow', name: 'Zillow Rental Manager', category: 'rent', hint: 'Pay rent online', url: 'https://www.zillow.com/rental-manager/' },
-  { id: 'payyourrent', name: 'PayYourRent', category: 'rent', hint: 'Pay rent online', url: 'https://www.payyourrent.com/' },
+  { id: 'buildium', name: 'Buildium', category: 'rent', hint: 'Resident portal', url: 'https://signin.managebuilding.com/manager/public/authentication/login' },
+  { id: 'zillow', name: 'Zillow Rental Manager', category: 'rent', hint: 'Pay rent online', url: 'https://www.zillow.com/user/acct/login/' },
+  { id: 'payyourrent', name: 'PayYourRent', category: 'rent', hint: 'Pay rent online', url: 'https://online.payyourrent.com/' },
   { id: 'entrata', name: 'Entrata / ResidentPortal', category: 'rent', hint: 'Resident portal', url: 'https://www.residentportal.com/' },
 
   // ── Telecom (national) ─────────────────────────────────────────────────────
-  { id: 'att', name: 'AT&T', category: 'telecom', hint: 'Wireless & internet', url: 'https://www.att.com/my/' },
-  { id: 'verizon', name: 'Verizon', category: 'telecom', hint: 'Wireless & Fios', url: 'https://www.verizon.com/pay-bill/' },
-  { id: 'tmobile', name: 'T-Mobile', category: 'telecom', hint: 'Wireless', url: 'https://www.t-mobile.com/' },
-  { id: 'xfinity', name: 'Xfinity / Comcast', category: 'telecom', hint: 'Internet & TV', url: 'https://www.xfinity.com/bill' },
-  { id: 'spectrum', name: 'Spectrum', category: 'telecom', hint: 'Internet & TV', url: 'https://www.spectrum.net/pay-bill' },
+  { id: 'att', name: 'AT&T', category: 'telecom', hint: 'Wireless & internet', url: 'https://signin.att.com/' },
+  { id: 'verizon', name: 'Verizon', category: 'telecom', hint: 'Wireless & Fios', url: 'https://www.verizon.com/signin' },
+  { id: 'tmobile', name: 'T-Mobile', category: 'telecom', hint: 'Wireless', url: 'https://account.t-mobile.com/' },
+  { id: 'xfinity', name: 'Xfinity / Comcast', category: 'telecom', hint: 'Internet & TV', url: 'https://login.xfinity.com/login' },
+  { id: 'spectrum', name: 'Spectrum', category: 'telecom', hint: 'Internet & TV', url: 'https://www.spectrum.net/login' },
   { id: 'cox', name: 'Cox Communications', category: 'telecom', hint: 'Internet & TV', url: 'https://www.cox.com/residential/pay-bill.html' },
 ];
 


### PR DESCRIPTION
Fixes two issues from feedback: blank portal screens, and links landing on the homepage.

## Blank screens
Billers overwhelmingly block iframing (`X-Frame-Options`), and that **can't be detected cross-origin** — a blocked frame often fires `onLoad` with a blank doc, so the old timeout fallback never tripped and you got a blank screen. So iframe-first was the wrong default.

Now the default is a **branded launch screen** (category icon + "Pay your {biller} bill" + Open login button) that opens the biller in a new tab, with the Clear card overlay right there to copy. **No blank iframes.** Only portals explicitly flagged `frameable` embed (none yet — it's there for the rare site that allows it).

## Deep links
Every portal URL now points at the **login / pay-bill page** instead of the marketing homepage (e.g. `m.pge.com`, `login.xfinity.com/login`, `myaccount.socalgas.com`, `signin.att.com`).

Typecheck + build pass; behind the KYC gate so not exercisable in the sandbox preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)