### PR TITLE
Clear Pay: bill/transaction detail drawer (fully featured) + Send/notifications/analytics

### DIFF
--- a/app/server/src/routes/pay.ts
+++ b/app/server/src/routes/pay.ts
@@ -52,6 +52,19 @@ router.get('/:wallet/billers', async (req: Request, res: Response) => {
   }
 });
 
+// GET /api/pay/:wallet/billers/:id/payments — a biller's payment history (bill detail view)
+router.get('/:wallet/billers/:id/payments', async (req: Request, res: Response) => {
+  const w = wallet(req);
+  if (!requireWalletMatch(req, res, w, 'wallet')) return;
+  if (!ensureReady(res)) return;
+  try {
+    res.json({ payments: await payLedgerStore.listBillerPayments(w, String(req.params.id)) });
+  } catch (error) {
+    console.error('[pay/biller payments]', error);
+    res.status(500).json({ error: 'Failed to load payments' });
+  }
+});
+
 // POST /api/pay/:wallet/billers  { name, payee?, type, defaultAmount, dueDay }
 router.post('/:wallet/billers', async (req: Request, res: Response) => {
   const w = wallet(req);

--- a/app/server/src/routes/pay.ts
+++ b/app/server/src/routes/pay.ts
@@ -78,6 +78,38 @@ router.get('/:wallet/billers/:id/payments', async (req: Request, res: Response) 
   }
 });
 
+// GET /api/pay/:wallet/merchant-meta?name= — shared merchant portal/address
+router.get('/:wallet/merchant-meta', async (req: Request, res: Response) => {
+  const w = wallet(req);
+  if (!requireWalletMatch(req, res, w, 'wallet')) return;
+  if (!ensureReady(res)) return;
+  try {
+    res.json({ meta: await payLedgerStore.getMerchantMeta(w, String(req.query.name || '')) });
+  } catch (error) {
+    console.error('[pay/merchant-meta GET]', error);
+    res.status(500).json({ error: 'Failed to load merchant info' });
+  }
+});
+
+// PUT /api/pay/:wallet/merchant-meta  { name, portalUrl?, address? }
+router.put('/:wallet/merchant-meta', async (req: Request, res: Response) => {
+  const w = wallet(req);
+  if (!requireWalletMatch(req, res, w, 'wallet')) return;
+  if (!ensureReady(res)) return;
+  const b = req.body as { name?: string; portalUrl?: string | null; address?: string | null };
+  if (!b?.name) { res.status(400).json({ error: 'name is required' }); return; }
+  try {
+    const meta = await payLedgerStore.upsertMerchantMeta(w, String(b.name), {
+      ...(b.portalUrl !== undefined ? { portalUrl: cleanUrl(b.portalUrl) } : {}),
+      ...(b.address !== undefined ? { address: b.address ? String(b.address).slice(0, 300) : null } : {}),
+    });
+    res.json({ meta });
+  } catch (error) {
+    console.error('[pay/merchant-meta PUT]', error);
+    res.status(500).json({ error: 'Failed to save merchant info' });
+  }
+});
+
 // POST /api/pay/:wallet/billers  { name, payee?, type, defaultAmount, dueDay }
 router.post('/:wallet/billers', async (req: Request, res: Response) => {
   const w = wallet(req);

--- a/app/server/src/routes/pay.ts
+++ b/app/server/src/routes/pay.ts
@@ -14,6 +14,19 @@ const router = Router();
 const VALID_TYPES = new Set<BillerType>(['rent', 'utility', 'subscription', 'card', 'phone', 'other']);
 const wallet = (req: Request) => String(req.params.wallet || '').toLowerCase();
 
+/** Normalize a user-supplied portal URL to a safe http(s) link, or null. */
+function cleanUrl(v: unknown): string | null {
+  const s = typeof v === 'string' ? v.trim() : '';
+  if (!s) return null;
+  const withProto = /^https?:\/\//i.test(s) ? s : `https://${s}`;
+  try {
+    const u = new URL(withProto);
+    return u.protocol === 'http:' || u.protocol === 'https:' ? u.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Credit environment from the request origin: the live app earns mainnet credits, the demo testnet. */
 const networkFromOrigin = (req: Request): 'mainnet' | 'testnet' =>
   String(req.headers.origin || req.headers.referer || '').includes('app.useclear.org') ? 'mainnet' : 'testnet';
@@ -70,7 +83,7 @@ router.post('/:wallet/billers', async (req: Request, res: Response) => {
   const w = wallet(req);
   if (!requireWalletMatch(req, res, w, 'wallet')) return;
   if (!ensureReady(res)) return;
-  const b = req.body as { name?: string; payee?: string; type?: string; defaultAmount?: number; dueDay?: number };
+  const b = req.body as { name?: string; payee?: string; type?: string; defaultAmount?: number; dueDay?: number; portalUrl?: string; address?: string };
   if (!b?.name || !b?.type || !VALID_TYPES.has(b.type as BillerType)) {
     res.status(400).json({ error: 'name and valid type are required' });
     return;
@@ -82,6 +95,8 @@ router.post('/:wallet/billers', async (req: Request, res: Response) => {
       type: b.type as BillerType,
       defaultAmount: Number(b.defaultAmount) || 0,
       dueDay: b.dueDay == null ? null : Math.min(Math.max(Math.round(Number(b.dueDay)), 1), 31),
+      portalUrl: cleanUrl(b.portalUrl),
+      address: b.address ? String(b.address).slice(0, 300) : null,
     });
     res.json({ biller });
   } catch (error) {
@@ -95,7 +110,7 @@ router.put('/:wallet/billers/:id', async (req: Request, res: Response) => {
   const w = wallet(req);
   if (!requireWalletMatch(req, res, w, 'wallet')) return;
   if (!ensureReady(res)) return;
-  const b = req.body as { name?: string; payee?: string; type?: string; defaultAmount?: number; dueDay?: number };
+  const b = req.body as { name?: string; payee?: string; type?: string; defaultAmount?: number; dueDay?: number; portalUrl?: string; address?: string };
   if (!b?.name || !b?.type || !VALID_TYPES.has(b.type as BillerType)) {
     res.status(400).json({ error: 'name and valid type are required' });
     return;
@@ -107,6 +122,8 @@ router.put('/:wallet/billers/:id', async (req: Request, res: Response) => {
       type: b.type as BillerType,
       defaultAmount: Number(b.defaultAmount) || 0,
       dueDay: b.dueDay == null ? null : Math.min(Math.max(Math.round(Number(b.dueDay)), 1), 31),
+      portalUrl: cleanUrl(b.portalUrl),
+      address: b.address ? String(b.address).slice(0, 300) : null,
     });
     if (!biller) {
       res.status(404).json({ error: 'Biller not found or not editable (auto-detected billers are read-only)' });
@@ -116,6 +133,21 @@ router.put('/:wallet/billers/:id', async (req: Request, res: Response) => {
   } catch (error) {
     console.error('[pay/billers PUT]', error);
     res.status(500).json({ error: 'Failed to update biller' });
+  }
+});
+
+// PATCH /api/pay/:wallet/billers/:id/reminders  { enabled }  — works for any biller
+router.patch('/:wallet/billers/:id/reminders', async (req: Request, res: Response) => {
+  const w = wallet(req);
+  if (!requireWalletMatch(req, res, w, 'wallet')) return;
+  if (!ensureReady(res)) return;
+  try {
+    const biller = await payLedgerStore.setBillerReminders(w, String(req.params.id), Boolean((req.body as { enabled?: boolean })?.enabled));
+    if (!biller) { res.status(404).json({ error: 'Biller not found' }); return; }
+    res.json({ biller });
+  } catch (error) {
+    console.error('[pay/billers reminders]', error);
+    res.status(500).json({ error: 'Failed to update reminders' });
   }
 });
 

--- a/app/server/src/services/payLedgerStore.ts
+++ b/app/server/src/services/payLedgerStore.ts
@@ -127,6 +127,9 @@ async function ensureTables(): Promise<void> {
     ALTER TABLE pay_billers ADD COLUMN IF NOT EXISTS payout_routing TEXT;
     ALTER TABLE pay_billers ADD COLUMN IF NOT EXISTS payout_bank_name TEXT;
     ALTER TABLE pay_billers ADD COLUMN IF NOT EXISTS bridge_external_account_id TEXT;
+    ALTER TABLE pay_billers ADD COLUMN IF NOT EXISTS portal_url TEXT;
+    ALTER TABLE pay_billers ADD COLUMN IF NOT EXISTS address TEXT;
+    ALTER TABLE pay_billers ADD COLUMN IF NOT EXISTS reminders BOOLEAN NOT NULL DEFAULT true;
   `);
   // Tag each credit with the environment it was earned in ('mainnet' = live/real, 'testnet' = demo).
   // The demo's deposit-match credits (Base Sepolia) stay separate from mainnet credits that count.
@@ -148,6 +151,9 @@ export interface Biller {
   payoutLast4: string | null;
   payoutBank: string | null;
   bridgeExternalAccountId: string | null;
+  portalUrl: string | null;
+  address: string | null;
+  reminders: boolean;
 }
 
 export interface PaySummary {
@@ -177,6 +183,9 @@ function rowToBiller(r: Record<string, unknown>): Biller {
     payoutLast4: r.payout_account_last4 ? String(r.payout_account_last4) : null,
     payoutBank: r.payout_bank_name ? String(r.payout_bank_name) : null,
     bridgeExternalAccountId: r.bridge_external_account_id ? String(r.bridge_external_account_id) : null,
+    portalUrl: r.portal_url ? String(r.portal_url) : null,
+    address: r.address ? String(r.address) : null,
+    reminders: r.reminders !== false,
   };
 }
 
@@ -249,16 +258,16 @@ export const payLedgerStore = {
 
   async addBiller(
     wallet: string,
-    b: Pick<Biller, 'name' | 'payee' | 'type' | 'defaultAmount' | 'dueDay'>,
+    b: Pick<Biller, 'name' | 'payee' | 'type' | 'defaultAmount' | 'dueDay'> & { portalUrl?: string | null; address?: string | null },
   ): Promise<Biller> {
     const pool = getPayPool();
     if (!pool) throw new Error('Postgres not configured');
     await ensureTables();
     const id = crypto.randomUUID();
     const r = await pool.query(
-      `INSERT INTO pay_billers (id, wallet, name, payee, type, default_amount, due_day, source)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,'manual') RETURNING *`,
-      [id, wallet, b.name, b.payee, b.type, b.defaultAmount, b.dueDay],
+      `INSERT INTO pay_billers (id, wallet, name, payee, type, default_amount, due_day, source, portal_url, address)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,'manual',$8,$9) RETURNING *`,
+      [id, wallet, b.name, b.payee, b.type, b.defaultAmount, b.dueDay, b.portalUrl ?? null, b.address ?? null],
     );
     return rowToBiller(r.rows[0]);
   },
@@ -268,16 +277,29 @@ export const payLedgerStore = {
   async updateBiller(
     wallet: string,
     id: string,
-    b: { name: string; payee: string | null; type: BillerType; defaultAmount: number; dueDay: number | null },
+    b: { name: string; payee: string | null; type: BillerType; defaultAmount: number; dueDay: number | null; portalUrl?: string | null; address?: string | null },
   ): Promise<Biller | null> {
     const pool = getPayPool();
     if (!pool) throw new Error('Postgres not configured');
     await ensureTables();
     const r = await pool.query(
-      `UPDATE pay_billers SET name = $3, payee = $4, type = $5, default_amount = $6, due_day = $7
+      `UPDATE pay_billers SET name = $3, payee = $4, type = $5, default_amount = $6, due_day = $7,
+         portal_url = $8, address = $9
         WHERE wallet = $1 AND id = $2 AND source = 'manual' AND archived_at IS NULL
         RETURNING *`,
-      [wallet, id, b.name, b.payee, b.type, b.defaultAmount, b.dueDay],
+      [wallet, id, b.name, b.payee, b.type, b.defaultAmount, b.dueDay, b.portalUrl ?? null, b.address ?? null],
+    );
+    return r.rows[0] ? rowToBiller(r.rows[0]) : null;
+  },
+
+  /** Toggle reminders for any biller (manual or detected). */
+  async setBillerReminders(wallet: string, id: string, enabled: boolean): Promise<Biller | null> {
+    const pool = getPayPool();
+    if (!pool) throw new Error('Postgres not configured');
+    await ensureTables();
+    const r = await pool.query(
+      `UPDATE pay_billers SET reminders = $3 WHERE wallet = $1 AND id = $2 AND archived_at IS NULL RETURNING *`,
+      [wallet, id, enabled],
     );
     return r.rows[0] ? rowToBiller(r.rows[0]) : null;
   },

--- a/app/server/src/services/payLedgerStore.ts
+++ b/app/server/src/services/payLedgerStore.ts
@@ -222,6 +222,31 @@ export const payLedgerStore = {
     return r.rows.map(rowToBiller);
   },
 
+  /** A biller's payment history (for the bill detail view). Newest first. */
+  async listBillerPayments(
+    wallet: string,
+    billerId: string,
+  ): Promise<Array<{ id: string; name: string | null; type: string; amount: number; paidAt: string; onTime: boolean; source: string; period: string }>> {
+    const pool = getPayPool();
+    if (!pool) return [];
+    await ensureTables();
+    const r = await pool.query(
+      `SELECT id, name, type, amount, paid_at, on_time, source, period
+         FROM pay_payments WHERE wallet = $1 AND biller_id = $2 ORDER BY paid_at DESC LIMIT 60`,
+      [wallet, billerId],
+    );
+    return r.rows.map((x) => ({
+      id: String(x.id),
+      name: x.name ? String(x.name) : null,
+      type: String(x.type),
+      amount: num(x.amount),
+      paidAt: (x.paid_at instanceof Date ? x.paid_at : new Date(String(x.paid_at))).toISOString(),
+      onTime: x.on_time !== false,
+      source: String(x.source),
+      period: String(x.period),
+    }));
+  },
+
   async addBiller(
     wallet: string,
     b: Pick<Biller, 'name' | 'payee' | 'type' | 'defaultAmount' | 'dueDay'>,

--- a/app/server/src/services/payLedgerStore.ts
+++ b/app/server/src/services/payLedgerStore.ts
@@ -134,7 +134,25 @@ async function ensureTables(): Promise<void> {
   // Tag each credit with the environment it was earned in ('mainnet' = live/real, 'testnet' = demo).
   // The demo's deposit-match credits (Base Sepolia) stay separate from mainnet credits that count.
   await pool.query(`ALTER TABLE pay_credits ADD COLUMN IF NOT EXISTS network TEXT NOT NULL DEFAULT 'mainnet';`);
+  // Per-merchant metadata (portal link + address), keyed by a normalized merchant name so it's shared
+  // across a merchant's transactions AND its matching biller. The bill/transaction detail view reads +
+  // inline-edits this. One source of truth for merchant info.
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS pay_merchant_meta (
+      wallet TEXT NOT NULL,
+      name_key TEXT NOT NULL,
+      portal_url TEXT,
+      address TEXT,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (wallet, name_key)
+    );
+  `);
   ensured = true;
+}
+
+/** Normalized key for merchant metadata (matches billPortals.matchPortal normalization). */
+export function merchantKey(name: string): string {
+  return String(name || '').toLowerCase().replace(/[^a-z0-9&]+/g, '');
 }
 
 export interface Biller {
@@ -254,6 +272,40 @@ export const payLedgerStore = {
       source: String(x.source),
       period: String(x.period),
     }));
+  },
+
+  /** Read a merchant's shared metadata (portal + address) by name. */
+  async getMerchantMeta(wallet: string, name: string): Promise<{ portalUrl: string | null; address: string | null } | null> {
+    const pool = getPayPool();
+    if (!pool) return null;
+    await ensureTables();
+    const r = await pool.query(`SELECT portal_url, address FROM pay_merchant_meta WHERE wallet = $1 AND name_key = $2`, [wallet, merchantKey(name)]);
+    if (!r.rows[0]) return null;
+    return { portalUrl: r.rows[0].portal_url ?? null, address: r.rows[0].address ?? null };
+  },
+
+  /** Set a merchant's shared metadata. Only the fields passed (not undefined) are changed. */
+  async upsertMerchantMeta(
+    wallet: string,
+    name: string,
+    p: { portalUrl?: string | null; address?: string | null },
+  ): Promise<{ portalUrl: string | null; address: string | null }> {
+    const pool = getPayPool();
+    if (!pool) throw new Error('Postgres not configured');
+    await ensureTables();
+    const key = merchantKey(name);
+    const cur = (await this.getMerchantMeta(wallet, name)) ?? { portalUrl: null, address: null };
+    const next = {
+      portalUrl: p.portalUrl !== undefined ? p.portalUrl : cur.portalUrl,
+      address: p.address !== undefined ? p.address : cur.address,
+    };
+    await pool.query(
+      `INSERT INTO pay_merchant_meta (wallet, name_key, portal_url, address, updated_at)
+         VALUES ($1,$2,$3,$4, now())
+       ON CONFLICT (wallet, name_key) DO UPDATE SET portal_url = $3, address = $4, updated_at = now()`,
+      [wallet, key, next.portalUrl, next.address],
+    );
+    return next;
   },
 
   async addBiller(

--- a/app/src/components/app-ui/ActivityDetailModal.tsx
+++ b/app/src/components/app-ui/ActivityDetailModal.tsx
@@ -1,12 +1,14 @@
 import { type ReactNode } from 'react';
-import { X, ExternalLink, Check, type LucideIcon } from 'lucide-react';
+import { ChevronLeft, BadgeCheck, type LucideIcon } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 
 /*
- * Unified detail view for a bill OR a transaction, styled as a RECEIPT — the modal itself is the paper:
- * one surface, dashed tear-lines between sections, dotted leader rows, monospace figures, a hero total,
- * and (bills only) a bottom action bar. No nested cards. Purely presentational — callers map to DetailInfo.
+ * Unified expanded detail view for a bill OR a transaction — a faithful port of the reference layout:
+ * back-bar + title, an identity card (icon + name + status pill + subtitle) with grouped label/value
+ * rows (Category chip, Next due, Alerts toggle, Portal, Address), a metrics card of big numbers with
+ * unit chips, a PAYMENT HISTORY section of check-badge cards, and floating bottom actions (bills only).
+ * Purely presentational — callers map into `DetailInfo`.
  */
 export type Tone = 'positive' | 'pending' | 'negative' | 'muted';
 
@@ -29,6 +31,7 @@ export interface DetailAction {
   onClick: () => void;
   primary?: boolean;
   disabled?: boolean;
+  icon?: LucideIcon; // when set, renders as a circular icon button instead of a pill
 }
 export interface DetailInfo {
   icon: LucideIcon;
@@ -61,17 +64,18 @@ const TONE_TEXT: Record<Tone, string> = {
   muted: 'text-foreground',
 };
 
-/** Receipt tear-line. */
-const Tear = () => <div className="mx-6 border-t border-dashed border-border" aria-hidden />;
+const UnitChip = ({ unit }: { unit: string }) => (
+  <span className="rounded bg-background/60 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{unit}</span>
+);
 
-/** A label — dotted leader — value row (the receipt line-item look). */
-function Leader({ label, children }: { label: string; children: ReactNode }) {
+/** One label/value row inside the identity card. */
+function Row({ label, onClick, children }: { label: string; onClick?: () => void; children: ReactNode }) {
+  const Tag = onClick ? 'button' : 'div';
   return (
-    <div className="flex items-baseline gap-2">
-      <span className="shrink-0 text-sm text-muted-foreground">{label}</span>
-      <span className="min-w-3 flex-1 translate-y-[-3px] border-b border-dotted border-border" aria-hidden />
-      <span className="shrink-0 font-mono text-sm tabular-nums text-foreground">{children}</span>
-    </div>
+    <Tag type={onClick ? 'button' : undefined} onClick={onClick} className={cn('flex min-h-[48px] w-full items-center justify-between gap-3 px-4 text-left', onClick && 'transition-colors hover:bg-foreground/[0.03]')}>
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">{children}</div>
+    </Tag>
   );
 }
 
@@ -86,149 +90,136 @@ export default function ActivityDetailModal({
 }) {
   if (!item) return null;
   const Icon = item.icon;
-  const [hero, ...mini] = item.metrics;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[400px]">
-        <button type="button" onClick={() => onOpenChange(false)} aria-label="Close" className="absolute right-3 top-3 z-10 rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground">
-          <X className="h-4 w-4" />
-        </button>
-
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[420px]">
         <div className="flex max-h-[90vh] flex-col">
-          <div className="min-h-0 flex-1 overflow-y-auto">
-            {/* header */}
-            <div className="px-6 pb-5 pt-9 text-center">
-              <span className={cn('mx-auto flex h-14 w-14 items-center justify-center rounded-2xl', item.iconTint ?? 'bg-secondary text-foreground')}>
-                <Icon className="h-6 w-6" />
-              </span>
-              {(item.typeLabel || item.subtitle) && (
-                <div className="mt-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                  {[item.typeLabel, item.subtitle].filter(Boolean).join(' · ')}
+          {/* back bar */}
+          <div className="flex items-center gap-1 px-3 py-3">
+            <button type="button" onClick={() => onOpenChange(false)} aria-label="Back" className="rounded-lg p-1 text-foreground hover:bg-secondary">
+              <ChevronLeft className="h-5 w-5" />
+            </button>
+            <span className="text-base font-semibold text-foreground">{item.title}</span>
+          </div>
+
+          <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 pb-4">
+            {/* identity card + grouped rows */}
+            <div className="overflow-hidden rounded-2xl bg-secondary/50">
+              <div className="flex items-start justify-between gap-3 p-4 pb-3">
+                <div className="flex min-w-0 items-center gap-3">
+                  <span className={cn('flex h-11 w-11 shrink-0 items-center justify-center rounded-xl', item.iconTint ?? 'bg-background text-foreground')}>
+                    <Icon className="h-5 w-5" />
+                  </span>
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-base font-semibold text-foreground">{item.title}</span>
+                      {item.status && <span className={cn('shrink-0 rounded-md px-2 py-0.5 text-[11px] font-medium', TONE_BADGE[item.status.tone])}>{item.status.label}</span>}
+                    </div>
+                    {item.subtitle && <div className="mt-0.5 text-xs text-muted-foreground">{item.subtitle}</div>}
+                  </div>
                 </div>
-              )}
-              <div className="mt-1 font-display text-2xl tracking-tight text-foreground">{item.title}</div>
-              {item.status && (
-                <span className={cn('mt-2 inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-medium', TONE_BADGE[item.status.tone])}>
-                  {item.status.label}
-                </span>
-              )}
+              </div>
+
+              <div className="divide-y divide-border/60 border-t border-border/60">
+                {item.typeLabel && (
+                  <Row label="Category">
+                    <span className="inline-flex items-center gap-1.5 rounded-lg bg-background px-2 py-1 text-xs font-medium text-foreground">
+                      <Icon className={cn('h-3.5 w-3.5', item.iconTint ? item.iconTint.split(' ').find((c) => c.startsWith('text-')) : 'text-muted-foreground')} /> {item.typeLabel}
+                    </span>
+                  </Row>
+                )}
+                {item.nextDue && <Row label="Next due">{item.nextDue}</Row>}
+                {item.notifications && (
+                  <Row label="Alerts">
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={item.notifications.enabled}
+                      onClick={() => item.notifications!.onToggle(!item.notifications!.enabled)}
+                      className={cn('relative h-6 w-10 rounded-full transition-colors', item.notifications.enabled ? 'bg-primary' : 'bg-border')}
+                    >
+                      <span className={cn('absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-all', item.notifications.enabled ? 'left-[18px]' : 'left-0.5')} />
+                    </button>
+                  </Row>
+                )}
+                {item.portalHost && <Row label="Portal" onClick={item.onPortal}>{item.portalHost}</Row>}
+                {item.address && <Row label="Address"><span className="max-w-[210px] truncate text-right">{item.address}</span></Row>}
+              </div>
             </div>
 
-            {/* info leaders */}
-            {(item.nextDue || item.notifications || item.portalHost || item.address) && (
-              <>
-                <Tear />
-                <div className="space-y-3 px-6 py-4">
-                  {item.nextDue && <Leader label="Next due">{item.nextDue}</Leader>}
-                  {item.notifications && (
-                    <div className="flex items-center justify-between">
-                      <span className="text-sm text-muted-foreground">Reminders</span>
-                      <button
-                        type="button"
-                        role="switch"
-                        aria-checked={item.notifications.enabled}
-                        onClick={() => item.notifications!.onToggle(!item.notifications!.enabled)}
-                        className={cn('relative h-6 w-10 rounded-full transition-colors', item.notifications.enabled ? 'bg-primary' : 'bg-secondary')}
-                      >
-                        <span className={cn('absolute top-0.5 h-5 w-5 rounded-full bg-background shadow transition-all', item.notifications.enabled ? 'left-[18px]' : 'left-0.5')} />
-                      </button>
+            {/* metrics card */}
+            {item.metrics.length > 0 && (
+              <div className="grid grid-cols-2 gap-x-4 gap-y-5 rounded-2xl bg-secondary/50 p-4">
+                {item.metrics.map((m) => (
+                  <div key={m.label}>
+                    <div className="flex items-baseline gap-1.5">
+                      <span className="font-display text-[26px] leading-none tabular-nums text-foreground">{m.value}</span>
+                      {m.unit && <UnitChip unit={m.unit} />}
                     </div>
-                  )}
-                  {item.portalHost && (
-                    <button type="button" onClick={item.onPortal} className="flex w-full items-baseline gap-2 text-left">
-                      <span className="shrink-0 text-sm text-muted-foreground">Portal</span>
-                      <span className="min-w-3 flex-1 translate-y-[-3px] border-b border-dotted border-border" aria-hidden />
-                      <span className="inline-flex shrink-0 items-center gap-1 font-mono text-sm text-foreground">{item.portalHost}<ExternalLink className="h-3.5 w-3.5 text-muted-foreground" /></span>
-                    </button>
-                  )}
-                  {item.address && (
-                    <div className="flex items-baseline gap-2">
-                      <span className="shrink-0 text-sm text-muted-foreground">Address</span>
-                      <span className="min-w-3 flex-1 translate-y-[-3px] border-b border-dotted border-border" aria-hidden />
-                      <span className="max-w-[210px] shrink-0 truncate text-right text-sm text-foreground">{item.address}</span>
-                    </div>
-                  )}
-                </div>
-              </>
-            )}
-
-            {/* hero total + mini stats */}
-            {hero && (
-              <>
-                <Tear />
-                <div className="px-6 py-6 text-center">
-                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{hero.label}</div>
-                  <div className="mt-1.5 flex items-baseline justify-center gap-2">
-                    <span className="font-display text-[42px] leading-none tracking-tight text-foreground tabular-nums">{hero.value}</span>
-                    {hero.unit && <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{hero.unit}</span>}
+                    <div className="mt-1.5 text-xs text-muted-foreground">{m.label}</div>
                   </div>
-                  {mini.length > 0 && (
-                    <div className="mt-6 grid divide-x divide-border" style={{ gridTemplateColumns: `repeat(${mini.length}, minmax(0,1fr))` }}>
-                      {mini.map((m) => (
-                        <div key={m.label} className="px-2">
-                          <div className="font-mono text-base tabular-nums text-foreground">{m.value}{m.unit ? <span className="ml-0.5 text-[10px] text-muted-foreground">{m.unit}</span> : null}</div>
-                          <div className="mt-1 text-[11px] text-muted-foreground">{m.label}</div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </>
+                ))}
+              </div>
             )}
 
             {/* history */}
-            <Tear />
-            <div className="px-6 py-4">
-              <div className="mb-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{item.historyTitle ?? 'History'}</div>
+            <div>
+              <h3 className="px-1 pb-2 pt-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{item.historyTitle ?? 'History'}</h3>
               {item.history.length > 0 ? (
-                <div className="space-y-2.5">
+                <div className="space-y-2">
                   {item.history.map((h) => (
-                    <div key={h.id} className="flex items-center gap-2.5">
-                      {h.success && (
-                        <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-positive/15 text-positive">
-                          <Check className="h-2.5 w-2.5" strokeWidth={3.5} />
-                        </span>
-                      )}
-                      <span className="min-w-0 truncate text-sm text-foreground">{h.title}</span>
-                      <span className="shrink-0 font-mono text-[11px] text-muted-foreground">{h.subtitle}</span>
-                      <span className="min-w-3 flex-1 translate-y-[-3px] border-b border-dotted border-border" aria-hidden />
-                      <span className={cn('shrink-0 font-mono text-sm tabular-nums', h.tone ? TONE_TEXT[h.tone] : 'text-foreground')}>
-                        {h.value}{h.unit ? <span className="ml-1 text-[10px] text-muted-foreground">{h.unit}</span> : null}
+                    <div key={h.id} className="flex items-center justify-between gap-3 rounded-xl bg-secondary/50 p-3">
+                      <div className="flex min-w-0 items-center gap-2.5">
+                        {h.success && <BadgeCheck className="h-5 w-5 shrink-0 text-positive" />}
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-medium text-foreground">{h.title}</div>
+                          {h.subtitle && <div className="truncate text-xs text-muted-foreground">{h.subtitle}</div>}
+                        </div>
+                      </div>
+                      <span className={cn('flex shrink-0 items-baseline gap-1.5 text-sm font-medium tabular-nums', h.tone ? TONE_TEXT[h.tone] : 'text-foreground')}>
+                        {h.value}
+                        {h.unit && <UnitChip unit={h.unit} />}
                       </span>
                     </div>
                   ))}
                 </div>
               ) : (
-                <div className="py-6 text-center font-mono text-xs uppercase tracking-wider text-muted-foreground">— no history yet —</div>
+                <div className="rounded-xl bg-secondary/50 py-8 text-center text-sm text-muted-foreground">No history yet.</div>
               )}
             </div>
-
-            {/* scalloped receipt bottom */}
-            <div
-              className="h-3 bg-border"
-              aria-hidden
-              style={{ WebkitMaskImage: 'radial-gradient(6px at 6px 100%, transparent 98%, #000)', WebkitMaskSize: '12px 12px', WebkitMaskRepeat: 'repeat-x', maskImage: 'radial-gradient(6px at 6px 100%, transparent 98%, #000)', maskSize: '12px 12px', maskRepeat: 'repeat-x' }}
-            />
           </div>
 
-          {/* pay actions (bills only) */}
+          {/* floating bottom actions (bills only) */}
           {item.actions && item.actions.length > 0 && (
-            <div className="flex gap-2 border-t border-border p-4">
-              {item.actions.map((a) => (
-                <button
-                  key={a.label}
-                  type="button"
-                  disabled={a.disabled}
-                  onClick={a.onClick}
-                  className={cn(
-                    'flex-1 rounded-xl py-3 text-sm font-semibold transition-transform active:scale-[0.99] disabled:opacity-40',
-                    a.primary ? 'bg-primary text-primary-foreground' : 'border border-border text-foreground hover:bg-secondary',
-                  )}
-                >
-                  {a.label}
-                </button>
-              ))}
+            <div className="flex items-center justify-center gap-3 px-4 py-4">
+              {item.actions.map((a) =>
+                a.icon ? (
+                  <button
+                    key={a.label}
+                    type="button"
+                    aria-label={a.label}
+                    disabled={a.disabled}
+                    onClick={a.onClick}
+                    className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-secondary text-foreground transition-colors hover:bg-secondary/70 disabled:opacity-40"
+                  >
+                    <a.icon className="h-5 w-5" />
+                  </button>
+                ) : (
+                  <button
+                    key={a.label}
+                    type="button"
+                    disabled={a.disabled}
+                    onClick={a.onClick}
+                    className={cn(
+                      'rounded-full px-6 py-3 text-sm font-semibold transition-transform active:scale-[0.98] disabled:opacity-40',
+                      a.primary ? 'bg-primary text-primary-foreground' : 'bg-secondary text-foreground',
+                    )}
+                  >
+                    {a.label}
+                  </button>
+                ),
+              )}
             </div>
           )}
         </div>

--- a/app/src/components/app-ui/ActivityDetailModal.tsx
+++ b/app/src/components/app-ui/ActivityDetailModal.tsx
@@ -4,10 +4,9 @@ import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 
 /*
- * Unified expanded detail view for a bill OR a transaction, following the reference layout exactly:
- * identity card (icon + name + status pill + subtitle, category chip on the right) with grouped info
- * rows, a big-number metrics block, an uppercase history section with check-badge rows, and a bottom
- * action bar (pay buttons on bills only). Purely presentational — callers map into `DetailInfo`.
+ * Unified detail view for a bill OR a transaction, styled as a RECEIPT — the modal itself is the paper:
+ * one surface, dashed tear-lines between sections, dotted leader rows, monospace figures, a hero total,
+ * and (bills only) a bottom action bar. No nested cards. Purely presentational — callers map to DetailInfo.
  */
 export type Tone = 'positive' | 'pending' | 'negative' | 'muted';
 
@@ -35,8 +34,8 @@ export interface DetailInfo {
   icon: LucideIcon;
   iconTint?: string;
   title: string;
-  subtitle?: string; // "Bill" · "Transaction"
-  typeLabel?: string; // category chip on the right — "Utility", "Rent", …
+  subtitle?: string;
+  typeLabel?: string;
   status?: { label: string; tone: Tone };
   nextDue?: string | null;
   address?: string | null;
@@ -62,16 +61,16 @@ const TONE_TEXT: Record<Tone, string> = {
   muted: 'text-foreground',
 };
 
-function UnitChip({ unit }: { unit: string }) {
-  return <span className="rounded bg-secondary px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{unit}</span>;
-}
+/** Receipt tear-line. */
+const Tear = () => <div className="mx-6 border-t border-dashed border-border" aria-hidden />;
 
-/** One grouped label/value/control row inside the identity card. */
-function Row({ label, children }: { label: string; children: ReactNode }) {
+/** A label — dotted leader — value row (the receipt line-item look). */
+function Leader({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <div className="flex min-h-[44px] items-center justify-between gap-3 px-4 py-2.5">
-      <span className="text-sm text-muted-foreground">{label}</span>
-      <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">{children}</div>
+    <div className="flex items-baseline gap-2">
+      <span className="shrink-0 text-sm text-muted-foreground">{label}</span>
+      <span className="min-w-3 flex-1 translate-y-[-3px] border-b border-dotted border-border" aria-hidden />
+      <span className="shrink-0 font-mono text-sm tabular-nums text-foreground">{children}</span>
     </div>
   );
 }
@@ -87,49 +86,44 @@ export default function ActivityDetailModal({
 }) {
   if (!item) return null;
   const Icon = item.icon;
+  const [hero, ...mini] = item.metrics;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[440px]">
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[400px]">
+        <button type="button" onClick={() => onOpenChange(false)} aria-label="Close" className="absolute right-3 top-3 z-10 rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground">
+          <X className="h-4 w-4" />
+        </button>
+
         <div className="flex max-h-[90vh] flex-col">
-          {/* top bar */}
-          <div className="flex items-center justify-between px-4 py-3">
-            <span className="truncate text-base font-semibold text-foreground">{item.title}</span>
-            <button type="button" onClick={() => onOpenChange(false)} aria-label="Close" className="-mr-1 rounded-lg p-1.5 text-muted-foreground hover:bg-secondary hover:text-foreground">
-              <X className="h-4 w-4" />
-            </button>
-          </div>
-
-          <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 pb-4">
-            {/* identity card + grouped rows */}
-            <div className="overflow-hidden rounded-2xl border border-border bg-card">
-              <div className="flex items-start justify-between gap-3 p-4">
-                <div className="flex min-w-0 items-center gap-3">
-                  <span className={cn('flex h-11 w-11 shrink-0 items-center justify-center rounded-xl', item.iconTint ?? 'bg-secondary text-foreground')}>
-                    <Icon className="h-5 w-5" />
-                  </span>
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="truncate text-base font-semibold text-foreground">{item.title}</span>
-                      {item.status && (
-                        <span className={cn('shrink-0 rounded-md px-1.5 py-0.5 text-[11px] font-medium', TONE_BADGE[item.status.tone])}>{item.status.label}</span>
-                      )}
-                    </div>
-                    {item.subtitle && <div className="mt-0.5 text-xs text-muted-foreground">{item.subtitle}</div>}
-                  </div>
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {/* header */}
+            <div className="px-6 pb-5 pt-9 text-center">
+              <span className={cn('mx-auto flex h-14 w-14 items-center justify-center rounded-2xl', item.iconTint ?? 'bg-secondary text-foreground')}>
+                <Icon className="h-6 w-6" />
+              </span>
+              {(item.typeLabel || item.subtitle) && (
+                <div className="mt-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                  {[item.typeLabel, item.subtitle].filter(Boolean).join(' · ')}
                 </div>
-                {item.typeLabel && (
-                  <span className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-secondary px-2 py-1 text-xs font-medium text-foreground">
-                    <Icon className="h-3.5 w-3.5 text-muted-foreground" /> {item.typeLabel}
-                  </span>
-                )}
-              </div>
+              )}
+              <div className="mt-1 font-display text-2xl tracking-tight text-foreground">{item.title}</div>
+              {item.status && (
+                <span className={cn('mt-2 inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-medium', TONE_BADGE[item.status.tone])}>
+                  {item.status.label}
+                </span>
+              )}
+            </div>
 
-              {(item.nextDue || item.notifications || item.portalHost || item.address) && (
-                <div className="divide-y divide-border border-t border-border">
-                  {item.nextDue && <Row label="Next due">{item.nextDue}</Row>}
+            {/* info leaders */}
+            {(item.nextDue || item.notifications || item.portalHost || item.address) && (
+              <>
+                <Tear />
+                <div className="space-y-3 px-6 py-4">
+                  {item.nextDue && <Leader label="Next due">{item.nextDue}</Leader>}
                   {item.notifications && (
-                    <Row label="Reminders">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-muted-foreground">Reminders</span>
                       <button
                         type="button"
                         role="switch"
@@ -139,68 +133,86 @@ export default function ActivityDetailModal({
                       >
                         <span className={cn('absolute top-0.5 h-5 w-5 rounded-full bg-background shadow transition-all', item.notifications.enabled ? 'left-[18px]' : 'left-0.5')} />
                       </button>
-                    </Row>
+                    </div>
                   )}
                   {item.portalHost && (
-                    <button type="button" onClick={item.onPortal} className="flex min-h-[44px] w-full items-center justify-between gap-3 px-4 py-2.5 text-left transition-colors hover:bg-secondary/40">
-                      <span className="text-sm text-muted-foreground">Portal</span>
-                      <span className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground">{item.portalHost} <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" /></span>
+                    <button type="button" onClick={item.onPortal} className="flex w-full items-baseline gap-2 text-left">
+                      <span className="shrink-0 text-sm text-muted-foreground">Portal</span>
+                      <span className="min-w-3 flex-1 translate-y-[-3px] border-b border-dotted border-border" aria-hidden />
+                      <span className="inline-flex shrink-0 items-center gap-1 font-mono text-sm text-foreground">{item.portalHost}<ExternalLink className="h-3.5 w-3.5 text-muted-foreground" /></span>
                     </button>
                   )}
                   {item.address && (
-                    <Row label="Address"><span className="max-w-[220px] truncate text-right">{item.address}</span></Row>
+                    <div className="flex items-baseline gap-2">
+                      <span className="shrink-0 text-sm text-muted-foreground">Address</span>
+                      <span className="min-w-3 flex-1 translate-y-[-3px] border-b border-dotted border-border" aria-hidden />
+                      <span className="max-w-[210px] shrink-0 truncate text-right text-sm text-foreground">{item.address}</span>
+                    </div>
                   )}
                 </div>
-              )}
-            </div>
+              </>
+            )}
 
-            {/* metrics block */}
-            {item.metrics.length > 0 && (
-              <div className="grid grid-cols-2 gap-px overflow-hidden rounded-2xl border border-border bg-border">
-                {item.metrics.map((m) => (
-                  <div key={m.label} className="bg-card p-4">
-                    <div className="flex items-baseline gap-1.5">
-                      <span className="font-display text-2xl leading-none tabular-nums text-foreground">{m.value}</span>
-                      {m.unit && <UnitChip unit={m.unit} />}
-                    </div>
-                    <div className="mt-1.5 text-xs text-muted-foreground">{m.label}</div>
+            {/* hero total + mini stats */}
+            {hero && (
+              <>
+                <Tear />
+                <div className="px-6 py-6 text-center">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{hero.label}</div>
+                  <div className="mt-1.5 flex items-baseline justify-center gap-2">
+                    <span className="font-display text-[42px] leading-none tracking-tight text-foreground tabular-nums">{hero.value}</span>
+                    {hero.unit && <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{hero.unit}</span>}
                   </div>
-                ))}
-              </div>
+                  {mini.length > 0 && (
+                    <div className="mt-6 grid divide-x divide-border" style={{ gridTemplateColumns: `repeat(${mini.length}, minmax(0,1fr))` }}>
+                      {mini.map((m) => (
+                        <div key={m.label} className="px-2">
+                          <div className="font-mono text-base tabular-nums text-foreground">{m.value}{m.unit ? <span className="ml-0.5 text-[10px] text-muted-foreground">{m.unit}</span> : null}</div>
+                          <div className="mt-1 text-[11px] text-muted-foreground">{m.label}</div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </>
             )}
 
             {/* history */}
-            <div>
-              <h3 className="px-1 pb-2 pt-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{item.historyTitle ?? 'History'}</h3>
+            <Tear />
+            <div className="px-6 py-4">
+              <div className="mb-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{item.historyTitle ?? 'History'}</div>
               {item.history.length > 0 ? (
-                <div className="space-y-2">
+                <div className="space-y-2.5">
                   {item.history.map((h) => (
-                    <div key={h.id} className="flex items-center justify-between gap-3 rounded-xl border border-border bg-card p-3">
-                      <div className="flex min-w-0 items-center gap-2.5">
-                        {h.success && (
-                          <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-positive/15 text-positive">
-                            <Check className="h-3 w-3" strokeWidth={3} />
-                          </span>
-                        )}
-                        <div className="min-w-0">
-                          <div className="truncate text-sm font-medium text-foreground">{h.title}</div>
-                          {h.subtitle && <div className="truncate text-xs text-muted-foreground">{h.subtitle}</div>}
-                        </div>
-                      </div>
-                      <span className={cn('flex shrink-0 items-baseline gap-1.5 text-sm font-medium tabular-nums', h.tone ? TONE_TEXT[h.tone] : 'text-foreground')}>
-                        {h.value}
-                        {h.unit && <UnitChip unit={h.unit} />}
+                    <div key={h.id} className="flex items-center gap-2.5">
+                      {h.success && (
+                        <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-positive/15 text-positive">
+                          <Check className="h-2.5 w-2.5" strokeWidth={3.5} />
+                        </span>
+                      )}
+                      <span className="min-w-0 truncate text-sm text-foreground">{h.title}</span>
+                      <span className="shrink-0 font-mono text-[11px] text-muted-foreground">{h.subtitle}</span>
+                      <span className="min-w-3 flex-1 translate-y-[-3px] border-b border-dotted border-border" aria-hidden />
+                      <span className={cn('shrink-0 font-mono text-sm tabular-nums', h.tone ? TONE_TEXT[h.tone] : 'text-foreground')}>
+                        {h.value}{h.unit ? <span className="ml-1 text-[10px] text-muted-foreground">{h.unit}</span> : null}
                       </span>
                     </div>
                   ))}
                 </div>
               ) : (
-                <div className="rounded-xl border border-border py-8 text-center text-sm text-muted-foreground">No history yet.</div>
+                <div className="py-6 text-center font-mono text-xs uppercase tracking-wider text-muted-foreground">— no history yet —</div>
               )}
             </div>
+
+            {/* scalloped receipt bottom */}
+            <div
+              className="h-3 bg-border"
+              aria-hidden
+              style={{ WebkitMaskImage: 'radial-gradient(6px at 6px 100%, transparent 98%, #000)', WebkitMaskSize: '12px 12px', WebkitMaskRepeat: 'repeat-x', maskImage: 'radial-gradient(6px at 6px 100%, transparent 98%, #000)', maskSize: '12px 12px', maskRepeat: 'repeat-x' }}
+            />
           </div>
 
-          {/* bottom action bar (bills only) */}
+          {/* pay actions (bills only) */}
           {item.actions && item.actions.length > 0 && (
             <div className="flex gap-2 border-t border-border p-4">
               {item.actions.map((a) => (

--- a/app/src/components/app-ui/ActivityDetailModal.tsx
+++ b/app/src/components/app-ui/ActivityDetailModal.tsx
@@ -4,25 +4,24 @@ import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 
 /*
- * Unified expanded detail view for a bill OR a transaction — a faithful port of the reference layout:
- * back-bar + title, an identity card (icon + name + status pill + subtitle) with grouped label/value
- * rows (Category chip, Next due, Alerts toggle, Portal, Address), a metrics card of big numbers with
- * unit chips, a PAYMENT HISTORY section of check-badge cards, and floating bottom actions (bills only).
- * Purely presentational — callers map into `DetailInfo`.
+ * Unified expanded detail view for a bill OR a transaction, aligned to the app design system:
+ * back-bar + title; an identity card (icon + name + status pill + subtitle) with grouped label/value
+ * rows; a StatBar-style hairline metrics grid; an editorial PAYMENT HISTORY list (divider rows, no
+ * cards); and floating bottom actions (bills only). Full-round radius is reserved for chips/pills/
+ * toggles/buttons — cards use the app's rounded-xl. Purely presentational — callers map to `DetailInfo`.
  */
 export type Tone = 'positive' | 'pending' | 'negative' | 'muted';
 
 export interface DetailMetric {
   label: string;
   value: string;
-  unit?: string;
+  icon?: LucideIcon;
 }
 export interface DetailHistoryEntry {
   id: string;
   title: string;
   subtitle?: string;
   value: string;
-  unit?: string;
   tone?: Tone;
   success?: boolean;
 }
@@ -64,10 +63,6 @@ const TONE_TEXT: Record<Tone, string> = {
   muted: 'text-foreground',
 };
 
-const UnitChip = ({ unit }: { unit: string }) => (
-  <span className="rounded bg-background/60 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{unit}</span>
-);
-
 /** One label/value row inside the identity card. */
 function Row({ label, onClick, children }: { label: string; onClick?: () => void; children: ReactNode }) {
   const Tag = onClick ? 'button' : 'div';
@@ -90,6 +85,7 @@ export default function ActivityDetailModal({
 }) {
   if (!item) return null;
   const Icon = item.icon;
+  const tintText = item.iconTint?.split(' ').find((c) => c.startsWith('text-')) ?? 'text-muted-foreground';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -97,35 +93,33 @@ export default function ActivityDetailModal({
         <div className="flex max-h-[90vh] flex-col">
           {/* back bar */}
           <div className="flex items-center gap-1 px-3 py-3">
-            <button type="button" onClick={() => onOpenChange(false)} aria-label="Back" className="rounded-lg p-1 text-foreground hover:bg-secondary">
+            <button type="button" onClick={() => onOpenChange(false)} aria-label="Back" className="rounded-full p-1 text-foreground hover:bg-secondary">
               <ChevronLeft className="h-5 w-5" />
             </button>
             <span className="text-base font-semibold text-foreground">{item.title}</span>
           </div>
 
-          <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 pb-4">
+          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 pb-4">
             {/* identity card + grouped rows */}
-            <div className="overflow-hidden rounded-2xl bg-secondary/50">
-              <div className="flex items-start justify-between gap-3 p-4 pb-3">
-                <div className="flex min-w-0 items-center gap-3">
-                  <span className={cn('flex h-11 w-11 shrink-0 items-center justify-center rounded-xl', item.iconTint ?? 'bg-background text-foreground')}>
-                    <Icon className="h-5 w-5" />
-                  </span>
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="truncate text-base font-semibold text-foreground">{item.title}</span>
-                      {item.status && <span className={cn('shrink-0 rounded-md px-2 py-0.5 text-[11px] font-medium', TONE_BADGE[item.status.tone])}>{item.status.label}</span>}
-                    </div>
-                    {item.subtitle && <div className="mt-0.5 text-xs text-muted-foreground">{item.subtitle}</div>}
+            <div className="overflow-hidden rounded-xl border border-border bg-card">
+              <div className="flex items-center gap-3 p-4">
+                <span className={cn('flex h-11 w-11 shrink-0 items-center justify-center rounded-lg', item.iconTint ?? 'bg-secondary text-foreground')}>
+                  <Icon className="h-5 w-5" />
+                </span>
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-base font-semibold text-foreground">{item.title}</span>
+                    {item.status && <span className={cn('shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium', TONE_BADGE[item.status.tone])}>{item.status.label}</span>}
                   </div>
+                  {item.subtitle && <div className="mt-0.5 text-xs text-muted-foreground">{item.subtitle}</div>}
                 </div>
               </div>
 
-              <div className="divide-y divide-border/60 border-t border-border/60">
+              <div className="divide-y divide-border border-t border-border">
                 {item.typeLabel && (
                   <Row label="Category">
-                    <span className="inline-flex items-center gap-1.5 rounded-lg bg-background px-2 py-1 text-xs font-medium text-foreground">
-                      <Icon className={cn('h-3.5 w-3.5', item.iconTint ? item.iconTint.split(' ').find((c) => c.startsWith('text-')) : 'text-muted-foreground')} /> {item.typeLabel}
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-foreground">
+                      <Icon className={cn('h-3.5 w-3.5', tintText)} /> {item.typeLabel}
                     </span>
                   </Row>
                 )}
@@ -148,44 +142,43 @@ export default function ActivityDetailModal({
               </div>
             </div>
 
-            {/* metrics card */}
+            {/* metrics — StatBar hairline grid */}
             {item.metrics.length > 0 && (
-              <div className="grid grid-cols-2 gap-x-4 gap-y-5 rounded-2xl bg-secondary/50 p-4">
-                {item.metrics.map((m) => (
-                  <div key={m.label}>
-                    <div className="flex items-baseline gap-1.5">
-                      <span className="font-display text-[26px] leading-none tabular-nums text-foreground">{m.value}</span>
-                      {m.unit && <UnitChip unit={m.unit} />}
+              <div className="overflow-hidden rounded-xl border border-border bg-border">
+                <div className="grid grid-cols-2 gap-px bg-border">
+                  {item.metrics.map((m) => (
+                    <div key={m.label} className="bg-card p-4">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-muted-foreground">{m.label}</span>
+                        {m.icon && <m.icon className="h-4 w-4 text-muted-foreground" />}
+                      </div>
+                      <div className="mt-2 font-display text-2xl tracking-tight tabular-nums text-foreground">{m.value}</div>
                     </div>
-                    <div className="mt-1.5 text-xs text-muted-foreground">{m.label}</div>
-                  </div>
-                ))}
+                  ))}
+                </div>
               </div>
             )}
 
-            {/* history */}
+            {/* history — editorial divider rows */}
             <div>
-              <h3 className="px-1 pb-2 pt-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{item.historyTitle ?? 'History'}</h3>
+              <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{item.historyTitle ?? 'History'}</h3>
               {item.history.length > 0 ? (
-                <div className="space-y-2">
+                <div className="divide-y divide-border border-t border-border">
                   {item.history.map((h) => (
-                    <div key={h.id} className="flex items-center justify-between gap-3 rounded-xl bg-secondary/50 p-3">
+                    <div key={h.id} className="flex items-center justify-between gap-3 py-3">
                       <div className="flex min-w-0 items-center gap-2.5">
-                        {h.success && <BadgeCheck className="h-5 w-5 shrink-0 text-positive" />}
+                        {h.success && <BadgeCheck className="h-[18px] w-[18px] shrink-0 text-positive" />}
                         <div className="min-w-0">
                           <div className="truncate text-sm font-medium text-foreground">{h.title}</div>
                           {h.subtitle && <div className="truncate text-xs text-muted-foreground">{h.subtitle}</div>}
                         </div>
                       </div>
-                      <span className={cn('flex shrink-0 items-baseline gap-1.5 text-sm font-medium tabular-nums', h.tone ? TONE_TEXT[h.tone] : 'text-foreground')}>
-                        {h.value}
-                        {h.unit && <UnitChip unit={h.unit} />}
-                      </span>
+                      <span className={cn('shrink-0 font-display text-sm tabular-nums', h.tone ? TONE_TEXT[h.tone] : 'text-foreground')}>{h.value}</span>
                     </div>
                   ))}
                 </div>
               ) : (
-                <div className="rounded-xl bg-secondary/50 py-8 text-center text-sm text-muted-foreground">No history yet.</div>
+                <div className="border-t border-border py-8 text-center text-sm text-muted-foreground">No history yet.</div>
               )}
             </div>
           </div>

--- a/app/src/components/app-ui/ActivityDetailModal.tsx
+++ b/app/src/components/app-ui/ActivityDetailModal.tsx
@@ -1,5 +1,5 @@
-import { type ReactNode } from 'react';
-import { ChevronLeft, BadgeCheck, type LucideIcon } from 'lucide-react';
+import { type ReactNode, useEffect, useState } from 'react';
+import { ChevronLeft, BadgeCheck, Check, X, Pencil, ExternalLink, Plus, type LucideIcon } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 
@@ -40,9 +40,9 @@ export interface DetailInfo {
   typeLabel?: string;
   status?: { label: string; tone: Tone };
   nextDue?: string | null;
-  address?: string | null;
-  portalHost?: string | null;
-  onPortal?: () => void;
+  /** Editable portal + address rows (always shown; empty → "Add …" inline editor). */
+  portal?: { url: string | null; onOpen?: () => void; onSave: (v: string) => void };
+  address?: { value: string | null; onSave: (v: string) => void };
   notifications?: { enabled: boolean; onToggle: (v: boolean) => void };
   metrics: DetailMetric[];
   historyTitle?: string;
@@ -73,6 +73,67 @@ function Row({ label, onClick, children }: { label: string; onClick?: () => void
     </Tag>
   );
 }
+
+/** A label/value row that inline-edits when empty or via the pencil. `display` is shown, `value` is edited. */
+function EditableRow({
+  label,
+  value,
+  display,
+  placeholder,
+  onSave,
+  onOpen,
+}: {
+  label: string;
+  value: string | null;
+  display?: string;
+  placeholder: string;
+  onSave: (v: string) => void;
+  onOpen?: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value ?? '');
+  useEffect(() => setDraft(value ?? ''), [value]);
+  const save = () => { onSave(draft.trim()); setEditing(false); };
+
+  if (editing) {
+    return (
+      <div className="flex min-h-[48px] items-center gap-2 px-4">
+        <span className="shrink-0 text-sm text-muted-foreground">{label}</span>
+        <input
+          autoFocus
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') save(); if (e.key === 'Escape') { setDraft(value ?? ''); setEditing(false); } }}
+          placeholder={placeholder}
+          className="min-w-0 flex-1 bg-transparent text-right text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+        />
+        <button type="button" onClick={save} aria-label="Save" className="shrink-0 rounded-full p-1 text-positive hover:bg-secondary"><Check className="h-4 w-4" /></button>
+        <button type="button" onClick={() => { setDraft(value ?? ''); setEditing(false); }} aria-label="Cancel" className="shrink-0 rounded-full p-1 text-muted-foreground hover:bg-secondary"><X className="h-4 w-4" /></button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-[48px] items-center justify-between gap-3 px-4">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      {value ? (
+        <div className="flex min-w-0 items-center gap-1.5">
+          <button type="button" onClick={onOpen} disabled={!onOpen} className="inline-flex min-w-0 items-center gap-1.5 text-sm font-medium text-foreground disabled:cursor-default">
+            <span className="truncate">{display ?? value}</span>
+            {onOpen && <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+          </button>
+          <button type="button" onClick={() => setEditing(true)} aria-label={`Edit ${label.toLowerCase()}`} className="shrink-0 rounded-full p-1 text-muted-foreground hover:bg-secondary hover:text-foreground"><Pencil className="h-3.5 w-3.5" /></button>
+        </div>
+      ) : (
+        <button type="button" onClick={() => { setDraft(''); setEditing(true); }} className="inline-flex items-center gap-1 text-sm font-medium text-primary">
+          <Plus className="h-3.5 w-3.5" /> Add {label.toLowerCase()}
+        </button>
+      )}
+    </div>
+  );
+}
+
+const hostOf = (url: string) => { try { return new URL(url).host; } catch { return url; } };
 
 export default function ActivityDetailModal({
   open,
@@ -137,8 +198,19 @@ export default function ActivityDetailModal({
                     </button>
                   </Row>
                 )}
-                {item.portalHost && <Row label="Portal" onClick={item.onPortal}>{item.portalHost}</Row>}
-                {item.address && <Row label="Address"><span className="max-w-[210px] truncate text-right">{item.address}</span></Row>}
+                {item.portal && (
+                  <EditableRow
+                    label="Portal"
+                    value={item.portal.url}
+                    display={item.portal.url ? hostOf(item.portal.url) : undefined}
+                    placeholder="pge.com/login"
+                    onOpen={item.portal.onOpen}
+                    onSave={item.portal.onSave}
+                  />
+                )}
+                {item.address && (
+                  <EditableRow label="Address" value={item.address.value} placeholder="123 Main St, City, ST" onSave={item.address.onSave} />
+                )}
               </div>
             </div>
 

--- a/app/src/components/app-ui/ActivityDetailModal.tsx
+++ b/app/src/components/app-ui/ActivityDetailModal.tsx
@@ -1,24 +1,29 @@
-import { X, ExternalLink, Bell, type LucideIcon } from 'lucide-react';
+import { type ReactNode } from 'react';
+import { X, ExternalLink, Check, type LucideIcon } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 
 /*
- * Unified expanded detail view for a bill OR a transaction (a bill is just a recurring transaction).
- * Purely presentational — callers map their data into a `DetailInfo` and pass optional pay `actions`
- * (bills get them; transactions don't). Shared by the Pay bill detail + the transaction/activity detail.
+ * Unified expanded detail view for a bill OR a transaction, following the reference layout exactly:
+ * identity card (icon + name + status pill + subtitle, category chip on the right) with grouped info
+ * rows, a big-number metrics block, an uppercase history section with check-badge rows, and a bottom
+ * action bar (pay buttons on bills only). Purely presentational — callers map into `DetailInfo`.
  */
 export type Tone = 'positive' | 'pending' | 'negative' | 'muted';
 
 export interface DetailMetric {
   label: string;
   value: string;
+  unit?: string;
 }
 export interface DetailHistoryEntry {
   id: string;
   title: string;
   subtitle?: string;
-  amount: string;
+  value: string;
+  unit?: string;
   tone?: Tone;
+  success?: boolean;
 }
 export interface DetailAction {
   label: string;
@@ -28,11 +33,12 @@ export interface DetailAction {
 }
 export interface DetailInfo {
   icon: LucideIcon;
-  iconTint?: string; // e.g. 'bg-amber-500/10 text-amber-600'
+  iconTint?: string;
   title: string;
-  subtitle?: string; // "Bill" · "Payment" · counterparty
-  typeLabel?: string; // "Utility" · "Rent" · category
+  subtitle?: string; // "Bill" · "Transaction"
+  typeLabel?: string; // category chip on the right — "Utility", "Rent", …
   status?: { label: string; tone: Tone };
+  nextDue?: string | null;
   address?: string | null;
   portalHost?: string | null;
   onPortal?: () => void;
@@ -44,17 +50,31 @@ export interface DetailInfo {
 }
 
 const TONE_BADGE: Record<Tone, string> = {
-  positive: 'bg-positive/10 text-positive',
-  pending: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
-  negative: 'bg-negative/10 text-negative',
+  positive: 'bg-positive/15 text-positive',
+  pending: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
+  negative: 'bg-negative/15 text-negative',
   muted: 'bg-secondary text-muted-foreground',
 };
 const TONE_TEXT: Record<Tone, string> = {
   positive: 'text-positive',
   pending: 'text-amber-600 dark:text-amber-400',
   negative: 'text-negative',
-  muted: 'text-muted-foreground',
+  muted: 'text-foreground',
 };
+
+function UnitChip({ unit }: { unit: string }) {
+  return <span className="rounded bg-secondary px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{unit}</span>;
+}
+
+/** One grouped label/value/control row inside the identity card. */
+function Row({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex min-h-[44px] items-center justify-between gap-3 px-4 py-2.5">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">{children}</div>
+    </div>
+  );
+}
 
 export default function ActivityDetailModal({
   open,
@@ -70,58 +90,46 @@ export default function ActivityDetailModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[460px]">
-        <div className="flex max-h-[88vh] flex-col">
-          {/* header */}
-          <div className="flex items-center justify-between px-5 pt-4">
-            <span className="text-sm font-medium text-muted-foreground">{item.subtitle ?? 'Details'}</span>
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[440px]">
+        <div className="flex max-h-[90vh] flex-col">
+          {/* top bar */}
+          <div className="flex items-center justify-between px-4 py-3">
+            <span className="truncate text-base font-semibold text-foreground">{item.title}</span>
             <button type="button" onClick={() => onOpenChange(false)} aria-label="Close" className="-mr-1 rounded-lg p-1.5 text-muted-foreground hover:bg-secondary hover:text-foreground">
               <X className="h-4 w-4" />
             </button>
           </div>
 
-          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 pb-4 pt-3">
-            {/* identity */}
-            <div className="flex items-center gap-3">
-              <span className={cn('flex h-12 w-12 shrink-0 items-center justify-center rounded-xl', item.iconTint ?? 'bg-secondary text-foreground')}>
-                <Icon className="h-5 w-5" />
-              </span>
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="truncate text-lg font-semibold text-foreground">{item.title}</span>
-                  {item.status && (
-                    <span className={cn('shrink-0 rounded-md px-1.5 py-0.5 text-[11px] font-medium', TONE_BADGE[item.status.tone])}>
-                      {item.status.label}
-                    </span>
-                  )}
-                </div>
-                {item.typeLabel && <div className="mt-0.5 text-xs text-muted-foreground">{item.typeLabel}</div>}
-              </div>
-            </div>
-
-            {/* info rows */}
-            {(item.address || item.portalHost || item.notifications) && (
-              <div className="overflow-hidden rounded-xl border border-border">
-                <div className="divide-y divide-border">
-                  {item.address && (
-                    <div className="flex items-start justify-between gap-3 px-4 py-3">
-                      <span className="text-sm text-muted-foreground">Address</span>
-                      <span className="max-w-[65%] text-right text-sm text-foreground">{item.address}</span>
+          <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 pb-4">
+            {/* identity card + grouped rows */}
+            <div className="overflow-hidden rounded-2xl border border-border bg-card">
+              <div className="flex items-start justify-between gap-3 p-4">
+                <div className="flex min-w-0 items-center gap-3">
+                  <span className={cn('flex h-11 w-11 shrink-0 items-center justify-center rounded-xl', item.iconTint ?? 'bg-secondary text-foreground')}>
+                    <Icon className="h-5 w-5" />
+                  </span>
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-base font-semibold text-foreground">{item.title}</span>
+                      {item.status && (
+                        <span className={cn('shrink-0 rounded-md px-1.5 py-0.5 text-[11px] font-medium', TONE_BADGE[item.status.tone])}>{item.status.label}</span>
+                      )}
                     </div>
-                  )}
-                  {item.portalHost && (
-                    <button type="button" onClick={item.onPortal} className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-secondary/40">
-                      <span className="text-sm text-muted-foreground">Portal</span>
-                      <span className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
-                        {item.portalHost} <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
-                      </span>
-                    </button>
-                  )}
+                    {item.subtitle && <div className="mt-0.5 text-xs text-muted-foreground">{item.subtitle}</div>}
+                  </div>
+                </div>
+                {item.typeLabel && (
+                  <span className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-secondary px-2 py-1 text-xs font-medium text-foreground">
+                    <Icon className="h-3.5 w-3.5 text-muted-foreground" /> {item.typeLabel}
+                  </span>
+                )}
+              </div>
+
+              {(item.nextDue || item.notifications || item.portalHost || item.address) && (
+                <div className="divide-y divide-border border-t border-border">
+                  {item.nextDue && <Row label="Next due">{item.nextDue}</Row>}
                   {item.notifications && (
-                    <div className="flex items-center justify-between gap-3 px-4 py-3">
-                      <span className="inline-flex items-center gap-2 text-sm text-muted-foreground">
-                        <Bell className="h-4 w-4" /> Reminders
-                      </span>
+                    <Row label="Reminders">
                       <button
                         type="button"
                         role="switch"
@@ -131,19 +139,31 @@ export default function ActivityDetailModal({
                       >
                         <span className={cn('absolute top-0.5 h-5 w-5 rounded-full bg-background shadow transition-all', item.notifications.enabled ? 'left-[18px]' : 'left-0.5')} />
                       </button>
-                    </div>
+                    </Row>
+                  )}
+                  {item.portalHost && (
+                    <button type="button" onClick={item.onPortal} className="flex min-h-[44px] w-full items-center justify-between gap-3 px-4 py-2.5 text-left transition-colors hover:bg-secondary/40">
+                      <span className="text-sm text-muted-foreground">Portal</span>
+                      <span className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground">{item.portalHost} <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" /></span>
+                    </button>
+                  )}
+                  {item.address && (
+                    <Row label="Address"><span className="max-w-[220px] truncate text-right">{item.address}</span></Row>
                   )}
                 </div>
-              </div>
-            )}
+              )}
+            </div>
 
-            {/* metrics */}
+            {/* metrics block */}
             {item.metrics.length > 0 && (
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-2 gap-px overflow-hidden rounded-2xl border border-border bg-border">
                 {item.metrics.map((m) => (
-                  <div key={m.label} className="rounded-xl border border-border p-3">
-                    <div className="font-display text-lg leading-none tabular-nums text-foreground">{m.value}</div>
-                    <div className="mt-1 text-[11px] text-muted-foreground">{m.label}</div>
+                  <div key={m.label} className="bg-card p-4">
+                    <div className="flex items-baseline gap-1.5">
+                      <span className="font-display text-2xl leading-none tabular-nums text-foreground">{m.value}</span>
+                      {m.unit && <UnitChip unit={m.unit} />}
+                    </div>
+                    <div className="mt-1.5 text-xs text-muted-foreground">{m.label}</div>
                   </div>
                 ))}
               </div>
@@ -151,20 +171,28 @@ export default function ActivityDetailModal({
 
             {/* history */}
             <div>
-              <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">{item.historyTitle ?? 'History'}</h3>
+              <h3 className="px-1 pb-2 pt-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{item.historyTitle ?? 'History'}</h3>
               {item.history.length > 0 ? (
-                <div className="overflow-hidden rounded-xl border border-border">
-                  <div className="divide-y divide-border">
-                    {item.history.map((h) => (
-                      <div key={h.id} className="flex items-center justify-between gap-3 px-4 py-3">
+                <div className="space-y-2">
+                  {item.history.map((h) => (
+                    <div key={h.id} className="flex items-center justify-between gap-3 rounded-xl border border-border bg-card p-3">
+                      <div className="flex min-w-0 items-center gap-2.5">
+                        {h.success && (
+                          <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-positive/15 text-positive">
+                            <Check className="h-3 w-3" strokeWidth={3} />
+                          </span>
+                        )}
                         <div className="min-w-0">
                           <div className="truncate text-sm font-medium text-foreground">{h.title}</div>
                           {h.subtitle && <div className="truncate text-xs text-muted-foreground">{h.subtitle}</div>}
                         </div>
-                        <span className={cn('shrink-0 text-sm font-medium tabular-nums', h.tone ? TONE_TEXT[h.tone] : 'text-foreground')}>{h.amount}</span>
                       </div>
-                    ))}
-                  </div>
+                      <span className={cn('flex shrink-0 items-baseline gap-1.5 text-sm font-medium tabular-nums', h.tone ? TONE_TEXT[h.tone] : 'text-foreground')}>
+                        {h.value}
+                        {h.unit && <UnitChip unit={h.unit} />}
+                      </span>
+                    </div>
+                  ))}
                 </div>
               ) : (
                 <div className="rounded-xl border border-border py-8 text-center text-sm text-muted-foreground">No history yet.</div>
@@ -172,9 +200,9 @@ export default function ActivityDetailModal({
             </div>
           </div>
 
-          {/* pay actions (bills only) */}
+          {/* bottom action bar (bills only) */}
           {item.actions && item.actions.length > 0 && (
-            <div className="flex gap-2 border-t border-border px-5 py-4">
+            <div className="flex gap-2 border-t border-border p-4">
               {item.actions.map((a) => (
                 <button
                   key={a.label}

--- a/app/src/components/app-ui/ActivityDetailModal.tsx
+++ b/app/src/components/app-ui/ActivityDetailModal.tsx
@@ -1,22 +1,21 @@
 import { type ReactNode, useEffect, useState } from 'react';
-import { ChevronLeft, BadgeCheck, Check, X, Pencil, ExternalLink, Plus, type LucideIcon } from 'lucide-react';
-import { Dialog, DialogContent } from '@/components/ui/dialog';
+import {
+  ChevronLeft, ChevronDown, BadgeCheck, Check, X, Pencil, Copy, ExternalLink, Plus,
+  ArrowDownLeft, ArrowUpRight, Share2, type LucideIcon,
+} from 'lucide-react';
+import { Sheet, SheetContent } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
 
 /*
- * Unified expanded detail view for a bill OR a transaction, aligned to the app design system:
- * back-bar + title; an identity card (icon + name + status pill + subtitle) with grouped label/value
- * rows; a StatBar-style hairline metrics grid; an editorial PAYMENT HISTORY list (divider rows, no
- * cards); and floating bottom actions (bills only). Full-round radius is reserved for chips/pills/
- * toggles/buttons — cards use the app's rounded-xl. Purely presentational — callers map to `DetailInfo`.
+ * Unified detail view for a bill OR a transaction, as a right-side drawer (full-screen sheet on mobile).
+ * Tabs (Details · History); Details has collapsible sections (Summary, Transaction, Latest receipt), a
+ * metrics grid, editable portal/address, and copyable reference fields; History is grouped with
+ * directional in/out icons + signed colored amounts. Bills get a pinned pay bar; transactions don't.
+ * Purely presentational — callers map into `DetailInfo`.
  */
 export type Tone = 'positive' | 'pending' | 'negative' | 'muted';
 
-export interface DetailMetric {
-  label: string;
-  value: string;
-  icon?: LucideIcon;
-}
+export interface DetailMetric { label: string; value: string; icon?: LucideIcon }
 export interface DetailHistoryEntry {
   id: string;
   title: string;
@@ -24,14 +23,15 @@ export interface DetailHistoryEntry {
   value: string;
   tone?: Tone;
   success?: boolean;
+  direction?: 'in' | 'out';
+  group?: string;
 }
-export interface DetailAction {
-  label: string;
-  onClick: () => void;
-  primary?: boolean;
-  disabled?: boolean;
-  icon?: LucideIcon; // when set, renders as a circular icon button instead of a pill
+export interface DetailReceipt {
+  lines: { label: string; value: string; tone?: Tone }[];
+  total?: { label: string; value: string };
+  onShare?: () => void;
 }
+export interface DetailAction { label: string; onClick: () => void; primary?: boolean; disabled?: boolean; icon?: LucideIcon }
 export interface DetailInfo {
   icon: LucideIcon;
   iconTint?: string;
@@ -40,13 +40,17 @@ export interface DetailInfo {
   typeLabel?: string;
   status?: { label: string; tone: Tone };
   nextDue?: string | null;
-  /** Editable portal + address rows (always shown; empty → "Add …" inline editor). */
+  reference?: string | null;
+  account?: string | null;
+  dateTime?: string | null;
   portal?: { url: string | null; onOpen?: () => void; onSave: (v: string) => void };
   address?: { value: string | null; onSave: (v: string) => void };
   notifications?: { enabled: boolean; onToggle: (v: boolean) => void };
   metrics: DetailMetric[];
+  receipt?: DetailReceipt;
   historyTitle?: string;
   history: DetailHistoryEntry[];
+  onViewAll?: () => void;
   actions?: DetailAction[];
 }
 
@@ -63,46 +67,58 @@ const TONE_TEXT: Record<Tone, string> = {
   muted: 'text-foreground',
 };
 
-/** One label/value row inside the identity card. */
-function Row({ label, onClick, children }: { label: string; onClick?: () => void; children: ReactNode }) {
-  const Tag = onClick ? 'button' : 'div';
+const hostOf = (url: string) => { try { return new URL(url).host; } catch { return url; } };
+
+function Section({ title, defaultOpen = true, children }: { title: string; defaultOpen?: boolean; children: ReactNode }) {
+  const [open, setOpen] = useState(defaultOpen);
   return (
-    <Tag type={onClick ? 'button' : undefined} onClick={onClick} className={cn('flex min-h-[48px] w-full items-center justify-between gap-3 px-4 text-left', onClick && 'transition-colors hover:bg-foreground/[0.03]')}>
-      <span className="text-sm text-muted-foreground">{label}</span>
-      <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">{children}</div>
-    </Tag>
+    <div>
+      <button type="button" onClick={() => setOpen((o) => !o)} className="mb-2 flex w-full items-center justify-between px-1">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{title}</span>
+        <ChevronDown className={cn('h-4 w-4 text-muted-foreground transition-transform', !open && '-rotate-90')} />
+      </button>
+      {open && children}
+    </div>
   );
 }
 
-/** A label/value row that inline-edits when empty or via the pencil. `display` is shown, `value` is edited. */
-function EditableRow({
-  label,
-  value,
-  display,
-  placeholder,
-  onSave,
-  onOpen,
-}: {
-  label: string;
-  value: string | null;
-  display?: string;
-  placeholder: string;
-  onSave: (v: string) => void;
-  onOpen?: () => void;
+function Row({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex min-h-[46px] items-center justify-between gap-3 px-4">
+      <span className="shrink-0 text-sm text-muted-foreground">{label}</span>
+      <div className="flex min-w-0 items-center justify-end gap-1.5 text-sm font-medium text-foreground">{children}</div>
+    </div>
+  );
+}
+
+function CopyValue({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={() => { navigator.clipboard?.writeText(value).catch(() => {}); setCopied(true); setTimeout(() => setCopied(false), 1200); }}
+      className="inline-flex min-w-0 items-center gap-1.5 font-mono text-sm text-foreground"
+    >
+      <span className="truncate">{value}</span>
+      {copied ? <Check className="h-3.5 w-3.5 shrink-0 text-positive" /> : <Copy className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+    </button>
+  );
+}
+
+/** Inline-editable row (empty → "Add …"); `display` shown, `value` edited. */
+function EditableRow({ label, value, display, placeholder, onSave, onOpen }: {
+  label: string; value: string | null; display?: string; placeholder: string; onSave: (v: string) => void; onOpen?: () => void;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value ?? '');
   useEffect(() => setDraft(value ?? ''), [value]);
   const save = () => { onSave(draft.trim()); setEditing(false); };
-
   if (editing) {
     return (
-      <div className="flex min-h-[48px] items-center gap-2 px-4">
+      <div className="flex min-h-[46px] items-center gap-2 px-4">
         <span className="shrink-0 text-sm text-muted-foreground">{label}</span>
         <input
-          autoFocus
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
+          autoFocus value={draft} onChange={(e) => setDraft(e.target.value)}
           onKeyDown={(e) => { if (e.key === 'Enter') save(); if (e.key === 'Escape') { setDraft(value ?? ''); setEditing(false); } }}
           placeholder={placeholder}
           className="min-w-0 flex-1 bg-transparent text-right text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
@@ -112,186 +128,205 @@ function EditableRow({
       </div>
     );
   }
-
   return (
-    <div className="flex min-h-[48px] items-center justify-between gap-3 px-4">
-      <span className="text-sm text-muted-foreground">{label}</span>
+    <Row label={label}>
       {value ? (
-        <div className="flex min-w-0 items-center gap-1.5">
-          <button type="button" onClick={onOpen} disabled={!onOpen} className="inline-flex min-w-0 items-center gap-1.5 text-sm font-medium text-foreground disabled:cursor-default">
+        <>
+          <button type="button" onClick={onOpen} disabled={!onOpen} className="inline-flex min-w-0 items-center gap-1.5 disabled:cursor-default">
             <span className="truncate">{display ?? value}</span>
             {onOpen && <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
           </button>
           <button type="button" onClick={() => setEditing(true)} aria-label={`Edit ${label.toLowerCase()}`} className="shrink-0 rounded-full p-1 text-muted-foreground hover:bg-secondary hover:text-foreground"><Pencil className="h-3.5 w-3.5" /></button>
-        </div>
+        </>
       ) : (
-        <button type="button" onClick={() => { setDraft(''); setEditing(true); }} className="inline-flex items-center gap-1 text-sm font-medium text-primary">
-          <Plus className="h-3.5 w-3.5" /> Add {label.toLowerCase()}
-        </button>
+        <button type="button" onClick={() => { setDraft(''); setEditing(true); }} className="inline-flex items-center gap-1 text-primary"><Plus className="h-3.5 w-3.5" /> Add {label.toLowerCase()}</button>
       )}
-    </div>
+    </Row>
   );
 }
 
-const hostOf = (url: string) => { try { return new URL(url).host; } catch { return url; } };
-
-export default function ActivityDetailModal({
-  open,
-  onOpenChange,
-  item,
-}: {
-  open: boolean;
-  onOpenChange: (o: boolean) => void;
-  item: DetailInfo | null;
-}) {
+export default function ActivityDetailModal({ open, onOpenChange, item }: { open: boolean; onOpenChange: (o: boolean) => void; item: DetailInfo | null }) {
+  const [tab, setTab] = useState<'details' | 'history'>('details');
+  useEffect(() => { if (open) setTab('details'); }, [open]);
   if (!item) return null;
   const Icon = item.icon;
   const tintText = item.iconTint?.split(' ').find((c) => c.startsWith('text-')) ?? 'text-muted-foreground';
 
+  // Group history entries in order.
+  const groups: { label: string; entries: DetailHistoryEntry[] }[] = [];
+  for (const h of item.history) {
+    const g = h.group ?? '';
+    const last = groups[groups.length - 1];
+    if (last && last.label === g) last.entries.push(h);
+    else groups.push({ label: g, entries: [h] });
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[420px]">
-        <div className="flex max-h-[90vh] flex-col">
-          {/* back bar */}
-          <div className="flex items-center gap-1 px-3 py-3">
-            <button type="button" onClick={() => onOpenChange(false)} aria-label="Back" className="rounded-full p-1 text-foreground hover:bg-secondary">
-              <ChevronLeft className="h-5 w-5" />
-            </button>
-            <span className="text-base font-semibold text-foreground">{item.title}</span>
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent aria-label={item.title} className="gap-0 p-0">
+        {/* header */}
+        <div className="flex shrink-0 items-center justify-between px-3 py-3">
+          <div className="flex min-w-0 items-center gap-1">
+            <button type="button" onClick={() => onOpenChange(false)} aria-label="Close" className="rounded-full p-1 text-foreground hover:bg-secondary"><ChevronLeft className="h-5 w-5" /></button>
+            <span className="truncate text-base font-semibold text-foreground">{item.title}</span>
           </div>
+          {item.receipt?.onShare && (
+            <button type="button" onClick={item.receipt.onShare} aria-label="Share" className="rounded-full p-2 text-muted-foreground hover:bg-secondary hover:text-foreground"><Share2 className="h-4 w-4" /></button>
+          )}
+        </div>
 
-          <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 pb-4">
-            {/* identity card + grouped rows (outline only) */}
-            <div className="overflow-hidden rounded-xl border border-border">
-              <div className="flex items-center gap-3 p-4">
-                <span className={cn('flex h-11 w-11 shrink-0 items-center justify-center rounded-lg', item.iconTint ?? 'bg-secondary text-foreground')}>
-                  <Icon className="h-5 w-5" />
-                </span>
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="truncate text-base font-semibold text-foreground">{item.title}</span>
-                    {item.status && <span className={cn('shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium', TONE_BADGE[item.status.tone])}>{item.status.label}</span>}
-                  </div>
-                  {item.subtitle && <div className="mt-0.5 text-xs text-muted-foreground">{item.subtitle}</div>}
-                </div>
-              </div>
-
-              <div className="divide-y divide-border border-t border-border">
-                {item.typeLabel && (
-                  <Row label="Category">
-                    <span className="inline-flex items-center gap-1.5 rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-foreground">
-                      <Icon className={cn('h-3.5 w-3.5', tintText)} /> {item.typeLabel}
-                    </span>
-                  </Row>
-                )}
-                {item.nextDue && <Row label="Next due">{item.nextDue}</Row>}
-                {item.notifications && (
-                  <Row label="Alerts">
-                    <button
-                      type="button"
-                      role="switch"
-                      aria-checked={item.notifications.enabled}
-                      onClick={() => item.notifications!.onToggle(!item.notifications!.enabled)}
-                      className={cn('relative h-6 w-10 rounded-full transition-colors', item.notifications.enabled ? 'bg-primary' : 'bg-border')}
-                    >
-                      <span className={cn('absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-all', item.notifications.enabled ? 'left-[18px]' : 'left-0.5')} />
-                    </button>
-                  </Row>
-                )}
-                {item.portal && (
-                  <EditableRow
-                    label="Portal"
-                    value={item.portal.url}
-                    display={item.portal.url ? hostOf(item.portal.url) : undefined}
-                    placeholder="pge.com/login"
-                    onOpen={item.portal.onOpen}
-                    onSave={item.portal.onSave}
-                  />
-                )}
-                {item.address && (
-                  <EditableRow label="Address" value={item.address.value} placeholder="123 Main St, City, ST" onSave={item.address.onSave} />
-                )}
-              </div>
+        {/* identity */}
+        <div className="flex shrink-0 items-center gap-3 px-4 pb-4">
+          <span className={cn('flex h-12 w-12 shrink-0 items-center justify-center rounded-xl', item.iconTint ?? 'bg-secondary text-foreground')}>
+            <Icon className="h-5 w-5" />
+          </span>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="truncate text-lg font-semibold text-foreground">{item.title}</span>
+              {item.status && <span className={cn('shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium', TONE_BADGE[item.status.tone])}>{item.status.label}</span>}
             </div>
+            {(item.typeLabel || item.subtitle) && <div className="mt-0.5 truncate text-xs text-muted-foreground">{[item.typeLabel, item.subtitle].filter(Boolean).join(' · ')}</div>}
+          </div>
+        </div>
 
-            {/* metrics — outline grid, hairline-divided */}
-            {item.metrics.length > 0 && (
-              <div className="grid grid-cols-2 overflow-hidden rounded-xl border border-border">
-                {item.metrics.map((m, i) => (
-                  <div
-                    key={m.label}
-                    className={cn('p-3.5', i % 2 === 0 && 'border-r border-border', i + 2 < item.metrics.length && 'border-b border-border')}
-                  >
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs font-medium text-muted-foreground">{m.label}</span>
-                      {m.icon && <m.icon className="h-3.5 w-3.5 text-muted-foreground" />}
-                    </div>
-                    <div className="mt-1.5 font-display text-xl tracking-tight tabular-nums text-foreground">{m.value}</div>
+        {/* tabs */}
+        <div className="flex shrink-0 gap-5 border-b border-border px-4">
+          {(['details', 'history'] as const).map((t) => (
+            <button key={t} type="button" onClick={() => setTab(t)} className={cn('-mb-px flex items-center gap-1.5 border-b-2 py-2.5 text-sm capitalize', tab === t ? 'border-foreground font-semibold text-foreground' : 'border-transparent font-medium text-muted-foreground hover:text-foreground')}>
+              {t}
+              {t === 'history' && <span className="rounded-full bg-secondary px-1.5 text-[11px] font-medium">{item.history.length}</span>}
+            </button>
+          ))}
+        </div>
+
+        {/* body */}
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4">
+          {tab === 'details' ? (
+            <>
+              <Section title="Summary">
+                <div className="divide-y divide-border overflow-hidden rounded-xl border border-border">
+                  {item.typeLabel && (
+                    <Row label="Category">
+                      <span className="inline-flex items-center gap-1.5 rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-foreground">
+                        <Icon className={cn('h-3.5 w-3.5', tintText)} /> {item.typeLabel}
+                      </span>
+                    </Row>
+                  )}
+                  {item.nextDue && <Row label="Next due">{item.nextDue}</Row>}
+                  {item.notifications && (
+                    <Row label="Alerts">
+                      <button type="button" role="switch" aria-checked={item.notifications.enabled} onClick={() => item.notifications!.onToggle(!item.notifications!.enabled)} className={cn('relative h-6 w-10 rounded-full transition-colors', item.notifications.enabled ? 'bg-primary' : 'bg-border')}>
+                        <span className={cn('absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-all', item.notifications.enabled ? 'left-[18px]' : 'left-0.5')} />
+                      </button>
+                    </Row>
+                  )}
+                  {item.portal && <EditableRow label="Portal" value={item.portal.url} display={item.portal.url ? hostOf(item.portal.url) : undefined} placeholder="pge.com/login" onOpen={item.portal.onOpen} onSave={item.portal.onSave} />}
+                  {item.address && <EditableRow label="Address" value={item.address.value} placeholder="123 Main St, City, ST" onSave={item.address.onSave} />}
+                </div>
+              </Section>
+
+              {(item.reference || item.account || item.dateTime || item.status) && (
+                <Section title="Transaction">
+                  <div className="divide-y divide-border overflow-hidden rounded-xl border border-border">
+                    {item.reference && <Row label="Reference"><CopyValue value={item.reference} /></Row>}
+                    {item.account && <Row label="Account"><span className="font-mono">{item.account}</span></Row>}
+                    {item.dateTime && <Row label="Date">{item.dateTime}</Row>}
+                    {item.status && <Row label="Status"><span className={cn('inline-flex items-center gap-1', TONE_TEXT[item.status.tone])}><BadgeCheck className="h-4 w-4" /> {item.status.label}</span></Row>}
                   </div>
-                ))}
-              </div>
-            )}
+                </Section>
+              )}
 
-            {/* history — outline card, hairline rows */}
-            <div>
-              <h3 className="mb-2 px-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{item.historyTitle ?? 'History'}</h3>
-              <div className="overflow-hidden rounded-xl border border-border">
-                {item.history.length > 0 ? (
-                  <div className="divide-y divide-border">
-                    {item.history.map((h) => (
-                      <div key={h.id} className="flex items-center justify-between gap-3 px-4 py-3">
-                        <div className="flex min-w-0 items-center gap-2.5">
-                          {h.success && <BadgeCheck className="h-[18px] w-[18px] shrink-0 text-positive" />}
-                          <div className="min-w-0">
-                            <div className="truncate text-sm font-medium text-foreground">{h.title}</div>
-                            {h.subtitle && <div className="truncate text-xs text-muted-foreground">{h.subtitle}</div>}
-                          </div>
-                        </div>
-                        <span className={cn('shrink-0 font-display text-sm tabular-nums', h.tone ? TONE_TEXT[h.tone] : 'text-foreground')}>{h.value}</span>
+              {item.metrics.length > 0 && (
+                <div className="grid grid-cols-2 overflow-hidden rounded-xl border border-border">
+                  {item.metrics.map((m, i) => (
+                    <div key={m.label} className={cn('p-3.5', i % 2 === 0 && 'border-r border-border', i + 2 < item.metrics.length && 'border-b border-border')}>
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-muted-foreground">{m.label}</span>
+                        {m.icon && <m.icon className="h-3.5 w-3.5 text-muted-foreground" />}
+                      </div>
+                      <div className="mt-1.5 font-display text-xl tracking-tight tabular-nums text-foreground">{m.value}</div>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {item.receipt && (
+                <Section title="Latest receipt">
+                  <div className="rounded-xl border border-border p-4">
+                    {item.receipt.lines.map((l) => (
+                      <div key={l.label} className="flex justify-between py-1 text-sm">
+                        <span className="text-muted-foreground">{l.label}</span>
+                        <span className={cn('font-mono', l.tone ? TONE_TEXT[l.tone] : 'text-foreground')}>{l.value}</span>
                       </div>
                     ))}
-                  </div>
-                ) : (
-                  <div className="py-10 text-center text-sm text-muted-foreground">No history yet.</div>
-                )}
-              </div>
-            </div>
-          </div>
-
-          {/* floating bottom actions (bills only) */}
-          {item.actions && item.actions.length > 0 && (
-            <div className="flex items-center justify-center gap-3 px-4 py-4">
-              {item.actions.map((a) =>
-                a.icon ? (
-                  <button
-                    key={a.label}
-                    type="button"
-                    aria-label={a.label}
-                    disabled={a.disabled}
-                    onClick={a.onClick}
-                    className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-secondary text-foreground transition-colors hover:bg-secondary/70 disabled:opacity-40"
-                  >
-                    <a.icon className="h-5 w-5" />
-                  </button>
-                ) : (
-                  <button
-                    key={a.label}
-                    type="button"
-                    disabled={a.disabled}
-                    onClick={a.onClick}
-                    className={cn(
-                      'rounded-full px-6 py-3 text-sm font-semibold transition-transform active:scale-[0.98] disabled:opacity-40',
-                      a.primary ? 'bg-primary text-primary-foreground' : 'bg-secondary text-foreground',
+                    {item.receipt.total && (
+                      <div className="mt-1 flex justify-between border-t border-border pt-2.5 text-sm font-semibold">
+                        <span className="text-foreground">{item.receipt.total.label}</span>
+                        <span className="font-mono text-foreground">{item.receipt.total.value}</span>
+                      </div>
                     )}
-                  >
-                    {a.label}
-                  </button>
-                ),
+                    {item.receipt.onShare && (
+                      <button type="button" onClick={item.receipt.onShare} className="mt-3 flex w-full items-center justify-center gap-1.5 rounded-lg border border-border py-2.5 text-sm font-medium text-foreground hover:bg-secondary">
+                        <Share2 className="h-4 w-4" /> Share receipt
+                      </button>
+                    )}
+                  </div>
+                </Section>
+              )}
+            </>
+          ) : (
+            <div>
+              {item.history.length > 0 ? (
+                <>
+                  {groups.map((g) => (
+                    <div key={g.label || 'all'} className="mb-2">
+                      {g.label && <div className="px-1 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{g.label}</div>}
+                      <div className="divide-y divide-border">
+                        {g.entries.map((h) => (
+                          <div key={h.id} className="flex items-center justify-between gap-3 py-3">
+                            <div className="flex min-w-0 items-center gap-2.5">
+                              {h.direction === 'in' ? (
+                                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-positive/15 text-positive"><ArrowDownLeft className="h-4 w-4" /></span>
+                              ) : h.direction === 'out' ? (
+                                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-negative/10 text-negative"><ArrowUpRight className="h-4 w-4" /></span>
+                              ) : h.success ? (
+                                <BadgeCheck className="h-[18px] w-[18px] shrink-0 text-positive" />
+                              ) : null}
+                              <div className="min-w-0">
+                                <div className="truncate text-sm font-medium text-foreground">{h.title}</div>
+                                {h.subtitle && <div className="truncate text-xs text-muted-foreground">{h.subtitle}</div>}
+                              </div>
+                            </div>
+                            <span className={cn('shrink-0 font-display text-sm tabular-nums', h.tone ? TONE_TEXT[h.tone] : 'text-foreground')}>{h.value}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                  {item.onViewAll && (
+                    <button type="button" onClick={item.onViewAll} className="mt-2 w-full rounded-lg border border-border py-2.5 text-sm font-medium text-muted-foreground hover:bg-secondary hover:text-foreground">View all activity</button>
+                  )}
+                </>
+              ) : (
+                <div className="rounded-xl border border-border py-10 text-center text-sm text-muted-foreground">No activity yet.</div>
               )}
             </div>
           )}
         </div>
-      </DialogContent>
-    </Dialog>
+
+        {/* pay bar (bills only) */}
+        {item.actions && item.actions.length > 0 && (
+          <div className="flex shrink-0 items-center gap-2 border-t border-border p-4">
+            {item.actions.map((a) =>
+              a.icon ? (
+                <button key={a.label} type="button" aria-label={a.label} disabled={a.disabled} onClick={a.onClick} className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-secondary text-foreground transition-colors hover:bg-secondary/70 disabled:opacity-40"><a.icon className="h-5 w-5" /></button>
+              ) : (
+                <button key={a.label} type="button" disabled={a.disabled} onClick={a.onClick} className={cn('flex-1 rounded-xl py-3 text-sm font-semibold transition-transform active:scale-[0.98] disabled:opacity-40', a.primary ? 'bg-primary text-primary-foreground' : 'border border-border text-foreground hover:bg-secondary')}>{a.label}</button>
+              ),
+            )}
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/app/src/components/app-ui/ActivityDetailModal.tsx
+++ b/app/src/components/app-ui/ActivityDetailModal.tsx
@@ -93,13 +93,16 @@ function Row({ label, children }: { label: string; children: ReactNode }) {
 
 function CopyValue({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
+  // Middle-ellipsis long refs/hashes; copy the full value.
+  const display = value.length > 18 ? `${value.slice(0, 9)}…${value.slice(-6)}` : value;
   return (
     <button
       type="button"
       onClick={() => { navigator.clipboard?.writeText(value).catch(() => {}); setCopied(true); setTimeout(() => setCopied(false), 1200); }}
       className="inline-flex min-w-0 items-center gap-1.5 font-mono text-sm text-foreground"
+      title={value}
     >
-      <span className="truncate">{value}</span>
+      <span className="truncate">{display}</span>
       {copied ? <Check className="h-3.5 w-3.5 shrink-0 text-positive" /> : <Copy className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
     </button>
   );

--- a/app/src/components/app-ui/ActivityDetailModal.tsx
+++ b/app/src/components/app-ui/ActivityDetailModal.tsx
@@ -1,0 +1,198 @@
+import { X, ExternalLink, Bell, type LucideIcon } from 'lucide-react';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+
+/*
+ * Unified expanded detail view for a bill OR a transaction (a bill is just a recurring transaction).
+ * Purely presentational — callers map their data into a `DetailInfo` and pass optional pay `actions`
+ * (bills get them; transactions don't). Shared by the Pay bill detail + the transaction/activity detail.
+ */
+export type Tone = 'positive' | 'pending' | 'negative' | 'muted';
+
+export interface DetailMetric {
+  label: string;
+  value: string;
+}
+export interface DetailHistoryEntry {
+  id: string;
+  title: string;
+  subtitle?: string;
+  amount: string;
+  tone?: Tone;
+}
+export interface DetailAction {
+  label: string;
+  onClick: () => void;
+  primary?: boolean;
+  disabled?: boolean;
+}
+export interface DetailInfo {
+  icon: LucideIcon;
+  iconTint?: string; // e.g. 'bg-amber-500/10 text-amber-600'
+  title: string;
+  subtitle?: string; // "Bill" · "Payment" · counterparty
+  typeLabel?: string; // "Utility" · "Rent" · category
+  status?: { label: string; tone: Tone };
+  address?: string | null;
+  portalHost?: string | null;
+  onPortal?: () => void;
+  notifications?: { enabled: boolean; onToggle: (v: boolean) => void };
+  metrics: DetailMetric[];
+  historyTitle?: string;
+  history: DetailHistoryEntry[];
+  actions?: DetailAction[];
+}
+
+const TONE_BADGE: Record<Tone, string> = {
+  positive: 'bg-positive/10 text-positive',
+  pending: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  negative: 'bg-negative/10 text-negative',
+  muted: 'bg-secondary text-muted-foreground',
+};
+const TONE_TEXT: Record<Tone, string> = {
+  positive: 'text-positive',
+  pending: 'text-amber-600 dark:text-amber-400',
+  negative: 'text-negative',
+  muted: 'text-muted-foreground',
+};
+
+export default function ActivityDetailModal({
+  open,
+  onOpenChange,
+  item,
+}: {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  item: DetailInfo | null;
+}) {
+  if (!item) return null;
+  const Icon = item.icon;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[460px]">
+        <div className="flex max-h-[88vh] flex-col">
+          {/* header */}
+          <div className="flex items-center justify-between px-5 pt-4">
+            <span className="text-sm font-medium text-muted-foreground">{item.subtitle ?? 'Details'}</span>
+            <button type="button" onClick={() => onOpenChange(false)} aria-label="Close" className="-mr-1 rounded-lg p-1.5 text-muted-foreground hover:bg-secondary hover:text-foreground">
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 pb-4 pt-3">
+            {/* identity */}
+            <div className="flex items-center gap-3">
+              <span className={cn('flex h-12 w-12 shrink-0 items-center justify-center rounded-xl', item.iconTint ?? 'bg-secondary text-foreground')}>
+                <Icon className="h-5 w-5" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-lg font-semibold text-foreground">{item.title}</span>
+                  {item.status && (
+                    <span className={cn('shrink-0 rounded-md px-1.5 py-0.5 text-[11px] font-medium', TONE_BADGE[item.status.tone])}>
+                      {item.status.label}
+                    </span>
+                  )}
+                </div>
+                {item.typeLabel && <div className="mt-0.5 text-xs text-muted-foreground">{item.typeLabel}</div>}
+              </div>
+            </div>
+
+            {/* info rows */}
+            {(item.address || item.portalHost || item.notifications) && (
+              <div className="overflow-hidden rounded-xl border border-border">
+                <div className="divide-y divide-border">
+                  {item.address && (
+                    <div className="flex items-start justify-between gap-3 px-4 py-3">
+                      <span className="text-sm text-muted-foreground">Address</span>
+                      <span className="max-w-[65%] text-right text-sm text-foreground">{item.address}</span>
+                    </div>
+                  )}
+                  {item.portalHost && (
+                    <button type="button" onClick={item.onPortal} className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-secondary/40">
+                      <span className="text-sm text-muted-foreground">Portal</span>
+                      <span className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
+                        {item.portalHost} <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
+                      </span>
+                    </button>
+                  )}
+                  {item.notifications && (
+                    <div className="flex items-center justify-between gap-3 px-4 py-3">
+                      <span className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+                        <Bell className="h-4 w-4" /> Reminders
+                      </span>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={item.notifications.enabled}
+                        onClick={() => item.notifications!.onToggle(!item.notifications!.enabled)}
+                        className={cn('relative h-6 w-10 rounded-full transition-colors', item.notifications.enabled ? 'bg-primary' : 'bg-secondary')}
+                      >
+                        <span className={cn('absolute top-0.5 h-5 w-5 rounded-full bg-background shadow transition-all', item.notifications.enabled ? 'left-[18px]' : 'left-0.5')} />
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* metrics */}
+            {item.metrics.length > 0 && (
+              <div className="grid grid-cols-2 gap-2">
+                {item.metrics.map((m) => (
+                  <div key={m.label} className="rounded-xl border border-border p-3">
+                    <div className="font-display text-lg leading-none tabular-nums text-foreground">{m.value}</div>
+                    <div className="mt-1 text-[11px] text-muted-foreground">{m.label}</div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* history */}
+            <div>
+              <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">{item.historyTitle ?? 'History'}</h3>
+              {item.history.length > 0 ? (
+                <div className="overflow-hidden rounded-xl border border-border">
+                  <div className="divide-y divide-border">
+                    {item.history.map((h) => (
+                      <div key={h.id} className="flex items-center justify-between gap-3 px-4 py-3">
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-medium text-foreground">{h.title}</div>
+                          {h.subtitle && <div className="truncate text-xs text-muted-foreground">{h.subtitle}</div>}
+                        </div>
+                        <span className={cn('shrink-0 text-sm font-medium tabular-nums', h.tone ? TONE_TEXT[h.tone] : 'text-foreground')}>{h.amount}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div className="rounded-xl border border-border py-8 text-center text-sm text-muted-foreground">No history yet.</div>
+              )}
+            </div>
+          </div>
+
+          {/* pay actions (bills only) */}
+          {item.actions && item.actions.length > 0 && (
+            <div className="flex gap-2 border-t border-border px-5 py-4">
+              {item.actions.map((a) => (
+                <button
+                  key={a.label}
+                  type="button"
+                  disabled={a.disabled}
+                  onClick={a.onClick}
+                  className={cn(
+                    'flex-1 rounded-xl py-3 text-sm font-semibold transition-transform active:scale-[0.99] disabled:opacity-40',
+                    a.primary ? 'bg-primary text-primary-foreground' : 'border border-border text-foreground hover:bg-secondary',
+                  )}
+                >
+                  {a.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/app-ui/ActivityDetailModal.tsx
+++ b/app/src/components/app-ui/ActivityDetailModal.tsx
@@ -160,9 +160,9 @@ export default function ActivityDetailModal({
             <span className="text-base font-semibold text-foreground">{item.title}</span>
           </div>
 
-          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 pb-4">
-            {/* identity card + grouped rows */}
-            <div className="overflow-hidden rounded-xl border border-border bg-card">
+          <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 pb-4">
+            {/* identity card + grouped rows (outline only) */}
+            <div className="overflow-hidden rounded-xl border border-border">
               <div className="flex items-center gap-3 p-4">
                 <span className={cn('flex h-11 w-11 shrink-0 items-center justify-center rounded-lg', item.iconTint ?? 'bg-secondary text-foreground')}>
                   <Icon className="h-5 w-5" />
@@ -214,44 +214,47 @@ export default function ActivityDetailModal({
               </div>
             </div>
 
-            {/* metrics — StatBar hairline grid */}
+            {/* metrics — outline grid, hairline-divided */}
             {item.metrics.length > 0 && (
-              <div className="overflow-hidden rounded-xl border border-border bg-border">
-                <div className="grid grid-cols-2 gap-px bg-border">
-                  {item.metrics.map((m) => (
-                    <div key={m.label} className="bg-card p-4">
-                      <div className="flex items-center justify-between">
-                        <span className="text-xs font-medium text-muted-foreground">{m.label}</span>
-                        {m.icon && <m.icon className="h-4 w-4 text-muted-foreground" />}
-                      </div>
-                      <div className="mt-2 font-display text-2xl tracking-tight tabular-nums text-foreground">{m.value}</div>
+              <div className="grid grid-cols-2 overflow-hidden rounded-xl border border-border">
+                {item.metrics.map((m, i) => (
+                  <div
+                    key={m.label}
+                    className={cn('p-3.5', i % 2 === 0 && 'border-r border-border', i + 2 < item.metrics.length && 'border-b border-border')}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs font-medium text-muted-foreground">{m.label}</span>
+                      {m.icon && <m.icon className="h-3.5 w-3.5 text-muted-foreground" />}
                     </div>
-                  ))}
-                </div>
+                    <div className="mt-1.5 font-display text-xl tracking-tight tabular-nums text-foreground">{m.value}</div>
+                  </div>
+                ))}
               </div>
             )}
 
-            {/* history — editorial divider rows */}
+            {/* history — outline card, hairline rows */}
             <div>
-              <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{item.historyTitle ?? 'History'}</h3>
-              {item.history.length > 0 ? (
-                <div className="divide-y divide-border border-t border-border">
-                  {item.history.map((h) => (
-                    <div key={h.id} className="flex items-center justify-between gap-3 py-3">
-                      <div className="flex min-w-0 items-center gap-2.5">
-                        {h.success && <BadgeCheck className="h-[18px] w-[18px] shrink-0 text-positive" />}
-                        <div className="min-w-0">
-                          <div className="truncate text-sm font-medium text-foreground">{h.title}</div>
-                          {h.subtitle && <div className="truncate text-xs text-muted-foreground">{h.subtitle}</div>}
+              <h3 className="mb-2 px-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{item.historyTitle ?? 'History'}</h3>
+              <div className="overflow-hidden rounded-xl border border-border">
+                {item.history.length > 0 ? (
+                  <div className="divide-y divide-border">
+                    {item.history.map((h) => (
+                      <div key={h.id} className="flex items-center justify-between gap-3 px-4 py-3">
+                        <div className="flex min-w-0 items-center gap-2.5">
+                          {h.success && <BadgeCheck className="h-[18px] w-[18px] shrink-0 text-positive" />}
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-medium text-foreground">{h.title}</div>
+                            {h.subtitle && <div className="truncate text-xs text-muted-foreground">{h.subtitle}</div>}
+                          </div>
                         </div>
+                        <span className={cn('shrink-0 font-display text-sm tabular-nums', h.tone ? TONE_TEXT[h.tone] : 'text-foreground')}>{h.value}</span>
                       </div>
-                      <span className={cn('shrink-0 font-display text-sm tabular-nums', h.tone ? TONE_TEXT[h.tone] : 'text-foreground')}>{h.value}</span>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="border-t border-border py-8 text-center text-sm text-muted-foreground">No history yet.</div>
-              )}
+                    ))}
+                  </div>
+                ) : (
+                  <div className="py-10 text-center text-sm text-muted-foreground">No history yet.</div>
+                )}
+              </div>
             </div>
           </div>
 

--- a/app/src/components/app-ui/BillDetailModal.tsx
+++ b/app/src/components/app-ui/BillDetailModal.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useAppKitAccount } from '@/lib/walletCompat';
+import ActivityDetailModal, { type DetailInfo } from '@/components/app-ui/ActivityDetailModal';
+import BillPortalBrowser from '@/components/app-ui/BillPortalBrowser';
+import { usePay, creditsFor, type Bill, type BillType } from '@/context/PayContext';
+import { useMemberProfile } from '@/hooks/useMemberProfile';
+import { getPayBillerPayments, type PayBillerPayment } from '@/utils/apiClient';
+import { matchPortal, type BillPortal } from '@/data/billPortals';
+
+/*
+ * Bill detail: maps a Bill + its payment history into the unified ActivityDetailModal, with the two pay
+ * actions ("Pay from balance" = ACH via the existing Pay flow; "Pay on their site" = the biller's portal
+ * with the Clear card). See ActivityDetailModal (presentational) + PayContext.
+ */
+const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const fmtInt = (n: number) => n.toLocaleString('en-US', { maximumFractionDigits: 0 });
+
+const TYPE_TINT: Record<BillType, string> = {
+  rent: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  utility: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  subscription: 'bg-violet-500/10 text-violet-600 dark:text-violet-400',
+  card: 'bg-sky-500/10 text-sky-600 dark:text-sky-400',
+  phone: 'bg-sky-500/10 text-sky-600 dark:text-sky-400',
+  other: 'bg-secondary text-foreground',
+};
+const TYPE_LABEL: Record<BillType, string> = {
+  rent: 'Rent', utility: 'Utility', subscription: 'Subscription', card: 'Credit card', phone: 'Phone', other: 'Bill',
+};
+
+export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; onClose: () => void }) {
+  const { address } = useAppKitAccount();
+  const { openPay, streak } = usePay();
+  const { accelerated } = useMemberProfile();
+  const [payments, setPayments] = useState<PayBillerPayment[]>([]);
+  const [reminders, setReminders] = useState(true);
+  const [portal, setPortal] = useState<BillPortal | null>(null);
+
+  useEffect(() => {
+    if (!bill || !address) { setPayments([]); return; }
+    let cancelled = false;
+    void getPayBillerPayments(address, bill.id).then((p) => { if (!cancelled) setPayments(p); });
+    return () => { cancelled = true; };
+  }, [bill, address]);
+
+  const matched = useMemo(() => (bill ? matchPortal(bill.payee || bill.name) : undefined), [bill]);
+
+  const info: DetailInfo | null = useMemo(() => {
+    if (!bill) return null;
+    const total = payments.reduce((s, p) => s + p.amount, 0);
+    const count = payments.length;
+    const avg = count ? total / count : bill.amount;
+    const creditsEarned = payments.reduce((s, p) => s + creditsFor({ type: bill.type, amount: p.amount }, streak, p.amount, accelerated), 0);
+    const oldest = payments.length ? new Date(payments[payments.length - 1].paidAt) : null;
+    const months = oldest ? Math.max(1, Math.round((Date.now() - oldest.getTime()) / (30 * 864e5))) : 0;
+
+    return {
+      icon: bill.icon,
+      iconTint: TYPE_TINT[bill.type],
+      title: bill.name,
+      subtitle: 'Bill',
+      typeLabel: TYPE_LABEL[bill.type] + (bill.dueLabel ? ` · due ${bill.dueLabel}` : ''),
+      status: { label: 'Active', tone: 'positive' },
+      portalHost: matched ? new URL(matched.url).host : null,
+      onPortal: matched ? () => setPortal(matched) : undefined,
+      notifications: { enabled: reminders, onToggle: setReminders },
+      metrics: [
+        { label: 'Total paid', value: fmt(total) },
+        { label: 'Credits earned', value: fmtInt(creditsEarned) },
+        { label: 'Payments', value: count ? String(count) : '—' },
+        { label: months ? 'Active since' : 'Avg payment', value: months ? `${months} mo` : fmt(avg) },
+      ],
+      historyTitle: 'Payment history',
+      history: payments.map((p) => ({
+        id: p.id,
+        title: 'Payment successful',
+        subtitle: new Date(p.paidAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' }) + (p.onTime ? '' : ' · late'),
+        amount: fmt(p.amount),
+        tone: 'muted' as const,
+      })),
+      actions: [
+        { label: 'Pay from balance', primary: true, onClick: () => { onClose(); openPay(bill.id); } },
+        { label: 'Pay on their site', disabled: !matched, onClick: () => matched && setPortal(matched) },
+      ],
+    };
+  }, [bill, payments, matched, reminders, streak, accelerated, openPay, onClose]);
+
+  return (
+    <>
+      <ActivityDetailModal open={!!bill} onOpenChange={(o) => !o && onClose()} item={info} />
+      <BillPortalBrowser portal={portal} onClose={() => setPortal(null)} />
+    </>
+  );
+}

--- a/app/src/components/app-ui/BillDetailModal.tsx
+++ b/app/src/components/app-ui/BillDetailModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { Globe } from 'lucide-react';
 import { useAppKitAccount } from '@/lib/walletCompat';
 import ActivityDetailModal, { type DetailInfo } from '@/components/app-ui/ActivityDetailModal';
 import BillPortalBrowser from '@/components/app-ui/BillPortalBrowser';
@@ -93,7 +94,7 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
       })),
       actions: [
         { label: 'Pay from balance', primary: true, onClick: () => { onClose(); openPay(bill.id); } },
-        { label: 'Pay on their site', disabled: !matched, onClick: () => matched && setPortal(matched) },
+        { label: 'Pay on their site', icon: Globe, disabled: !matched, onClick: () => matched && setPortal(matched) },
       ],
     };
   }, [bill, payments, matched, reminders, streak, accelerated, openPay, onClose, setReminders]);

--- a/app/src/components/app-ui/BillDetailModal.tsx
+++ b/app/src/components/app-ui/BillDetailModal.tsx
@@ -5,13 +5,14 @@ import ActivityDetailModal, { type DetailInfo } from '@/components/app-ui/Activi
 import BillPortalBrowser from '@/components/app-ui/BillPortalBrowser';
 import { usePay, creditsFor, type Bill, type BillType } from '@/context/PayContext';
 import { useMemberProfile } from '@/hooks/useMemberProfile';
-import { getPayBillerPayments, type PayBillerPayment } from '@/utils/apiClient';
+import { getPayBillerPayments, getMerchantMeta, setMerchantMeta, type PayBillerPayment, type MerchantMeta } from '@/utils/apiClient';
 import { matchPortal, type BillPortal } from '@/data/billPortals';
 
 /*
- * Bill detail: maps a Bill + its payment history into the unified ActivityDetailModal, with the two pay
- * actions ("Pay from balance" = ACH via the existing Pay flow; "Pay on their site" = the biller's portal
- * with the Clear card). See ActivityDetailModal (presentational) + PayContext.
+ * Bill detail: maps a Bill + its payment history into the unified ActivityDetailModal. Portal + address
+ * come from the shared per-merchant store (getMerchantMeta), falling back to the biller record / a
+ * directory match; they're inline-editable (setMerchantMeta, keyed by merchant name, so edits also show
+ * on the matching transactions). Two pay actions: "Pay from balance" (ACH) + "Pay on their site" (portal).
  */
 const nInt = (n: number) => n.toLocaleString('en-US', { maximumFractionDigits: 0 });
 const n2 = (n: number) => n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
@@ -33,23 +34,31 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
   const { openPay, streak, setReminders } = usePay();
   const { accelerated } = useMemberProfile();
   const [payments, setPayments] = useState<PayBillerPayment[]>([]);
+  const [meta, setMeta] = useState<MerchantMeta | null>(null);
   const [reminders, setLocalReminders] = useState(true);
   const [portal, setPortal] = useState<BillPortal | null>(null);
+  const merchantName = bill ? bill.payee || bill.name : '';
 
   useEffect(() => {
     setLocalReminders(bill?.reminders ?? true);
+    setMeta(null);
     if (!bill || !address) { setPayments([]); return; }
     let cancelled = false;
     void getPayBillerPayments(address, bill.id).then((p) => { if (!cancelled) setPayments(p); });
+    void getMerchantMeta(address, bill.payee || bill.name).then((m) => { if (!cancelled) setMeta(m); });
     return () => { cancelled = true; };
   }, [bill, address]);
 
-  // Prefer a portal the user saved on the biller; else best-effort match by name.
-  const matched: BillPortal | undefined = useMemo(() => {
-    if (!bill) return undefined;
-    if (bill.portalUrl) return { id: bill.id, name: bill.name, category: 'utilities', url: bill.portalUrl };
-    return matchPortal(bill.payee || bill.name);
-  }, [bill]);
+  // Effective portal: user-set (merchant store) → biller record → directory match.
+  const portalUrl = meta?.portalUrl ?? bill?.portalUrl ?? (bill ? matchPortal(bill.payee || bill.name)?.url ?? null : null);
+  const addressVal = meta?.address ?? bill?.address ?? null;
+
+  const openPortal = () => {
+    if (!bill || !portalUrl) return;
+    setPortal({ id: bill.id, name: bill.name, category: 'utilities', url: portalUrl });
+  };
+  const savePortal = (v: string) => { setMeta((m) => ({ portalUrl: v || null, address: m?.address ?? addressVal })); if (address) void setMerchantMeta(address, merchantName, { portalUrl: v || null }); };
+  const saveAddress = (v: string) => { setMeta((m) => ({ portalUrl: m?.portalUrl ?? portalUrl, address: v || null })); if (address) void setMerchantMeta(address, merchantName, { address: v || null }); };
 
   const info: DetailInfo | null = useMemo(() => {
     if (!bill) return null;
@@ -68,9 +77,8 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
       typeLabel: TYPE_LABEL[bill.type],
       status: { label: 'Active', tone: 'positive' },
       nextDue: bill.dueLabel || null,
-      address: bill.address,
-      portalHost: matched ? new URL(matched.url).host : null,
-      onPortal: matched ? () => setPortal(matched) : undefined,
+      portal: { url: portalUrl, onOpen: portalUrl ? openPortal : undefined, onSave: savePortal },
+      address: { value: addressVal, onSave: saveAddress },
       notifications: {
         enabled: reminders,
         onToggle: (v: boolean) => { setLocalReminders(v); setReminders(bill.id, v); },
@@ -93,10 +101,11 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
       })),
       actions: [
         { label: 'Pay from balance', primary: true, onClick: () => { onClose(); openPay(bill.id); } },
-        { label: 'Pay on their site', icon: Globe, disabled: !matched, onClick: () => matched && setPortal(matched) },
+        { label: 'Pay on their site', icon: Globe, disabled: !portalUrl, onClick: openPortal },
       ],
     };
-  }, [bill, payments, matched, reminders, streak, accelerated, openPay, onClose, setReminders]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bill, payments, portalUrl, addressVal, reminders, streak, accelerated, openPay, onClose, setReminders]);
 
   return (
     <>

--- a/app/src/components/app-ui/BillDetailModal.tsx
+++ b/app/src/components/app-ui/BillDetailModal.tsx
@@ -29,20 +29,26 @@ const TYPE_LABEL: Record<BillType, string> = {
 
 export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; onClose: () => void }) {
   const { address } = useAppKitAccount();
-  const { openPay, streak } = usePay();
+  const { openPay, streak, setReminders } = usePay();
   const { accelerated } = useMemberProfile();
   const [payments, setPayments] = useState<PayBillerPayment[]>([]);
-  const [reminders, setReminders] = useState(true);
+  const [reminders, setLocalReminders] = useState(true);
   const [portal, setPortal] = useState<BillPortal | null>(null);
 
   useEffect(() => {
+    setLocalReminders(bill?.reminders ?? true);
     if (!bill || !address) { setPayments([]); return; }
     let cancelled = false;
     void getPayBillerPayments(address, bill.id).then((p) => { if (!cancelled) setPayments(p); });
     return () => { cancelled = true; };
   }, [bill, address]);
 
-  const matched = useMemo(() => (bill ? matchPortal(bill.payee || bill.name) : undefined), [bill]);
+  // Prefer a portal the user saved on the biller; else best-effort match by name.
+  const matched: BillPortal | undefined = useMemo(() => {
+    if (!bill) return undefined;
+    if (bill.portalUrl) return { id: bill.id, name: bill.name, category: 'utilities', url: bill.portalUrl };
+    return matchPortal(bill.payee || bill.name);
+  }, [bill]);
 
   const info: DetailInfo | null = useMemo(() => {
     if (!bill) return null;
@@ -60,9 +66,13 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
       subtitle: 'Bill',
       typeLabel: TYPE_LABEL[bill.type] + (bill.dueLabel ? ` · due ${bill.dueLabel}` : ''),
       status: { label: 'Active', tone: 'positive' },
+      address: bill.address,
       portalHost: matched ? new URL(matched.url).host : null,
       onPortal: matched ? () => setPortal(matched) : undefined,
-      notifications: { enabled: reminders, onToggle: setReminders },
+      notifications: {
+        enabled: reminders,
+        onToggle: (v: boolean) => { setLocalReminders(v); setReminders(bill.id, v); },
+      },
       metrics: [
         { label: 'Total paid', value: fmt(total) },
         { label: 'Credits earned', value: fmtInt(creditsEarned) },
@@ -82,7 +92,7 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
         { label: 'Pay on their site', disabled: !matched, onClick: () => matched && setPortal(matched) },
       ],
     };
-  }, [bill, payments, matched, reminders, streak, accelerated, openPay, onClose]);
+  }, [bill, payments, matched, reminders, streak, accelerated, openPay, onClose, setReminders]);
 
   return (
     <>

--- a/app/src/components/app-ui/BillDetailModal.tsx
+++ b/app/src/components/app-ui/BillDetailModal.tsx
@@ -12,8 +12,8 @@ import { matchPortal, type BillPortal } from '@/data/billPortals';
  * actions ("Pay from balance" = ACH via the existing Pay flow; "Pay on their site" = the biller's portal
  * with the Clear card). See ActivityDetailModal (presentational) + PayContext.
  */
-const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-const fmtInt = (n: number) => n.toLocaleString('en-US', { maximumFractionDigits: 0 });
+const nInt = (n: number) => n.toLocaleString('en-US', { maximumFractionDigits: 0 });
+const n2 = (n: number) => n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 
 const TYPE_TINT: Record<BillType, string> = {
   rent: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
@@ -64,8 +64,9 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
       iconTint: TYPE_TINT[bill.type],
       title: bill.name,
       subtitle: 'Bill',
-      typeLabel: TYPE_LABEL[bill.type] + (bill.dueLabel ? ` · due ${bill.dueLabel}` : ''),
+      typeLabel: TYPE_LABEL[bill.type],
       status: { label: 'Active', tone: 'positive' },
+      nextDue: bill.dueLabel || null,
       address: bill.address,
       portalHost: matched ? new URL(matched.url).host : null,
       onPortal: matched ? () => setPortal(matched) : undefined,
@@ -74,18 +75,21 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
         onToggle: (v: boolean) => { setLocalReminders(v); setReminders(bill.id, v); },
       },
       metrics: [
-        { label: 'Total paid', value: fmt(total) },
-        { label: 'Credits earned', value: fmtInt(creditsEarned) },
-        { label: 'Payments', value: count ? String(count) : '—' },
-        { label: months ? 'Active since' : 'Avg payment', value: months ? `${months} mo` : fmt(avg) },
+        { label: 'Total paid', value: nInt(total), unit: 'USD' },
+        { label: 'Credits earned', value: nInt(creditsEarned) },
+        { label: 'Payments', value: String(count) },
+        months
+          ? { label: 'Active since', value: String(months), unit: 'mo' }
+          : { label: 'Avg payment', value: nInt(avg), unit: 'USD' },
       ],
       historyTitle: 'Payment history',
       history: payments.map((p) => ({
         id: p.id,
         title: 'Payment successful',
         subtitle: new Date(p.paidAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' }) + (p.onTime ? '' : ' · late'),
-        amount: fmt(p.amount),
-        tone: 'muted' as const,
+        value: n2(p.amount),
+        unit: 'USD',
+        success: true,
       })),
       actions: [
         { label: 'Pay from balance', primary: true, onClick: () => { onClose(); openPay(bill.id); } },

--- a/app/src/components/app-ui/BillDetailModal.tsx
+++ b/app/src/components/app-ui/BillDetailModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Globe } from 'lucide-react';
+import { Globe, Wallet, TrendingUp, Hash, Calendar } from 'lucide-react';
 import { useAppKitAccount } from '@/lib/walletCompat';
 import ActivityDetailModal, { type DetailInfo } from '@/components/app-ui/ActivityDetailModal';
 import BillPortalBrowser from '@/components/app-ui/BillPortalBrowser';
@@ -76,20 +76,19 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
         onToggle: (v: boolean) => { setLocalReminders(v); setReminders(bill.id, v); },
       },
       metrics: [
-        { label: 'Total paid', value: nInt(total), unit: 'USD' },
-        { label: 'Credits earned', value: nInt(creditsEarned) },
-        { label: 'Payments', value: String(count) },
+        { label: 'Total paid', value: `$${nInt(total)}`, icon: Wallet },
+        { label: 'Credits earned', value: nInt(creditsEarned), icon: TrendingUp },
+        { label: 'Payments', value: String(count), icon: Hash },
         months
-          ? { label: 'Active since', value: String(months), unit: 'mo' }
-          : { label: 'Avg payment', value: nInt(avg), unit: 'USD' },
+          ? { label: 'Active since', value: `${months} mo`, icon: Calendar }
+          : { label: 'Avg payment', value: `$${nInt(avg)}`, icon: Calendar },
       ],
       historyTitle: 'Payment history',
       history: payments.map((p) => ({
         id: p.id,
         title: 'Payment successful',
         subtitle: new Date(p.paidAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' }) + (p.onTime ? '' : ' · late'),
-        value: n2(p.amount),
-        unit: 'USD',
+        value: `$${n2(p.amount)}`,
         success: true,
       })),
       actions: [

--- a/app/src/components/app-ui/BillDetailModal.tsx
+++ b/app/src/components/app-ui/BillDetailModal.tsx
@@ -17,6 +17,12 @@ import { matchPortal, type BillPortal } from '@/data/billPortals';
 const nInt = (n: number) => n.toLocaleString('en-US', { maximumFractionDigits: 0 });
 const n2 = (n: number) => n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 
+function shareReceipt(name: string, amount: number) {
+  const text = `${name} — $${n2(amount)} paid via Clear`;
+  if (typeof navigator !== 'undefined' && navigator.share) void navigator.share({ title: 'Receipt', text }).catch(() => {});
+  else void navigator.clipboard?.writeText(text).catch(() => {});
+}
+
 const TYPE_TINT: Record<BillType, string> = {
   rent: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
   utility: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
@@ -68,6 +74,8 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
     const creditsEarned = payments.reduce((s, p) => s + creditsFor({ type: bill.type, amount: p.amount }, streak, p.amount, accelerated), 0);
     const oldest = payments.length ? new Date(payments[payments.length - 1].paidAt) : null;
     const months = oldest ? Math.max(1, Math.round((Date.now() - oldest.getTime()) / (30 * 864e5))) : 0;
+    const latest = payments[0];
+    const latestCredits = latest ? creditsFor({ type: bill.type, amount: latest.amount }, streak, latest.amount, accelerated) : 0;
 
     return {
       icon: bill.icon,
@@ -77,8 +85,22 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
       typeLabel: TYPE_LABEL[bill.type],
       status: { label: 'Active', tone: 'positive' },
       nextDue: bill.dueLabel || null,
+      reference: latest ? `#${latest.id}` : null,
+      account: bill.payoutLast4 ? `•••• ${bill.payoutLast4}` : null,
+      dateTime: latest ? new Date(latest.paidAt).toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' }) : null,
       portal: { url: portalUrl, onOpen: portalUrl ? openPortal : undefined, onSave: savePortal },
       address: { value: addressVal, onSave: saveAddress },
+      receipt: latest
+        ? {
+            lines: [
+              { label: 'Amount', value: `$${n2(latest.amount)}` },
+              { label: 'Fee', value: 'Free', tone: 'positive' as const },
+              { label: 'Credits earned', value: `+${latestCredits}`, tone: 'positive' as const },
+            ],
+            total: { label: 'Total', value: `$${n2(latest.amount)}` },
+            onShare: () => shareReceipt(bill.name, latest.amount),
+          }
+        : undefined,
       notifications: {
         enabled: reminders,
         onToggle: (v: boolean) => { setLocalReminders(v); setReminders(bill.id, v); },

--- a/app/src/components/app-ui/BillDetailModal.tsx
+++ b/app/src/components/app-ui/BillDetailModal.tsx
@@ -86,7 +86,7 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
       status: { label: 'Active', tone: 'positive' },
       nextDue: bill.dueLabel || null,
       reference: latest ? `#${latest.id}` : null,
-      account: bill.payoutLast4 ? `•••• ${bill.payoutLast4}` : null,
+      account: 'Cash · Clear Account',
       dateTime: latest ? new Date(latest.paidAt).toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' }) : null,
       portal: { url: portalUrl, onOpen: portalUrl ? openPortal : undefined, onSave: savePortal },
       address: { value: addressVal, onSave: saveAddress },
@@ -114,13 +114,18 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
           : { label: 'Avg payment', value: `$${nInt(avg)}`, icon: Calendar },
       ],
       historyTitle: 'Payment history',
-      history: payments.map((p) => ({
-        id: p.id,
-        title: 'Payment successful',
-        subtitle: new Date(p.paidAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' }) + (p.onTime ? '' : ' · late'),
-        value: `$${n2(p.amount)}`,
-        success: true,
-      })),
+      history: payments.map((p) => {
+        const c = creditsFor({ type: bill.type, amount: p.amount }, streak, p.amount, accelerated);
+        const d = new Date(p.paidAt);
+        return {
+          id: p.id,
+          title: 'Payment successful',
+          subtitle: `${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}${p.onTime ? '' : ' · late'}${c > 0 ? ` · +${c} credits` : ''}`,
+          value: `$${n2(p.amount)}`,
+          success: true,
+          group: String(d.getFullYear()),
+        };
+      }),
       actions: [
         { label: 'Pay from balance', primary: true, onClick: () => { onClose(); openPay(bill.id); } },
         { label: 'Pay on their site', icon: Globe, disabled: !portalUrl, onClick: openPortal },

--- a/app/src/components/app-ui/BillPortalsModal.tsx
+++ b/app/src/components/app-ui/BillPortalsModal.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Search, ChevronRight, TrendingUp, Flame, Zap, Droplet, Home, Smartphone, type LucideIcon } from 'lucide-react';
+import { Search, ArrowUpRight, TrendingUp, Flame, Zap, Droplet, Home, Smartphone, type LucideIcon } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 import BillPortalBrowser from '@/components/app-ui/BillPortalBrowser';
@@ -8,13 +8,12 @@ import { useMemberProfile } from '@/hooks/useMemberProfile';
 import { BILL_PORTALS, PORTAL_CATEGORIES, rankPortals, matchPortal, type BillPortal, type PortalCategory } from '@/data/billPortals';
 
 /*
- * "Pay a bill" — bills-first, styled to the dashboard design system (hairline-divided rows in a single
- * bordered card, tinted lucide icons, minimal chrome). Opens to the member's own billers (manual +
- * Plaid) with the equity credits each earns, then a short, smart provider list (top matches for their
- * billers + inferred state) with search to find more — not a long flat list.
+ * "Pay a bill" — bills-first, card/grid layout matching the app's ActionTile system. Opens to the
+ * member's own billers (manual + Plaid) as tiles with the equity credits each earns, then a short grid
+ * of smart provider tiles (top matches for their billers + inferred state) with search to find more.
  */
 const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-const LIMIT = 6;
+const LIMIT = 6; // 2×3 grid
 
 const CAT_ICON: Record<PortalCategory, LucideIcon> = { electric: Zap, utilities: Droplet, rent: Home, telecom: Smartphone };
 const CAT_TINT: Record<PortalCategory, string> = {
@@ -24,6 +23,9 @@ const CAT_TINT: Record<PortalCategory, string> = {
   telecom: 'bg-violet-500/10 text-violet-600 dark:text-violet-400',
 };
 
+const TILE =
+  'group relative flex min-h-[104px] flex-col justify-between overflow-hidden rounded-lg border border-border bg-card p-3.5 text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-[0_10px_24px_-14px_rgba(0,0,0,0.3)] active:translate-y-0 active:scale-[0.99]';
+
 export default function BillPortalsModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
   const { bills, summary, openPay, streak } = usePay();
   const { accelerated } = useMemberProfile();
@@ -32,7 +34,6 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
   const [showAll, setShowAll] = useState(false);
   const [active, setActive] = useState<BillPortal | null>(null);
 
-  // Infer the user's state from a state-specific biller they already have (e.g. a PG&E bill → CA).
   const inferredState = useMemo(() => {
     for (const b of bills) {
       const p = matchPortal(b.payee || b.name);
@@ -41,10 +42,7 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
     return undefined;
   }, [bills]);
 
-  const mineIds = useMemo(
-    () => new Set(bills.map((b) => matchPortal(b.payee || b.name)?.id).filter(Boolean)),
-    [bills],
-  );
+  const mineIds = useMemo(() => new Set(bills.map((b) => matchPortal(b.payee || b.name)?.id).filter(Boolean)), [bills]);
 
   const ranked = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -70,7 +68,7 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[460px]">
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[480px]">
         <div className="flex max-h-[86vh] flex-col">
           <div className="px-5 pt-5">
             <div className="text-base font-semibold text-foreground">Pay a bill</div>
@@ -78,7 +76,7 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
 
           <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-5 pb-5 pt-4">
             {/* equity credits + streak */}
-            <div className="flex items-center justify-between rounded-xl border border-border p-4">
+            <div className="flex items-center justify-between rounded-lg border border-border bg-card p-4">
               <div className="flex items-center gap-3">
                 <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-foreground text-background">
                   <TrendingUp className="h-[18px] w-[18px]" />
@@ -100,101 +98,85 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
             {/* your bills */}
             {bills.length > 0 && (
               <div>
-                <h3 className="mb-2 text-sm font-medium text-foreground">Your bills</h3>
-                <div className="overflow-hidden rounded-xl border border-border">
-                  <div className="divide-y divide-border">
-                    {bills.map((b) => {
-                      const credits = creditsFor(b, streak, b.amount, accelerated);
-                      return (
-                        <button
-                          key={b.id}
-                          type="button"
-                          onClick={() => payBill(b)}
-                          className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-secondary/40"
-                        >
-                          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
+                <h3 className="mb-3 text-xs font-medium text-muted-foreground">Your bills</h3>
+                <div className="grid grid-cols-2 gap-3">
+                  {bills.map((b) => {
+                    const credits = creditsFor(b, streak, b.amount, accelerated);
+                    return (
+                      <button key={b.id} type="button" onClick={() => payBill(b)} className={TILE}>
+                        <div className="flex items-center justify-between">
+                          <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-secondary text-foreground transition-colors group-hover:bg-foreground group-hover:text-background">
                             <b.icon className="h-[18px] w-[18px]" />
                           </span>
-                          <span className="min-w-0 flex-1">
-                            <span className="block truncate text-sm font-medium text-foreground">{b.name}</span>
-                            <span className="block truncate text-xs text-muted-foreground">
-                              {b.amount > 0 ? fmt(b.amount) : 'Amount varies'}
-                              {b.dueLabel ? ` · due ${b.dueLabel}` : ''}
-                              {b.source === 'plaid' ? ' · detected' : ''}
-                            </span>
-                          </span>
                           {credits > 0 && (
-                            <span className="shrink-0 rounded-md bg-positive/10 px-2 py-0.5 text-[11px] font-semibold text-positive">
-                              +{credits.toLocaleString()}
-                            </span>
+                            <span className="rounded-md bg-positive/10 px-2 py-0.5 text-[11px] font-semibold text-positive">+{credits.toLocaleString()}</span>
                           )}
-                          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-                        </button>
-                      );
-                    })}
-                  </div>
+                        </div>
+                        <div>
+                          <div className="truncate text-sm font-medium text-foreground">{b.name}</div>
+                          <div className="truncate text-xs text-muted-foreground">
+                            {b.amount > 0 ? fmt(b.amount) : 'Amount varies'}
+                            {b.dueLabel ? ` · ${b.dueLabel}` : ''}
+                          </div>
+                        </div>
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
             )}
 
             {/* providers */}
             <div>
-              <h3 className="mb-2 text-sm font-medium text-foreground">{bills.length > 0 ? 'Find another provider' : 'Pay a provider'}</h3>
-
-              <div className="relative">
-                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <input
-                  value={query}
-                  onChange={(e) => { setQuery(e.target.value); setShowAll(false); }}
-                  placeholder="Search providers"
-                  className="w-full rounded-lg border border-border bg-background py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-foreground/30 focus:outline-none"
-                />
+              <div className="mb-3 flex items-center gap-2">
+                <div className="relative flex-1">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <input
+                    value={query}
+                    onChange={(e) => { setQuery(e.target.value); setShowAll(false); }}
+                    placeholder="Search providers"
+                    className="w-full rounded-lg border border-border bg-background py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-foreground/30 focus:outline-none"
+                  />
+                </div>
               </div>
 
-              <div className="mt-2 flex items-center gap-1.5 overflow-x-auto pb-0.5">
+              <div className="mb-3 flex items-center gap-1.5 overflow-x-auto pb-0.5">
                 <Chip active={category === 'all'} onClick={() => setCategory('all')}>All</Chip>
                 {PORTAL_CATEGORIES.map((c) => (
                   <Chip key={c.id} active={category === c.id} onClick={() => setCategory(c.id)}>{c.label}</Chip>
                 ))}
               </div>
 
-              <div className="mt-2.5 overflow-hidden rounded-xl border border-border">
-                <div className="divide-y divide-border">
+              {visible.length > 0 ? (
+                <div className="grid grid-cols-2 gap-3">
                   {visible.map((p) => {
                     const Icon = CAT_ICON[p.category];
                     const mine = mineIds.has(p.id);
                     return (
-                      <button
-                        key={p.id}
-                        type="button"
-                        onClick={() => setActive(p)}
-                        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-secondary/40"
-                      >
-                        <span className={cn('flex h-10 w-10 shrink-0 items-center justify-center rounded-lg', CAT_TINT[p.category])}>
-                          <Icon className="h-[18px] w-[18px]" />
-                        </span>
-                        <span className="min-w-0 flex-1">
-                          <span className="block truncate text-sm font-medium text-foreground">{p.name}</span>
-                          <span className="block truncate text-xs text-muted-foreground">{p.hint}</span>
-                        </span>
-                        {mine && (
-                          <span className="shrink-0 rounded-md bg-secondary px-2 py-0.5 text-[11px] font-medium text-muted-foreground">Yours</span>
-                        )}
-                        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                      <button key={p.id} type="button" onClick={() => setActive(p)} className={TILE}>
+                        <div className="flex items-center justify-between">
+                          <span className={cn('flex h-10 w-10 items-center justify-center rounded-lg', CAT_TINT[p.category])}>
+                            <Icon className="h-[18px] w-[18px]" />
+                          </span>
+                          <ArrowUpRight className="h-4 w-4 text-muted-foreground/40 transition-all duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-foreground" />
+                        </div>
+                        <div>
+                          <div className="truncate text-sm font-medium text-foreground">{p.name}</div>
+                          <div className="truncate text-xs text-muted-foreground">{mine ? 'Your provider' : p.hint}</div>
+                        </div>
                       </button>
                     );
                   })}
-                  {visible.length === 0 && (
-                    <div className="py-10 text-center text-sm text-muted-foreground">No providers match.</div>
-                  )}
                 </div>
-              </div>
+              ) : (
+                <div className="rounded-lg border border-border py-10 text-center text-sm text-muted-foreground">No providers match.</div>
+              )}
 
               {!searching && !showAll && ranked.length > LIMIT && (
                 <button
                   type="button"
                   onClick={() => setShowAll(true)}
-                  className="mt-2 w-full rounded-lg py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                  className="mt-3 w-full rounded-lg border border-border py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
                 >
                   See all {ranked.length} providers
                 </button>

--- a/app/src/components/app-ui/BillPortalsModal.tsx
+++ b/app/src/components/app-ui/BillPortalsModal.tsx
@@ -3,6 +3,7 @@ import { Search, ArrowUpRight, TrendingUp, Flame, Zap, Droplet, Home, Smartphone
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 import BillPortalBrowser from '@/components/app-ui/BillPortalBrowser';
+import BillDetailModal from '@/components/app-ui/BillDetailModal';
 import { usePay, creditsFor, type Bill } from '@/context/PayContext';
 import { useMemberProfile } from '@/hooks/useMemberProfile';
 import { BILL_PORTALS, PORTAL_CATEGORIES, rankPortals, matchPortal, type BillPortal, type PortalCategory } from '@/data/billPortals';
@@ -27,12 +28,13 @@ const TILE =
   'group relative flex min-h-[104px] flex-col justify-between overflow-hidden rounded-lg border border-border bg-card p-3.5 text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-[0_10px_24px_-14px_rgba(0,0,0,0.3)] active:translate-y-0 active:scale-[0.99]';
 
 export default function BillPortalsModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
-  const { bills, summary, openPay, streak } = usePay();
+  const { bills, summary, streak } = usePay();
   const { accelerated } = useMemberProfile();
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<PortalCategory | 'all'>('all');
   const [showAll, setShowAll] = useState(false);
   const [active, setActive] = useState<BillPortal | null>(null);
+  const [activeBill, setActiveBill] = useState<Bill | null>(null);
 
   const inferredState = useMemo(() => {
     for (const b of bills) {
@@ -54,17 +56,6 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
 
   const searching = query.trim().length > 0;
   const visible = showAll || searching ? ranked : ranked.slice(0, LIMIT);
-
-  const payBill = (bill: Bill) => {
-    if (bill.payable) {
-      onOpenChange(false);
-      openPay(bill.id);
-      return;
-    }
-    const p = matchPortal(bill.payee || bill.name);
-    if (p) setActive(p);
-    else { setCategory('all'); setQuery(bill.payee || bill.name); }
-  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -103,7 +94,7 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
                   {bills.map((b) => {
                     const credits = creditsFor(b, streak, b.amount, accelerated);
                     return (
-                      <button key={b.id} type="button" onClick={() => payBill(b)} className={TILE}>
+                      <button key={b.id} type="button" onClick={() => setActiveBill(b)} className={TILE}>
                         <div className="flex items-center justify-between">
                           <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-secondary text-foreground transition-colors group-hover:bg-foreground group-hover:text-background">
                             <b.icon className="h-[18px] w-[18px]" />
@@ -187,6 +178,7 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
       </DialogContent>
 
       <BillPortalBrowser portal={active} onClose={() => setActive(null)} />
+      <BillDetailModal bill={activeBill} onClose={() => setActiveBill(null)} />
     </Dialog>
   );
 }

--- a/app/src/components/app-ui/BillPortalsModal.tsx
+++ b/app/src/components/app-ui/BillPortalsModal.tsx
@@ -1,40 +1,71 @@
 import { useMemo, useState } from 'react';
-import { Search, ChevronRight, Info, ChevronDown } from 'lucide-react';
+import { Search, ChevronRight, Info, ChevronDown, TrendingUp, Flame } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 import BillPortalBrowser from '@/components/app-ui/BillPortalBrowser';
+import { usePay, creditsFor, type Bill } from '@/context/PayContext';
+import { useMemberProfile } from '@/hooks/useMemberProfile';
 import {
   BILL_PORTALS,
   PORTAL_CATEGORIES,
   US_STATES,
   rankPortals,
+  matchPortal,
   type BillPortal,
   type PortalCategory,
 } from '@/data/billPortals';
 
 /*
- * "Pay a bill" via the biller's own portal, using the member's Clear card (Bridge / Stripe Issuing,
- * funded just-in-time from their Base USDC). The web app can't autofill a third-party site (cross-origin),
- * so the flow is: reveal + copy the Clear card, open the provider's portal in a new tab, paste to pay.
- *
- * P1 (this): directory + card wallet panel scaffold. P2 drops the PCI-compliant Stripe Issuing Element
- * into <CardPanel/> so the real PAN/CVV render + copy; the card status comes from the Bridge cardholder.
+ * "Pay a bill" — bills-first. Opens to the member's own billers (manual + Plaid-detected) with the
+ * equity credits each earns, a gamification banner (credits + streak), and a smart provider directory
+ * below that bubbles the user's matched billers + their inferred state. Paying routes to the ACH flow
+ * for billers with payout details, else the in-app portal browser (pay on the biller's site with the
+ * Clear card). See PayContext (bills/summary/creditsFor) + BillPortalBrowser.
  */
+const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
 export default function BillPortalsModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
+  const { bills, summary, openPay, streak } = usePay();
+  const { accelerated } = useMemberProfile();
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<PortalCategory | 'all'>('all');
-  const [state, setState] = useState<string>('');
+  const [state, setState] = useState('');
   const [active, setActive] = useState<BillPortal | null>(null);
+
+  // Infer the user's state from a state-specific biller they already have (e.g. a PG&E bill → CA).
+  const inferredState = useMemo(() => {
+    for (const b of bills) {
+      const p = matchPortal(b.payee || b.name);
+      if (p?.states?.length === 1) return p.states[0];
+    }
+    return '';
+  }, [bills]);
+  const effState = state || inferredState;
 
   const portals = useMemo(() => {
     const q = query.trim().toLowerCase();
     const filtered = BILL_PORTALS.filter(
-      (p) =>
-        (category === 'all' || p.category === category) &&
-        (!q || `${p.name} ${p.hint ?? ''}`.toLowerCase().includes(q)),
+      (p) => (category === 'all' || p.category === category) && (!q || `${p.name} ${p.hint ?? ''}`.toLowerCase().includes(q)),
     );
-    return rankPortals(filtered, state || undefined);
-  }, [query, category, state]);
+    const mine = new Set(bills.map((b) => matchPortal(b.payee || b.name)?.id).filter(Boolean));
+    // Bubble the user's own providers first, then in-state, then the rest.
+    return rankPortals(filtered, effState || undefined).sort((a, b) => (mine.has(b.id) ? 1 : 0) - (mine.has(a.id) ? 1 : 0));
+  }, [query, category, effState, bills]);
+
+  const payBill = (bill: Bill) => {
+    if (bill.payable) {
+      onOpenChange(false); // ACH direct-pay flow (biller has payout details on file)
+      openPay(bill.id);
+      return;
+    }
+    const p = matchPortal(bill.payee || bill.name);
+    if (p) {
+      setActive(p); // pay on the biller's own portal with the Clear card
+      return;
+    }
+    setCategory('all'); // no match → drop them into the directory pre-filtered to this biller
+    setQuery(bill.payee || bill.name);
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -43,85 +74,146 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
           {/* header */}
           <div className="px-5 pt-5">
             <div className="text-base font-semibold text-foreground">Pay a bill</div>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              Open your provider and pay with your Clear card — funded from your Cash balance.
-            </p>
           </div>
 
-          {/* controls */}
-          <div className="space-y-2.5 px-5 pb-3 pt-4">
-            <div className="relative">
-              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <input
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search providers"
-                className="w-full rounded-xl border border-border bg-background py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-foreground/30 focus:outline-none"
-              />
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="flex flex-1 items-center gap-1 overflow-x-auto">
-                <Chip active={category === 'all'} onClick={() => setCategory('all')}>All</Chip>
-                {PORTAL_CATEGORIES.map((c) => (
-                  <Chip key={c.id} active={category === c.id} onClick={() => setCategory(c.id)}>
-                    {c.emoji} {c.label}
-                  </Chip>
-                ))}
-              </div>
-              <div className="relative shrink-0">
-                <select
-                  value={state}
-                  onChange={(e) => setState(e.target.value)}
-                  className="appearance-none rounded-full border border-border bg-background py-1.5 pl-3 pr-7 text-xs font-medium text-foreground focus:border-foreground/30 focus:outline-none"
-                  aria-label="Filter by state"
-                >
-                  <option value="">All states</option>
-                  {US_STATES.map((s) => (
-                    <option key={s.code} value={s.code}>{s.code}</option>
-                  ))}
-                </select>
-                <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-              </div>
-            </div>
-          </div>
-
-          {/* portal list */}
-          <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-5">
-            <div className="space-y-1.5">
-              {portals.map((p) => {
-                const cat = PORTAL_CATEGORIES.find((c) => c.id === p.category);
-                return (
-                  <button
-                    key={p.id}
-                    type="button"
-                    onClick={() => setActive(p)}
-                    className="flex w-full items-center gap-3 rounded-xl border border-border p-2.5 text-left transition-colors hover:bg-secondary/50"
-                  >
-                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-secondary text-base">
-                      {cat?.emoji}
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate text-sm font-medium text-foreground">{p.name}</span>
-                      <span className="block truncate text-xs text-muted-foreground">
-                        {p.hint}
-                        {p.states && state && p.states.includes(state) ? ' · in your area' : ''}
-                      </span>
-                    </span>
-                    <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-                  </button>
-                );
-              })}
-              {portals.length === 0 && (
-                <div className="py-10 text-center text-sm text-muted-foreground">
-                  No providers match. Try a different category or search.
+          {/* gamification banner */}
+          <div className="px-5 pt-3">
+            <div className="flex items-center justify-between rounded-2xl bg-gradient-to-br from-primary/10 to-secondary/50 p-3">
+              <div className="flex items-center gap-2.5">
+                <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-background">
+                  <TrendingUp className="h-4 w-4 text-primary" />
+                </span>
+                <div>
+                  <div className="font-display text-xl leading-none tabular-nums text-foreground">
+                    {(summary?.totalEquity ?? 0).toLocaleString()}
+                  </div>
+                  <div className="mt-0.5 text-[11px] text-muted-foreground">
+                    Equity credits{summary?.pendingEquity ? ` · ${summary.pendingEquity.toLocaleString()} vesting` : ''}
+                  </div>
                 </div>
-              )}
+              </div>
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-background px-2.5 py-1 text-xs font-medium text-foreground">
+                <Flame className="h-3.5 w-3.5 text-amber-500" /> {streak} mo
+              </span>
             </div>
+          </div>
 
-            <p className="mt-3 flex items-start gap-1.5 text-[11px] text-muted-foreground">
-              <Info className="mt-0.5 h-3 w-3 shrink-0" />
-              Don't see your biller? You can still add it manually and pay by bank transfer from “Pay a bill”.
-            </p>
+          {/* scroll body */}
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-5 pt-4">
+            {/* Your bills */}
+            {bills.length > 0 && (
+              <section className="mb-5">
+                <h3 className="mb-2 text-xs font-medium text-muted-foreground">Your bills</h3>
+                <div className="space-y-1.5">
+                  {bills.map((b) => {
+                    const credits = creditsFor(b, streak, b.amount, accelerated);
+                    return (
+                      <button
+                        key={b.id}
+                        type="button"
+                        onClick={() => payBill(b)}
+                        className="flex w-full items-center gap-3 rounded-xl border border-border p-2.5 text-left transition-colors hover:bg-secondary/50"
+                      >
+                        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
+                          <b.icon className="h-[18px] w-[18px]" />
+                        </span>
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm font-medium text-foreground">{b.name}</span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {b.amount > 0 ? fmt(b.amount) : 'Amount varies'}
+                            {b.dueLabel ? ` · due ${b.dueLabel}` : ''}
+                            {b.source === 'plaid' ? ' · detected' : ''}
+                          </span>
+                        </span>
+                        {credits > 0 && (
+                          <span className="shrink-0 rounded-full bg-positive/10 px-2 py-0.5 text-[11px] font-semibold text-positive">
+                            +{credits.toLocaleString()}
+                          </span>
+                        )}
+                        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+            )}
+
+            {/* Find a provider (directory) */}
+            <section>
+              <h3 className="mb-2 text-xs font-medium text-muted-foreground">
+                {bills.length > 0 ? 'Find another provider' : 'Find your provider'}
+              </h3>
+              <div className="space-y-2.5">
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <input
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="Search providers"
+                    className="w-full rounded-xl border border-border bg-background py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-foreground/30 focus:outline-none"
+                  />
+                </div>
+                <div className="flex items-center gap-2">
+                  <div className="flex flex-1 items-center gap-1 overflow-x-auto">
+                    <Chip active={category === 'all'} onClick={() => setCategory('all')}>All</Chip>
+                    {PORTAL_CATEGORIES.map((c) => (
+                      <Chip key={c.id} active={category === c.id} onClick={() => setCategory(c.id)}>
+                        {c.emoji} {c.label}
+                      </Chip>
+                    ))}
+                  </div>
+                  <div className="relative shrink-0">
+                    <select
+                      value={effState}
+                      onChange={(e) => setState(e.target.value)}
+                      className="appearance-none rounded-full border border-border bg-background py-1.5 pl-3 pr-7 text-xs font-medium text-foreground focus:border-foreground/30 focus:outline-none"
+                      aria-label="Filter by state"
+                    >
+                      <option value="">All states</option>
+                      {US_STATES.map((s) => (
+                        <option key={s.code} value={s.code}>{s.code}</option>
+                      ))}
+                    </select>
+                    <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-2.5 space-y-1.5">
+                {portals.map((p) => {
+                  const cat = PORTAL_CATEGORIES.find((c) => c.id === p.category);
+                  const mine = bills.some((b) => matchPortal(b.payee || b.name)?.id === p.id);
+                  return (
+                    <button
+                      key={p.id}
+                      type="button"
+                      onClick={() => setActive(p)}
+                      className="flex w-full items-center gap-3 rounded-xl border border-border p-2.5 text-left transition-colors hover:bg-secondary/50"
+                    >
+                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-secondary text-base">
+                        {cat?.emoji}
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm font-medium text-foreground">{p.name}</span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {p.hint}
+                          {mine ? ' · your provider' : p.states && effState && p.states.includes(effState) ? ' · in your area' : ''}
+                        </span>
+                      </span>
+                      <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    </button>
+                  );
+                })}
+                {portals.length === 0 && (
+                  <div className="py-8 text-center text-sm text-muted-foreground">No providers match. Try a different category or search.</div>
+                )}
+              </div>
+
+              <p className="mt-3 flex items-start gap-1.5 text-[11px] text-muted-foreground">
+                <Info className="mt-0.5 h-3 w-3 shrink-0" />
+                Don't see your biller? Add it manually and pay by bank transfer from the bill timeline.
+              </p>
+            </section>
           </div>
         </div>
       </DialogContent>

--- a/app/src/components/app-ui/BillPortalsModal.tsx
+++ b/app/src/components/app-ui/BillPortalsModal.tsx
@@ -1,35 +1,35 @@
 import { useMemo, useState } from 'react';
-import { Search, ChevronRight, Info, ChevronDown, TrendingUp, Flame } from 'lucide-react';
+import { Search, ChevronRight, TrendingUp, Flame, Zap, Droplet, Home, Smartphone, type LucideIcon } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 import BillPortalBrowser from '@/components/app-ui/BillPortalBrowser';
 import { usePay, creditsFor, type Bill } from '@/context/PayContext';
 import { useMemberProfile } from '@/hooks/useMemberProfile';
-import {
-  BILL_PORTALS,
-  PORTAL_CATEGORIES,
-  US_STATES,
-  rankPortals,
-  matchPortal,
-  type BillPortal,
-  type PortalCategory,
-} from '@/data/billPortals';
+import { BILL_PORTALS, PORTAL_CATEGORIES, rankPortals, matchPortal, type BillPortal, type PortalCategory } from '@/data/billPortals';
 
 /*
- * "Pay a bill" — bills-first. Opens to the member's own billers (manual + Plaid-detected) with the
- * equity credits each earns, a gamification banner (credits + streak), and a smart provider directory
- * below that bubbles the user's matched billers + their inferred state. Paying routes to the ACH flow
- * for billers with payout details, else the in-app portal browser (pay on the biller's site with the
- * Clear card). See PayContext (bills/summary/creditsFor) + BillPortalBrowser.
+ * "Pay a bill" — bills-first, styled to the dashboard design system (hairline-divided rows in a single
+ * bordered card, tinted lucide icons, minimal chrome). Opens to the member's own billers (manual +
+ * Plaid) with the equity credits each earns, then a short, smart provider list (top matches for their
+ * billers + inferred state) with search to find more — not a long flat list.
  */
 const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const LIMIT = 6;
+
+const CAT_ICON: Record<PortalCategory, LucideIcon> = { electric: Zap, utilities: Droplet, rent: Home, telecom: Smartphone };
+const CAT_TINT: Record<PortalCategory, string> = {
+  electric: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  utilities: 'bg-sky-500/10 text-sky-600 dark:text-sky-400',
+  rent: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  telecom: 'bg-violet-500/10 text-violet-600 dark:text-violet-400',
+};
 
 export default function BillPortalsModal({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
   const { bills, summary, openPay, streak } = usePay();
   const { accelerated } = useMemberProfile();
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<PortalCategory | 'all'>('all');
-  const [state, setState] = useState('');
+  const [showAll, setShowAll] = useState(false);
   const [active, setActive] = useState<BillPortal | null>(null);
 
   // Infer the user's state from a state-specific biller they already have (e.g. a PG&E bill → CA).
@@ -38,187 +38,172 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
       const p = matchPortal(b.payee || b.name);
       if (p?.states?.length === 1) return p.states[0];
     }
-    return '';
+    return undefined;
   }, [bills]);
-  const effState = state || inferredState;
 
-  const portals = useMemo(() => {
+  const mineIds = useMemo(
+    () => new Set(bills.map((b) => matchPortal(b.payee || b.name)?.id).filter(Boolean)),
+    [bills],
+  );
+
+  const ranked = useMemo(() => {
     const q = query.trim().toLowerCase();
     const filtered = BILL_PORTALS.filter(
       (p) => (category === 'all' || p.category === category) && (!q || `${p.name} ${p.hint ?? ''}`.toLowerCase().includes(q)),
     );
-    const mine = new Set(bills.map((b) => matchPortal(b.payee || b.name)?.id).filter(Boolean));
-    // Bubble the user's own providers first, then in-state, then the rest.
-    return rankPortals(filtered, effState || undefined).sort((a, b) => (mine.has(b.id) ? 1 : 0) - (mine.has(a.id) ? 1 : 0));
-  }, [query, category, effState, bills]);
+    return rankPortals(filtered, inferredState).sort((a, b) => (mineIds.has(b.id) ? 1 : 0) - (mineIds.has(a.id) ? 1 : 0));
+  }, [query, category, inferredState, mineIds]);
+
+  const searching = query.trim().length > 0;
+  const visible = showAll || searching ? ranked : ranked.slice(0, LIMIT);
 
   const payBill = (bill: Bill) => {
     if (bill.payable) {
-      onOpenChange(false); // ACH direct-pay flow (biller has payout details on file)
+      onOpenChange(false);
       openPay(bill.id);
       return;
     }
     const p = matchPortal(bill.payee || bill.name);
-    if (p) {
-      setActive(p); // pay on the biller's own portal with the Clear card
-      return;
-    }
-    setCategory('all'); // no match → drop them into the directory pre-filtered to this biller
-    setQuery(bill.payee || bill.name);
+    if (p) setActive(p);
+    else { setCategory('all'); setQuery(bill.payee || bill.name); }
   };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[520px]">
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[460px]">
         <div className="flex max-h-[86vh] flex-col">
-          {/* header */}
           <div className="px-5 pt-5">
             <div className="text-base font-semibold text-foreground">Pay a bill</div>
           </div>
 
-          {/* gamification banner */}
-          <div className="px-5 pt-3">
-            <div className="flex items-center justify-between rounded-2xl bg-gradient-to-br from-primary/10 to-secondary/50 p-3">
-              <div className="flex items-center gap-2.5">
-                <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-background">
-                  <TrendingUp className="h-4 w-4 text-primary" />
+          <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-5 pb-5 pt-4">
+            {/* equity credits + streak */}
+            <div className="flex items-center justify-between rounded-xl border border-border p-4">
+              <div className="flex items-center gap-3">
+                <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-foreground text-background">
+                  <TrendingUp className="h-[18px] w-[18px]" />
                 </span>
                 <div>
                   <div className="font-display text-xl leading-none tabular-nums text-foreground">
                     {(summary?.totalEquity ?? 0).toLocaleString()}
                   </div>
-                  <div className="mt-0.5 text-[11px] text-muted-foreground">
+                  <div className="mt-1 text-xs text-muted-foreground">
                     Equity credits{summary?.pendingEquity ? ` · ${summary.pendingEquity.toLocaleString()} vesting` : ''}
                   </div>
                 </div>
               </div>
-              <span className="inline-flex items-center gap-1.5 rounded-full bg-background px-2.5 py-1 text-xs font-medium text-foreground">
+              <span className="inline-flex items-center gap-1.5 rounded-lg bg-secondary px-2.5 py-1.5 text-xs font-medium text-foreground">
                 <Flame className="h-3.5 w-3.5 text-amber-500" /> {streak} mo
               </span>
             </div>
-          </div>
 
-          {/* scroll body */}
-          <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-5 pt-4">
-            {/* Your bills */}
+            {/* your bills */}
             {bills.length > 0 && (
-              <section className="mb-5">
-                <h3 className="mb-2 text-xs font-medium text-muted-foreground">Your bills</h3>
-                <div className="space-y-1.5">
-                  {bills.map((b) => {
-                    const credits = creditsFor(b, streak, b.amount, accelerated);
+              <div>
+                <h3 className="mb-2 text-sm font-medium text-foreground">Your bills</h3>
+                <div className="overflow-hidden rounded-xl border border-border">
+                  <div className="divide-y divide-border">
+                    {bills.map((b) => {
+                      const credits = creditsFor(b, streak, b.amount, accelerated);
+                      return (
+                        <button
+                          key={b.id}
+                          type="button"
+                          onClick={() => payBill(b)}
+                          className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-secondary/40"
+                        >
+                          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
+                            <b.icon className="h-[18px] w-[18px]" />
+                          </span>
+                          <span className="min-w-0 flex-1">
+                            <span className="block truncate text-sm font-medium text-foreground">{b.name}</span>
+                            <span className="block truncate text-xs text-muted-foreground">
+                              {b.amount > 0 ? fmt(b.amount) : 'Amount varies'}
+                              {b.dueLabel ? ` · due ${b.dueLabel}` : ''}
+                              {b.source === 'plaid' ? ' · detected' : ''}
+                            </span>
+                          </span>
+                          {credits > 0 && (
+                            <span className="shrink-0 rounded-md bg-positive/10 px-2 py-0.5 text-[11px] font-semibold text-positive">
+                              +{credits.toLocaleString()}
+                            </span>
+                          )}
+                          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* providers */}
+            <div>
+              <h3 className="mb-2 text-sm font-medium text-foreground">{bills.length > 0 ? 'Find another provider' : 'Pay a provider'}</h3>
+
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  value={query}
+                  onChange={(e) => { setQuery(e.target.value); setShowAll(false); }}
+                  placeholder="Search providers"
+                  className="w-full rounded-lg border border-border bg-background py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-foreground/30 focus:outline-none"
+                />
+              </div>
+
+              <div className="mt-2 flex items-center gap-1.5 overflow-x-auto pb-0.5">
+                <Chip active={category === 'all'} onClick={() => setCategory('all')}>All</Chip>
+                {PORTAL_CATEGORIES.map((c) => (
+                  <Chip key={c.id} active={category === c.id} onClick={() => setCategory(c.id)}>{c.label}</Chip>
+                ))}
+              </div>
+
+              <div className="mt-2.5 overflow-hidden rounded-xl border border-border">
+                <div className="divide-y divide-border">
+                  {visible.map((p) => {
+                    const Icon = CAT_ICON[p.category];
+                    const mine = mineIds.has(p.id);
                     return (
                       <button
-                        key={b.id}
+                        key={p.id}
                         type="button"
-                        onClick={() => payBill(b)}
-                        className="flex w-full items-center gap-3 rounded-xl border border-border p-2.5 text-left transition-colors hover:bg-secondary/50"
+                        onClick={() => setActive(p)}
+                        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-secondary/40"
                       >
-                        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
-                          <b.icon className="h-[18px] w-[18px]" />
+                        <span className={cn('flex h-10 w-10 shrink-0 items-center justify-center rounded-lg', CAT_TINT[p.category])}>
+                          <Icon className="h-[18px] w-[18px]" />
                         </span>
                         <span className="min-w-0 flex-1">
-                          <span className="block truncate text-sm font-medium text-foreground">{b.name}</span>
-                          <span className="block truncate text-xs text-muted-foreground">
-                            {b.amount > 0 ? fmt(b.amount) : 'Amount varies'}
-                            {b.dueLabel ? ` · due ${b.dueLabel}` : ''}
-                            {b.source === 'plaid' ? ' · detected' : ''}
-                          </span>
+                          <span className="block truncate text-sm font-medium text-foreground">{p.name}</span>
+                          <span className="block truncate text-xs text-muted-foreground">{p.hint}</span>
                         </span>
-                        {credits > 0 && (
-                          <span className="shrink-0 rounded-full bg-positive/10 px-2 py-0.5 text-[11px] font-semibold text-positive">
-                            +{credits.toLocaleString()}
-                          </span>
+                        {mine && (
+                          <span className="shrink-0 rounded-md bg-secondary px-2 py-0.5 text-[11px] font-medium text-muted-foreground">Yours</span>
                         )}
                         <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
                       </button>
                     );
                   })}
-                </div>
-              </section>
-            )}
-
-            {/* Find a provider (directory) */}
-            <section>
-              <h3 className="mb-2 text-xs font-medium text-muted-foreground">
-                {bills.length > 0 ? 'Find another provider' : 'Find your provider'}
-              </h3>
-              <div className="space-y-2.5">
-                <div className="relative">
-                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                  <input
-                    value={query}
-                    onChange={(e) => setQuery(e.target.value)}
-                    placeholder="Search providers"
-                    className="w-full rounded-xl border border-border bg-background py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-foreground/30 focus:outline-none"
-                  />
-                </div>
-                <div className="flex items-center gap-2">
-                  <div className="flex flex-1 items-center gap-1 overflow-x-auto">
-                    <Chip active={category === 'all'} onClick={() => setCategory('all')}>All</Chip>
-                    {PORTAL_CATEGORIES.map((c) => (
-                      <Chip key={c.id} active={category === c.id} onClick={() => setCategory(c.id)}>
-                        {c.emoji} {c.label}
-                      </Chip>
-                    ))}
-                  </div>
-                  <div className="relative shrink-0">
-                    <select
-                      value={effState}
-                      onChange={(e) => setState(e.target.value)}
-                      className="appearance-none rounded-full border border-border bg-background py-1.5 pl-3 pr-7 text-xs font-medium text-foreground focus:border-foreground/30 focus:outline-none"
-                      aria-label="Filter by state"
-                    >
-                      <option value="">All states</option>
-                      {US_STATES.map((s) => (
-                        <option key={s.code} value={s.code}>{s.code}</option>
-                      ))}
-                    </select>
-                    <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-                  </div>
+                  {visible.length === 0 && (
+                    <div className="py-10 text-center text-sm text-muted-foreground">No providers match.</div>
+                  )}
                 </div>
               </div>
 
-              <div className="mt-2.5 space-y-1.5">
-                {portals.map((p) => {
-                  const cat = PORTAL_CATEGORIES.find((c) => c.id === p.category);
-                  const mine = bills.some((b) => matchPortal(b.payee || b.name)?.id === p.id);
-                  return (
-                    <button
-                      key={p.id}
-                      type="button"
-                      onClick={() => setActive(p)}
-                      className="flex w-full items-center gap-3 rounded-xl border border-border p-2.5 text-left transition-colors hover:bg-secondary/50"
-                    >
-                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-secondary text-base">
-                        {cat?.emoji}
-                      </span>
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate text-sm font-medium text-foreground">{p.name}</span>
-                        <span className="block truncate text-xs text-muted-foreground">
-                          {p.hint}
-                          {mine ? ' · your provider' : p.states && effState && p.states.includes(effState) ? ' · in your area' : ''}
-                        </span>
-                      </span>
-                      <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-                    </button>
-                  );
-                })}
-                {portals.length === 0 && (
-                  <div className="py-8 text-center text-sm text-muted-foreground">No providers match. Try a different category or search.</div>
-                )}
-              </div>
-
-              <p className="mt-3 flex items-start gap-1.5 text-[11px] text-muted-foreground">
-                <Info className="mt-0.5 h-3 w-3 shrink-0" />
-                Don't see your biller? Add it manually and pay by bank transfer from the bill timeline.
-              </p>
-            </section>
+              {!searching && !showAll && ranked.length > LIMIT && (
+                <button
+                  type="button"
+                  onClick={() => setShowAll(true)}
+                  className="mt-2 w-full rounded-lg py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                >
+                  See all {ranked.length} providers
+                </button>
+              )}
+            </div>
           </div>
         </div>
       </DialogContent>
 
-      {/* In-app browser sheet for the selected biller (opens over the directory) */}
       <BillPortalBrowser portal={active} onClose={() => setActive(null)} />
     </Dialog>
   );
@@ -230,8 +215,8 @@ function Chip({ active, onClick, children }: { active: boolean; onClick: () => v
       type="button"
       onClick={onClick}
       className={cn(
-        'shrink-0 whitespace-nowrap rounded-full border px-2.5 py-1.5 text-xs font-medium transition-colors',
-        active ? 'border-foreground bg-foreground text-background' : 'border-border text-muted-foreground hover:bg-secondary',
+        'shrink-0 whitespace-nowrap rounded-full px-3 py-1 text-xs font-medium transition-colors',
+        active ? 'bg-foreground text-background' : 'bg-secondary text-muted-foreground hover:text-foreground',
       )}
     >
       {children}

--- a/app/src/components/app-ui/PayModal.tsx
+++ b/app/src/components/app-ui/PayModal.tsx
@@ -31,8 +31,8 @@ interface Source {
   disabled?: boolean; // e.g. card issuance — coming soon
 }
 
-type Draft = { name: string; payee: string; amount: string; dueDay: string; type: BillType };
-const emptyDraft: Draft = { name: '', payee: '', amount: '', dueDay: '', type: 'other' };
+type Draft = { name: string; payee: string; amount: string; dueDay: string; type: BillType; portalUrl: string; address: string };
+const emptyDraft: Draft = { name: '', payee: '', amount: '', dueDay: '', type: 'other', portalUrl: '', address: '' };
 
 const ordinal = (n: number) => {
   const s = ['th', 'st', 'nd', 'rd'];
@@ -94,7 +94,7 @@ export default function PayModal({
   // Edit an existing (manual-only) biller: prefill the form and remember which one we're editing.
   const startEditBiller = (b: Bill) => {
     setEditingId(b.id);
-    setDraft({ name: b.name, payee: b.payee, amount: String(b.amount), dueDay: b.dueDay ? String(b.dueDay) : '', type: b.type });
+    setDraft({ name: b.name, payee: b.payee, amount: String(b.amount), dueDay: b.dueDay ? String(b.dueDay) : '', type: b.type, portalUrl: b.portalUrl ?? '', address: b.address ?? '' });
     setStep('addBiller');
   };
 
@@ -191,6 +191,8 @@ export default function PayModal({
       amount: amt,
       dueLabel: day ? `Due on the ${ordinal(day)}` : 'Due soon',
       dueDay: day,
+      portalUrl: draft.portalUrl.trim() || null,
+      address: draft.address.trim() || null,
     };
     if (editingId) {
       updateBiller(editingId, fields);
@@ -338,6 +340,22 @@ export default function PayModal({
                   />
                 </Labeled>
               </div>
+              <Labeled label="Biller portal">
+                <input
+                  value={draft.portalUrl}
+                  onChange={(e) => setDraft((d) => ({ ...d, portalUrl: e.target.value }))}
+                  placeholder="pge.com/login — pay on their site"
+                  className={inputCls}
+                />
+              </Labeled>
+              <Labeled label="Mailing address">
+                <input
+                  value={draft.address}
+                  onChange={(e) => setDraft((d) => ({ ...d, address: e.target.value }))}
+                  placeholder="Optional"
+                  className={inputCls}
+                />
+              </Labeled>
             </div>
             <button
               type="button"

--- a/app/src/components/app-ui/RecentActivity.tsx
+++ b/app/src/components/app-ui/RecentActivity.tsx
@@ -2,10 +2,11 @@ import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Search, SlidersHorizontal, ArrowLeftRight, ArrowDownLeft, Briefcase, Receipt, CreditCard, Repeat, ChevronLeft, ChevronRight, type LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { useClearTransactions, type ActivityStatus as Status } from '@/hooks/useClearTransactions';
+import { useClearTransactions, type ActivityStatus as Status, type ActivityItem } from '@/hooks/useClearTransactions';
 import { useAppKitAccount } from '@/lib/walletCompat';
 import { useLinkedWallets } from '@/context/LinkedWalletsContext';
 import TransactionFilterModal, { type Category, type AdvFilters, type SourceOption, DEFAULT_ADV, advCount } from './TransactionFilterModal';
+import TransactionDetailModal from './TransactionDetailModal';
 
 /** Compact page list with ellipses, e.g. 1 … 4 5 6 … 12. */
 function pageWindow(current: number, total: number): (number | 'gap')[] {
@@ -20,7 +21,7 @@ function pageWindow(current: number, total: number): (number | 'gap')[] {
   return out;
 }
 
-const CATEGORY: Record<Category, { icon: LucideIcon; tint: string }> = {
+export const CATEGORY: Record<Category, { icon: LucideIcon; tint: string }> = {
   Transfer: { icon: ArrowLeftRight, tint: 'bg-info/10 text-info' },
   Deposit: { icon: ArrowDownLeft, tint: 'bg-positive/10 text-positive' },
   Payroll: { icon: Briefcase, tint: 'bg-positive/10 text-positive' },
@@ -58,6 +59,7 @@ export default function RecentActivity({ className, limit }: { className?: strin
   const [filter, setFilter] = useState<Filter>('All');
   const [adv, setAdv] = useState<AdvFilters>(DEFAULT_ADV);
   const [modalOpen, setModalOpen] = useState(false);
+  const [detailTx, setDetailTx] = useState<ActivityItem | null>(null);
   const activeAdv = advCount(adv);
   // Full list can be hundreds of rows — paginate it (compact mode just shows the first `limit`).
   const PAGE_SIZE = 15;
@@ -176,7 +178,12 @@ export default function RecentActivity({ className, limit }: { className?: strin
           visible.map((it) => {
             const { icon: Icon, tint } = CATEGORY[it.category];
             return (
-              <div key={it.id} className="flex items-center gap-3 py-3 sm:gap-4">
+              <button
+                key={it.id}
+                type="button"
+                onClick={() => setDetailTx(it)}
+                className="-mx-2 flex w-full items-center gap-3 rounded-lg px-2 py-3 text-left transition-colors hover:bg-secondary/40 sm:gap-4"
+              >
                 <span className={cn('flex h-10 w-10 shrink-0 items-center justify-center rounded-lg', tint)}>
                   <Icon className="h-[18px] w-[18px]" />
                 </span>
@@ -204,7 +211,7 @@ export default function RecentActivity({ className, limit }: { className?: strin
                     {it.status}
                   </span>
                 </div>
-              </div>
+              </button>
             );
           })
         )}
@@ -263,6 +270,7 @@ export default function RecentActivity({ className, limit }: { className?: strin
       )}
 
       <TransactionFilterModal open={modalOpen} onOpenChange={setModalOpen} value={adv} onApply={setAdv} sources={sources} />
+      <TransactionDetailModal tx={detailTx} allItems={items} onClose={() => setDetailTx(null)} />
     </div>
   );
 }

--- a/app/src/components/app-ui/TransactionDetailModal.tsx
+++ b/app/src/components/app-ui/TransactionDetailModal.tsx
@@ -8,7 +8,8 @@ import type { ActivityItem, ActivityStatus } from '@/hooks/useClearTransactions'
  * buttons, and the "history" is ALL activity with that same merchant (grouped by name). Metrics summarize
  * the relationship (total, count, average, last).
  */
-const money = (n: number) => `${n < 0 ? '-' : ''}$${Math.abs(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const nInt = (n: number) => Math.abs(n).toLocaleString('en-US', { maximumFractionDigits: 0 });
+const n2 = (n: number) => `${n < 0 ? '-' : ''}${Math.abs(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 const STATUS_TONE: Record<ActivityStatus, Tone> = { completed: 'positive', pending: 'pending', failed: 'negative' };
 
 export default function TransactionDetailModal({
@@ -42,9 +43,9 @@ export default function TransactionDetailModal({
       typeLabel: `${tx.spendCategory || tx.category}${tx.internal ? ' · transfer' : ''}`,
       status: { label: tx.status, tone: STATUS_TONE[tx.status] },
       metrics: [
-        { label: count > 1 ? 'Total' : 'Amount', value: money(total) },
+        { label: count > 1 ? 'Total' : 'Amount', value: nInt(total), unit: 'USD' },
         { label: 'Transactions', value: String(count) },
-        { label: 'Average', value: money(avg) },
+        { label: 'Average', value: nInt(avg), unit: 'USD' },
         { label: 'Last', value: last.date },
       ],
       historyTitle: 'Activity',
@@ -52,8 +53,10 @@ export default function TransactionDetailModal({
         id: i.id,
         title: i.amount > 0 ? 'Received' : 'Payment',
         subtitle: `${i.category} · ${i.date}`,
-        amount: money(i.amount),
+        value: n2(i.amount),
+        unit: 'USD',
         tone: (i.amount > 0 ? 'positive' : 'muted') as Tone,
+        success: i.status === 'completed',
       })),
     };
   }, [tx, allItems]);

--- a/app/src/components/app-ui/TransactionDetailModal.tsx
+++ b/app/src/components/app-ui/TransactionDetailModal.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from 'react';
+import ActivityDetailModal, { type DetailInfo, type Tone } from '@/components/app-ui/ActivityDetailModal';
+import { CATEGORY } from '@/components/app-ui/RecentActivity';
+import type { ActivityItem, ActivityStatus } from '@/hooks/useClearTransactions';
+
+/*
+ * Transaction detail: the same unified ActivityDetailModal as bills, but for a transaction — no pay
+ * buttons, and the "history" is ALL activity with that same merchant (grouped by name). Metrics summarize
+ * the relationship (total, count, average, last).
+ */
+const money = (n: number) => `${n < 0 ? '-' : ''}$${Math.abs(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const STATUS_TONE: Record<ActivityStatus, Tone> = { completed: 'positive', pending: 'pending', failed: 'negative' };
+
+export default function TransactionDetailModal({
+  tx,
+  allItems,
+  onClose,
+}: {
+  tx: ActivityItem | null;
+  allItems: ActivityItem[];
+  onClose: () => void;
+}) {
+  const info: DetailInfo | null = useMemo(() => {
+    if (!tx) return null;
+    const key = tx.name.trim().toLowerCase();
+    const related = allItems
+      .filter((i) => i.name.trim().toLowerCase() === key)
+      .sort((a, b) => b.ts - a.ts);
+    const items = related.length ? related : [tx];
+
+    const total = items.reduce((s, i) => s + Math.abs(i.amount), 0);
+    const count = items.length;
+    const avg = count ? total / count : Math.abs(tx.amount);
+    const last = items[0];
+    const { icon, tint } = CATEGORY[tx.category];
+
+    return {
+      icon,
+      iconTint: tint,
+      title: tx.name,
+      subtitle: 'Transaction',
+      typeLabel: `${tx.spendCategory || tx.category}${tx.internal ? ' · transfer' : ''}`,
+      status: { label: tx.status, tone: STATUS_TONE[tx.status] },
+      metrics: [
+        { label: count > 1 ? 'Total' : 'Amount', value: money(total) },
+        { label: 'Transactions', value: String(count) },
+        { label: 'Average', value: money(avg) },
+        { label: 'Last', value: last.date },
+      ],
+      historyTitle: 'Activity',
+      history: items.map((i) => ({
+        id: i.id,
+        title: i.amount > 0 ? 'Received' : 'Payment',
+        subtitle: `${i.category} · ${i.date}`,
+        amount: money(i.amount),
+        tone: (i.amount > 0 ? 'positive' : 'muted') as Tone,
+      })),
+    };
+  }, [tx, allItems]);
+
+  return <ActivityDetailModal open={!!tx} onOpenChange={(o) => !o && onClose()} item={info} />;
+}

--- a/app/src/components/app-ui/TransactionDetailModal.tsx
+++ b/app/src/components/app-ui/TransactionDetailModal.tsx
@@ -1,13 +1,16 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Wallet, Hash, TrendingUp, Clock } from 'lucide-react';
+import { useAppKitAccount } from '@/lib/walletCompat';
 import ActivityDetailModal, { type DetailInfo, type Tone } from '@/components/app-ui/ActivityDetailModal';
 import { CATEGORY } from '@/components/app-ui/RecentActivity';
+import { getMerchantMeta, setMerchantMeta, type MerchantMeta } from '@/utils/apiClient';
 import type { ActivityItem, ActivityStatus } from '@/hooks/useClearTransactions';
 
 /*
  * Transaction detail: the same unified ActivityDetailModal as bills, but for a transaction — no pay
- * buttons, and the "history" is ALL activity with that same merchant (grouped by name). Metrics summarize
- * the relationship (total, count, average, last).
+ * buttons, and the "history" is ALL activity with that same merchant (grouped by name). Portal + address
+ * come from the shared per-merchant store (keyed by merchant name), inline-editable — so a portal added
+ * here also shows on the matching bill. Metrics summarize the relationship (total, count, average, last).
  */
 const usd0 = (n: number) => `$${Math.abs(n).toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
 const usd2 = (n: number) => `${n < 0 ? '-' : ''}$${Math.abs(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -22,12 +25,25 @@ export default function TransactionDetailModal({
   allItems: ActivityItem[];
   onClose: () => void;
 }) {
+  const { address } = useAppKitAccount();
+  const [meta, setMeta] = useState<MerchantMeta | null>(null);
+  const merchantName = tx?.name ?? '';
+
+  useEffect(() => {
+    setMeta(null);
+    if (!tx || !address) return;
+    let cancelled = false;
+    void getMerchantMeta(address, tx.name).then((m) => { if (!cancelled) setMeta(m); });
+    return () => { cancelled = true; };
+  }, [tx, address]);
+
+  const savePortal = (v: string) => { setMeta((m) => ({ portalUrl: v || null, address: m?.address ?? null })); if (address) void setMerchantMeta(address, merchantName, { portalUrl: v || null }); };
+  const saveAddress = (v: string) => { setMeta((m) => ({ portalUrl: m?.portalUrl ?? null, address: v || null })); if (address) void setMerchantMeta(address, merchantName, { address: v || null }); };
+
   const info: DetailInfo | null = useMemo(() => {
     if (!tx) return null;
     const key = tx.name.trim().toLowerCase();
-    const related = allItems
-      .filter((i) => i.name.trim().toLowerCase() === key)
-      .sort((a, b) => b.ts - a.ts);
+    const related = allItems.filter((i) => i.name.trim().toLowerCase() === key).sort((a, b) => b.ts - a.ts);
     const items = related.length ? related : [tx];
 
     const total = items.reduce((s, i) => s + Math.abs(i.amount), 0);
@@ -43,6 +59,12 @@ export default function TransactionDetailModal({
       subtitle: 'Transaction',
       typeLabel: `${tx.spendCategory || tx.category}${tx.internal ? ' · transfer' : ''}`,
       status: { label: tx.status, tone: STATUS_TONE[tx.status] },
+      portal: {
+        url: meta?.portalUrl ?? null,
+        onOpen: meta?.portalUrl ? () => window.open(meta.portalUrl!, '_blank', 'noopener,noreferrer') : undefined,
+        onSave: savePortal,
+      },
+      address: { value: meta?.address ?? null, onSave: saveAddress },
       metrics: [
         { label: count > 1 ? 'Total' : 'Amount', value: usd0(total), icon: Wallet },
         { label: 'Transactions', value: String(count), icon: Hash },
@@ -59,7 +81,8 @@ export default function TransactionDetailModal({
         success: i.status === 'completed',
       })),
     };
-  }, [tx, allItems]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tx, allItems, meta]);
 
   return <ActivityDetailModal open={!!tx} onOpenChange={(o) => !o && onClose()} item={info} />;
 }

--- a/app/src/components/app-ui/TransactionDetailModal.tsx
+++ b/app/src/components/app-ui/TransactionDetailModal.tsx
@@ -15,6 +15,21 @@ import type { ActivityItem, ActivityStatus } from '@/hooks/useClearTransactions'
 const usd0 = (n: number) => `$${Math.abs(n).toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
 const usd2 = (n: number) => `${n < 0 ? '-' : ''}$${Math.abs(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 const STATUS_TONE: Record<ActivityStatus, Tone> = { completed: 'positive', pending: 'pending', failed: 'negative' };
+const timeOf = (ts: number) => new Date(ts).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+
+function dayGroup(ts: number): string {
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  if (ts >= startOfToday) return 'Today';
+  if (ts >= startOfToday - 864e5) return 'Yesterday';
+  return new Date(ts).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+const acct = (source: string) => (source === 'bank' ? 'Bank account' : /^0x/.test(source) ? `•••• ${source.slice(-4)}` : source);
+function shareTx(name: string, amount: number) {
+  const text = `${name} — ${usd2(amount)}`;
+  if (typeof navigator !== 'undefined' && navigator.share) void navigator.share({ title: 'Receipt', text }).catch(() => {});
+  else void navigator.clipboard?.writeText(text).catch(() => {});
+}
 
 export default function TransactionDetailModal({
   tx,
@@ -59,6 +74,9 @@ export default function TransactionDetailModal({
       subtitle: 'Transaction',
       typeLabel: `${tx.spendCategory || tx.category}${tx.internal ? ' · transfer' : ''}`,
       status: { label: tx.status, tone: STATUS_TONE[tx.status] },
+      reference: `#${tx.id}`,
+      account: acct(tx.source),
+      dateTime: new Date(tx.ts).toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' }),
       portal: {
         url: meta?.portalUrl ?? null,
         onOpen: meta?.portalUrl ? () => window.open(meta.portalUrl!, '_blank', 'noopener,noreferrer') : undefined,
@@ -71,14 +89,20 @@ export default function TransactionDetailModal({
         { label: 'Average', value: usd0(avg), icon: TrendingUp },
         { label: 'Last', value: last.date, icon: Clock },
       ],
+      receipt: {
+        lines: [{ label: tx.amount > 0 ? 'Received' : 'Amount', value: usd2(tx.amount), tone: (tx.amount > 0 ? 'positive' : 'muted') as Tone }],
+        total: { label: 'Total', value: usd2(tx.amount) },
+        onShare: () => shareTx(tx.name, tx.amount),
+      },
       historyTitle: 'Activity',
       history: items.map((i) => ({
         id: i.id,
         title: i.amount > 0 ? 'Received' : 'Payment',
-        subtitle: `${i.category} · ${i.date}`,
+        subtitle: timeOf(i.ts),
         value: usd2(i.amount),
         tone: (i.amount > 0 ? 'positive' : 'muted') as Tone,
-        success: i.status === 'completed',
+        direction: (i.amount > 0 ? 'in' : 'out') as 'in' | 'out',
+        group: dayGroup(i.ts),
       })),
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/src/components/app-ui/TransactionDetailModal.tsx
+++ b/app/src/components/app-ui/TransactionDetailModal.tsx
@@ -24,7 +24,14 @@ function dayGroup(ts: number): string {
   if (ts >= startOfToday - 864e5) return 'Yesterday';
   return new Date(ts).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
-const acct = (source: string) => (source === 'bank' ? 'Bank account' : /^0x/.test(source) ? `•••• ${source.slice(-4)}` : source);
+const acctLabel = (source: string, primary?: string) =>
+  source === 'bank'
+    ? 'Bank account'
+    : primary && source === primary.toLowerCase()
+      ? 'Cash · Clear Account'
+      : /^0x/.test(source)
+        ? `External · •••• ${source.slice(-4)}`
+        : source;
 function shareTx(name: string, amount: number) {
   const text = `${name} — ${usd2(amount)}`;
   if (typeof navigator !== 'undefined' && navigator.share) void navigator.share({ title: 'Receipt', text }).catch(() => {});
@@ -75,7 +82,7 @@ export default function TransactionDetailModal({
       typeLabel: `${tx.spendCategory || tx.category}${tx.internal ? ' · transfer' : ''}`,
       status: { label: tx.status, tone: STATUS_TONE[tx.status] },
       reference: `#${tx.id}`,
-      account: acct(tx.source),
+      account: acctLabel(tx.source, address),
       dateTime: new Date(tx.ts).toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' }),
       portal: {
         url: meta?.portalUrl ?? null,
@@ -106,7 +113,7 @@ export default function TransactionDetailModal({
       })),
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tx, allItems, meta]);
+  }, [tx, allItems, meta, address]);
 
   return <ActivityDetailModal open={!!tx} onOpenChange={(o) => !o && onClose()} item={info} />;
 }

--- a/app/src/components/app-ui/TransactionDetailModal.tsx
+++ b/app/src/components/app-ui/TransactionDetailModal.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { Wallet, Hash, TrendingUp, Clock } from 'lucide-react';
 import ActivityDetailModal, { type DetailInfo, type Tone } from '@/components/app-ui/ActivityDetailModal';
 import { CATEGORY } from '@/components/app-ui/RecentActivity';
 import type { ActivityItem, ActivityStatus } from '@/hooks/useClearTransactions';
@@ -8,8 +9,8 @@ import type { ActivityItem, ActivityStatus } from '@/hooks/useClearTransactions'
  * buttons, and the "history" is ALL activity with that same merchant (grouped by name). Metrics summarize
  * the relationship (total, count, average, last).
  */
-const nInt = (n: number) => Math.abs(n).toLocaleString('en-US', { maximumFractionDigits: 0 });
-const n2 = (n: number) => `${n < 0 ? '-' : ''}${Math.abs(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const usd0 = (n: number) => `$${Math.abs(n).toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
+const usd2 = (n: number) => `${n < 0 ? '-' : ''}$${Math.abs(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 const STATUS_TONE: Record<ActivityStatus, Tone> = { completed: 'positive', pending: 'pending', failed: 'negative' };
 
 export default function TransactionDetailModal({
@@ -43,18 +44,17 @@ export default function TransactionDetailModal({
       typeLabel: `${tx.spendCategory || tx.category}${tx.internal ? ' · transfer' : ''}`,
       status: { label: tx.status, tone: STATUS_TONE[tx.status] },
       metrics: [
-        { label: count > 1 ? 'Total' : 'Amount', value: nInt(total), unit: 'USD' },
-        { label: 'Transactions', value: String(count) },
-        { label: 'Average', value: nInt(avg), unit: 'USD' },
-        { label: 'Last', value: last.date },
+        { label: count > 1 ? 'Total' : 'Amount', value: usd0(total), icon: Wallet },
+        { label: 'Transactions', value: String(count), icon: Hash },
+        { label: 'Average', value: usd0(avg), icon: TrendingUp },
+        { label: 'Last', value: last.date, icon: Clock },
       ],
       historyTitle: 'Activity',
       history: items.map((i) => ({
         id: i.id,
         title: i.amount > 0 ? 'Received' : 'Payment',
         subtitle: `${i.category} · ${i.date}`,
-        value: n2(i.amount),
-        unit: 'USD',
+        value: usd2(i.amount),
         tone: (i.amount > 0 ? 'positive' : 'muted') as Tone,
         success: i.status === 'completed',
       })),

--- a/app/src/components/ui/sheet.tsx
+++ b/app/src/components/ui/sheet.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import * as SheetPrimitive from '@radix-ui/react-dialog';
+import { cn } from '@/lib/utils';
+
+/**
+ * Right-side sheet (drawer): full-height panel anchored to the right on desktop, full-screen on mobile.
+ * Radix Dialog under the hood (same primitive as our Dialog); the consumer renders its own header/close.
+ */
+const Sheet = SheetPrimitive.Root;
+const SheetClose = SheetPrimitive.Close;
+const SheetPortal = SheetPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed inset-y-0 right-0 z-50 flex h-full w-full flex-col border-l border-border bg-background shadow-xl outline-none sm:max-w-[460px]',
+        'duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+export { Sheet, SheetClose, SheetContent };

--- a/app/src/context/PayContext.tsx
+++ b/app/src/context/PayContext.tsx
@@ -12,6 +12,7 @@ import {
   updatePayBiller,
   deletePayBiller,
   setPayBillerPayout,
+  setPayBillerReminders,
   payBiller,
   syncPlaidBillers,
   recordPayment,
@@ -45,10 +46,13 @@ export interface Bill {
   payable: boolean; // has ACH payout details on file → can be paid in-app
   payoutLast4: string | null;
   payoutBank: string | null;
+  portalUrl: string | null; // biller's login/pay page → "Pay on their site"
+  address: string | null; // mailing address (biller info; future mailed-check option)
+  reminders: boolean; // due-date reminders on/off
 }
 
-/** Fields a user can set/edit on a biller (id/icon derived; source + payout are server-controlled). */
-export type BillerDraft = Omit<Bill, 'id' | 'icon' | 'source' | 'payable' | 'payoutLast4' | 'payoutBank'>;
+/** Fields a user can set/edit on a biller (id/icon derived; source/payable/payout/reminders server-controlled). */
+export type BillerDraft = Omit<Bill, 'id' | 'icon' | 'source' | 'payable' | 'payoutLast4' | 'payoutBank' | 'reminders'>;
 
 /** On-time streak fallback when no summary is loaded yet. */
 export const ON_TIME_STREAK = 0;
@@ -117,6 +121,9 @@ function billerToBill(b: PayBiller): Bill {
     payable: b.payable,
     payoutLast4: b.payoutLast4,
     payoutBank: b.payoutBank,
+    portalUrl: b.portalUrl,
+    address: b.address,
+    reminders: b.reminders,
   };
 }
 
@@ -132,6 +139,8 @@ interface PayValue {
   removeBiller: (id: string) => void;
   /** Save a biller's ACH payout destination (account/routing), making it payable. */
   setBillerPayout: (id: string, p: { accountNumber: string; routingNumber: string; bankName?: string }) => Promise<boolean>;
+  /** Toggle due-date reminders for a biller (optimistic; persists in background). */
+  setReminders: (id: string, enabled: boolean) => void;
   /** Pay a biller from Cash (USDC) via Bridge ACH. Returns success + an optional error message. */
   payViaUsdc: (billerId: string, amount: number, email: string) => Promise<{ success: boolean; message?: string }>;
   /** Record an on-time payment + accrue equity credits (called when the Pay flow completes). */
@@ -159,6 +168,7 @@ export function usePay(): PayValue {
       updateBiller: () => {},
       removeBiller: () => {},
       setBillerPayout: async () => false,
+      setReminders: () => {},
       payViaUsdc: async () => ({ success: false }),
       recordBillPayment: async () => {},
       reconcile: async () => {},
@@ -265,9 +275,9 @@ export function PayProvider({ children }: { children: ReactNode }) {
   const addBiller = useCallback(
     (b: BillerDraft) => {
       const tempId = `bill${Date.now()}`;
-      setBills((bs) => [...bs, { ...b, id: tempId, icon: ICONS[b.type] ?? Receipt, source: 'manual', payable: false, payoutLast4: null, payoutBank: null }]);
+      setBills((bs) => [...bs, { ...b, id: tempId, icon: ICONS[b.type] ?? Receipt, source: 'manual', payable: false, payoutLast4: null, payoutBank: null, reminders: true }]);
       if (address) {
-        void addPayBiller(address, { name: b.name, payee: b.payee, type: b.type, defaultAmount: b.amount, dueDay: b.dueDay })
+        void addPayBiller(address, { name: b.name, payee: b.payee, type: b.type, defaultAmount: b.amount, dueDay: b.dueDay, portalUrl: b.portalUrl, address: b.address })
           .then((created) => {
             if (created) {
               realIdRef.current.set(tempId, created.id); // keep tempId in the UI, target realId server-side
@@ -290,12 +300,22 @@ export function PayProvider({ children }: { children: ReactNode }) {
       setBills((bs) => bs.map((x) => (x.id === id && x.source === 'manual' ? { ...x, ...b, icon: ICONS[b.type] ?? Receipt } : x)));
       const realId = resolveId(id);
       if (address && !realId.startsWith('bill')) {
-        void updatePayBiller(address, realId, { name: b.name, payee: b.payee, type: b.type, defaultAmount: b.amount, dueDay: b.dueDay }).then(
+        void updatePayBiller(address, realId, { name: b.name, payee: b.payee, type: b.type, defaultAmount: b.amount, dueDay: b.dueDay, portalUrl: b.portalUrl, address: b.address }).then(
           () => refreshSummaryOnly(),
         );
       }
     },
     [address, refreshSummaryOnly, resolveId],
+  );
+
+  // Optimistic reminders toggle (any biller); persists in the background.
+  const setReminders = useCallback(
+    (id: string, enabled: boolean) => {
+      setBills((bs) => bs.map((x) => (x.id === id ? { ...x, reminders: enabled } : x)));
+      const realId = resolveId(id);
+      if (address && !realId.startsWith('bill')) void setPayBillerReminders(address, realId, enabled);
+    },
+    [address, resolveId],
   );
 
   // Optimistic remove; persists the delete (skips temp/local-only billers not yet in the ledger).
@@ -369,6 +389,7 @@ export function PayProvider({ children }: { children: ReactNode }) {
     updateBiller,
     removeBiller,
     setBillerPayout,
+    setReminders,
     payViaUsdc,
     recordBillPayment,
     reconcile,

--- a/app/src/data/billPortals.ts
+++ b/app/src/data/billPortals.ts
@@ -94,3 +94,17 @@ export function rankPortals(portals: BillPortal[], state?: string): BillPortal[]
   const score = (p: BillPortal) => (p.states?.includes(state) ? 0 : !p.states ? 1 : 2);
   return [...portals].sort((a, b) => score(a) - score(b));
 }
+
+/** Best-effort match a detected/manual biller name to a directory portal (folds in the user's bills). */
+export function matchPortal(billerName: string): BillPortal | undefined {
+  const norm = (v: string) => v.toLowerCase().replace(/[^a-z0-9&]+/g, '');
+  const s = norm(billerName);
+  if (s.length < 3) return undefined;
+  return BILL_PORTALS.find((p) => {
+    const pn = norm(p.name);
+    if (pn.length < 3) return false;
+    if (s.includes(pn) || pn.includes(s)) return true;
+    // shared distinctive token (e.g. "verizon", "xfinity")
+    return p.name.toLowerCase().split(/[^a-z0-9&]+/).some((t) => t.length > 3 && s.includes(t));
+  });
+}

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2132,6 +2132,26 @@ export async function getPayBillerPayments(wallet: string, id: string): Promise<
   return r.error || !r.data ? [] : r.data.payments;
 }
 
+export interface MerchantMeta {
+  portalUrl: string | null;
+  address: string | null;
+}
+
+/** Shared per-merchant portal/address (keyed by merchant name; auto-fills matching bills). */
+export async function getMerchantMeta(wallet: string, name: string): Promise<MerchantMeta | null> {
+  const r = await apiRequest<{ meta: MerchantMeta | null }>(`/api/pay/${wallet.toLowerCase()}/merchant-meta?name=${encodeURIComponent(name)}`);
+  return r.error || !r.data ? null : r.data.meta;
+}
+
+/** Set a merchant's portal and/or address. Only the fields passed are changed. */
+export async function setMerchantMeta(wallet: string, name: string, patch: Partial<MerchantMeta>): Promise<MerchantMeta | null> {
+  const r = await apiRequest<{ meta: MerchantMeta }>(`/api/pay/${wallet.toLowerCase()}/merchant-meta`, {
+    method: 'PUT',
+    body: JSON.stringify({ name, ...patch }),
+  });
+  return r.error || !r.data ? null : r.data.meta;
+}
+
 export async function addPayBiller(
   wallet: string,
   b: { name: string; payee?: string; type: PayBillerType; defaultAmount: number; dueDay?: number | null; portalUrl?: string | null; address?: string | null },

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2088,6 +2088,9 @@ export interface PayBiller {
   payoutLast4: string | null;
   payoutBank: string | null;
   bridgeExternalAccountId: string | null;
+  portalUrl: string | null;
+  address: string | null;
+  reminders: boolean;
 }
 
 export interface PaySummary {
@@ -2131,7 +2134,7 @@ export async function getPayBillerPayments(wallet: string, id: string): Promise<
 
 export async function addPayBiller(
   wallet: string,
-  b: { name: string; payee?: string; type: PayBillerType; defaultAmount: number; dueDay?: number | null },
+  b: { name: string; payee?: string; type: PayBillerType; defaultAmount: number; dueDay?: number | null; portalUrl?: string | null; address?: string | null },
 ): Promise<PayBiller | null> {
   const r = await apiRequest<{ biller: PayBiller }>(`/api/pay/${wallet.toLowerCase()}/billers`, { method: 'POST', body: JSON.stringify(b) });
   return r.error || !r.data ? null : r.data.biller;
@@ -2140,13 +2143,22 @@ export async function addPayBiller(
 export async function updatePayBiller(
   wallet: string,
   id: string,
-  b: { name: string; payee?: string; type: PayBillerType; defaultAmount: number; dueDay?: number | null },
+  b: { name: string; payee?: string; type: PayBillerType; defaultAmount: number; dueDay?: number | null; portalUrl?: string | null; address?: string | null },
 ): Promise<PayBiller | null> {
   const r = await apiRequest<{ biller: PayBiller }>(`/api/pay/${wallet.toLowerCase()}/billers/${id}`, {
     method: 'PUT',
     body: JSON.stringify(b),
   });
   return r.error || !r.data ? null : r.data.biller;
+}
+
+/** Toggle reminders for a biller (any source). */
+export async function setPayBillerReminders(wallet: string, id: string, enabled: boolean): Promise<boolean> {
+  const r = await apiRequest<{ biller: PayBiller }>(`/api/pay/${wallet.toLowerCase()}/billers/${id}/reminders`, {
+    method: 'PATCH',
+    body: JSON.stringify({ enabled }),
+  });
+  return !r.error;
 }
 
 export async function setPayBillerPayout(

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2112,6 +2112,23 @@ export async function getPayBillers(wallet: string): Promise<PayBiller[]> {
   return r.error || !r.data ? [] : r.data.billers;
 }
 
+export interface PayBillerPayment {
+  id: string;
+  name: string | null;
+  type: string;
+  amount: number;
+  paidAt: string;
+  onTime: boolean;
+  source: string;
+  period: string;
+}
+
+/** A biller's payment history for the bill detail view. */
+export async function getPayBillerPayments(wallet: string, id: string): Promise<PayBillerPayment[]> {
+  const r = await apiRequest<{ payments: PayBillerPayment[] }>(`/api/pay/${wallet.toLowerCase()}/billers/${id}/payments`);
+  return r.error || !r.data ? [] : r.data.payments;
+}
+
 export async function addPayBiller(
   wallet: string,
   b: { name: string; payee?: string; type: PayBillerType; defaultAmount: number; dueDay?: number | null },


### PR DESCRIPTION
Ships the Clear Pay **bill/transaction detail** experience (and the accumulated dev work).

## Detail view (the headline)
A unified right-side **drawer** on desktop / full-screen sheet on mobile, for both bills and transactions:
- **Tabs** — Details · History (with count).
- **Details** — collapsible Summary (category, next due, alerts, inline-editable portal + address via the shared per-merchant store) and Transaction (copyable reference with **middle-ellipsis**, **friendly account names** like "Cash · Clear Account", precise date, status); an outline metrics grid; a Latest-receipt block (amount · fee · credits · total) with Share.
- **History** — grouped (Today/…/year), directional in/out colored icons + signed amounts for transactions; per-payment credits for bills.
- Bills get a pay bar ("Pay from balance" + "Pay on their site"); transactions don't.
- Reachable from any activity row (Accounts + Transactions pages). The bill-portal **directory stays gated off in production** (`IS_LIVE_APP`) — only the detail view ships live.

## Also included
Send status/notifications, notification polling fix, dismiss-persistence, offline toast, Plausible analytics, and the Clear Pay merchant-meta backend.

Typecheck + build green. Backend deploys from dev (already live); this merges the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)