### PR TITLE
Clear Pay: gate WIP portal directory off in production

### DIFF
--- a/app/src/pages/app/PayPage.tsx
+++ b/app/src/pages/app/PayPage.tsx
@@ -7,6 +7,7 @@ import BillTimeline, { type TimelineBill } from '@/components/app-ui/BillTimelin
 import CardVisual from '@/components/app-ui/CardVisual';
 import { usePay } from '@/context/PayContext';
 import { useMoneyActions } from '@/context/MoneyActionsContext';
+import { IS_LIVE_APP } from '@/lib/clearNetwork';
 
 const fmtUsd = (n: number) => `$${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
@@ -49,7 +50,8 @@ export default function PayPage() {
           <h3 className="mb-3 text-xs font-medium text-muted-foreground">Make a payment</h3>
           <div className="grid grid-cols-2 gap-3">
             <ActionTile icon={Home} label="Pay rent" hint="Schedule or pay now" primary onClick={() => openPay('rent')} />
-            <ActionTile icon={FileText} label="Pay a bill" hint="Utilities, rent & more" onClick={openPortals} />
+            {/* Clear Pay portal directory is still in progress — production keeps the old bill flow; demo/dev gets the new one. */}
+            <ActionTile icon={FileText} label="Pay a bill" hint="Utilities, rent & more" onClick={IS_LIVE_APP ? () => openPay() : openPortals} />
             <ActionTile icon={SendHorizontal} label="Send" hint="To anyone" onClick={openSend} />
             <ActionTile icon={ArrowDownLeft} label="Request" hint="Get paid" onClick={openRequest} />
             <ActionTile icon={Repeat} label="Auto-save" hint="Sign once, build equity" onClick={openAutoSave} />


### PR DESCRIPTION
Hides the in-progress bill-portal flow from production (app.useclear.org) — it keeps the existing 'Pay a bill' flow, while demo/dev show the new directory for iteration. Feature still needs: existing manual+Plaid billers folded in, the equity-credit gamification, and a smarter location/info-aware list. 🤖 Generated with [Claude Code](https://claude.com/claude-code)