### PR TITLE
Clear Pay: receipt PDF + motion pass + View all

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -44,6 +44,7 @@
         "date-fns": "^4.1.0",
         "ethers": "^6.15.0",
         "framer-motion": "^12.24.0",
+        "jspdf": "^4.2.1",
         "lucide-react": "^0.525.0",
         "mapbox-gl": "^3.14.0",
         "ox": "0.11.3",
@@ -400,9 +401,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -11882,11 +11883,24 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/pbf": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
       "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "19.2.7",
@@ -13987,6 +14001,16 @@
       "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -14409,6 +14433,26 @@
         "canonicalize": "bin/canonicalize.js"
       }
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/cbw-sdk": {
       "name": "@coinbase/wallet-sdk",
       "version": "3.9.3",
@@ -14616,6 +14660,18 @@
       "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -14783,6 +14839,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-to-react-native": {
@@ -15165,6 +15231,16 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -16072,6 +16148,33 @@
       "integrity": "sha512-dxm29/BPFrNgyEDygg/lf9c2xQR0vnQhG7+hZjAI39M/3um9fD4xiqG6F0ZjW6bya5m9CI0u6YryHGRtxCGCiw==",
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
+    "node_modules/fast-png/node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/fast-redact": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
@@ -16115,6 +16218,12 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
       "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
+      "license": "MIT"
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -16595,6 +16704,20 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -16698,6 +16821,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
@@ -17115,6 +17244,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/kdbush": {
@@ -18342,6 +18488,13 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/permissionless": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/permissionless/-/permissionless-0.3.6.tgz",
@@ -18963,6 +19116,16 @@
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -19328,6 +19491,13 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -19387,6 +19557,16 @@
       "license": "MIT",
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/ripemd160": {
@@ -19850,6 +20030,16 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
@@ -20091,6 +20281,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
@@ -20139,6 +20339,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
       "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/thread-stream": {
       "version": "3.1.0",
@@ -20670,6 +20880,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/uuid": {
       "version": "11.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -46,6 +46,7 @@
     "date-fns": "^4.1.0",
     "ethers": "^6.15.0",
     "framer-motion": "^12.24.0",
+    "jspdf": "^4.2.1",
     "lucide-react": "^0.525.0",
     "mapbox-gl": "^3.14.0",
     "ox": "0.11.3",

--- a/app/src/components/app-ui/ActivityDetailModal.tsx
+++ b/app/src/components/app-ui/ActivityDetailModal.tsx
@@ -1,10 +1,12 @@
-import { type ReactNode, useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { motion } from 'framer-motion';
 import {
   ChevronLeft, ChevronDown, BadgeCheck, Check, X, Pencil, Copy, ExternalLink, Plus,
-  ArrowDownLeft, ArrowUpRight, Share2, type LucideIcon,
+  ArrowDownLeft, ArrowUpRight, Share2, Download, type LucideIcon,
 } from 'lucide-react';
 import { Sheet, SheetContent } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
+import { downloadReceiptPdf } from '@/lib/receiptPdf';
 
 /*
  * Unified detail view for a bill OR a transaction, as a right-side drawer (full-screen sheet on mobile).
@@ -15,7 +17,7 @@ import { cn } from '@/lib/utils';
  */
 export type Tone = 'positive' | 'pending' | 'negative' | 'muted';
 
-export interface DetailMetric { label: string; value: string; icon?: LucideIcon }
+export interface DetailMetric { label: string; value: string; icon?: LucideIcon; animateTo?: number; format?: (n: number) => string }
 export interface DetailHistoryEntry {
   id: string;
   title: string;
@@ -52,8 +54,9 @@ export interface DetailInfo {
   receipt?: DetailReceipt;
   historyTitle?: string;
   history: DetailHistoryEntry[];
-  onViewAll?: () => void;
   actions?: DetailAction[];
+  /** Shows skeletons in the metrics + history while data loads. */
+  loading?: boolean;
 }
 
 const TONE_BADGE: Record<Tone, string> = {
@@ -150,16 +153,43 @@ function EditableRow({ label, value, display, placeholder, onSave, onOpen }: {
   );
 }
 
+/** Eases 0 → target once on mount (StatBar-style number roll-up). */
+function CountUp({ to, format }: { to: number; format: (n: number) => string }) {
+  const [n, setN] = useState(0);
+  const raf = useRef<number | null>(null);
+  useEffect(() => {
+    const start = performance.now();
+    const dur = 650;
+    const tick = (now: number) => {
+      const p = Math.min((now - start) / dur, 1);
+      setN(to * (1 - Math.pow(1 - p, 3)));
+      if (p < 1) raf.current = requestAnimationFrame(tick);
+      else setN(to);
+    };
+    raf.current = requestAnimationFrame(tick);
+    return () => { if (raf.current) cancelAnimationFrame(raf.current); };
+  }, [to]);
+  return <>{format(n)}</>;
+}
+
+const Skeleton = ({ className }: { className?: string }) => <div className={cn('animate-pulse rounded bg-secondary', className)} />;
+
+const fade = { hidden: { opacity: 0, y: 8 }, show: { opacity: 1, y: 0, transition: { duration: 0.24, ease: 'easeOut' as const } } };
+const stagger = { hidden: {}, show: { transition: { staggerChildren: 0.05 } } };
+const HISTORY_CAP = 6;
+
 export default function ActivityDetailModal({ open, onOpenChange, item }: { open: boolean; onOpenChange: (o: boolean) => void; item: DetailInfo | null }) {
   const [tab, setTab] = useState<'details' | 'history'>('details');
-  useEffect(() => { if (open) setTab('details'); }, [open]);
+  const [showAllHistory, setShowAllHistory] = useState(false);
+  useEffect(() => { if (open) { setTab('details'); setShowAllHistory(false); } }, [open]);
   if (!item) return null;
   const Icon = item.icon;
   const tintText = item.iconTint?.split(' ').find((c) => c.startsWith('text-')) ?? 'text-muted-foreground';
 
-  // Group history entries in order.
+  // Group history entries in order, capped until "View all".
+  const shownHistory = showAllHistory ? item.history : item.history.slice(0, HISTORY_CAP);
   const groups: { label: string; entries: DetailHistoryEntry[] }[] = [];
-  for (const h of item.history) {
+  for (const h of shownHistory) {
     const g = h.group ?? '';
     const last = groups[groups.length - 1];
     if (last && last.label === g) last.entries.push(h);
@@ -204,9 +234,10 @@ export default function ActivityDetailModal({ open, onOpenChange, item }: { open
         </div>
 
         {/* body */}
-        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4">
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
           {tab === 'details' ? (
-            <>
+            <motion.div key="details" variants={stagger} initial="hidden" animate="show" className="space-y-4">
+              <motion.div variants={fade}>
               <Section title="Summary">
                 <div className="divide-y divide-border overflow-hidden rounded-xl border border-border">
                   {item.typeLabel && (
@@ -236,8 +267,10 @@ export default function ActivityDetailModal({ open, onOpenChange, item }: { open
                   {item.address && <EditableRow label="Address" value={item.address.value} placeholder="123 Main St, City, ST" onSave={item.address.onSave} />}
                 </div>
               </Section>
+              </motion.div>
 
               {(item.reference || item.account || item.dateTime || item.status) && (
+                <motion.div variants={fade}>
                 <Section title="Transaction">
                   <div className="divide-y divide-border overflow-hidden rounded-xl border border-border">
                     {item.reference && <Row label="Reference"><CopyValue value={item.reference} /></Row>}
@@ -246,23 +279,34 @@ export default function ActivityDetailModal({ open, onOpenChange, item }: { open
                     {item.status && <Row label="Status"><span className={cn('inline-flex items-center gap-1', TONE_TEXT[item.status.tone])}><BadgeCheck className="h-4 w-4" /> {item.status.label}</span></Row>}
                   </div>
                 </Section>
+                </motion.div>
               )}
 
-              {item.metrics.length > 0 && (
-                <div className="grid grid-cols-2 overflow-hidden rounded-xl border border-border">
-                  {item.metrics.map((m, i) => (
-                    <div key={m.label} className={cn('p-3.5', i % 2 === 0 && 'border-r border-border', i + 2 < item.metrics.length && 'border-b border-border')}>
-                      <div className="flex items-center justify-between">
-                        <span className="text-xs font-medium text-muted-foreground">{m.label}</span>
-                        {m.icon && <m.icon className="h-3.5 w-3.5 text-muted-foreground" />}
-                      </div>
-                      <div className="mt-1.5 font-display text-xl tracking-tight tabular-nums text-foreground">{m.value}</div>
-                    </div>
-                  ))}
-                </div>
+              {(item.loading || item.metrics.length > 0) && (
+                <motion.div variants={fade} className="grid grid-cols-2 overflow-hidden rounded-xl border border-border">
+                  {item.loading
+                    ? Array.from({ length: 4 }).map((_, i) => (
+                        <div key={i} className={cn('p-3.5', i % 2 === 0 && 'border-r border-border', i < 2 && 'border-b border-border')}>
+                          <Skeleton className="h-3 w-16" />
+                          <Skeleton className="mt-2.5 h-6 w-14" />
+                        </div>
+                      ))
+                    : item.metrics.map((m, i) => (
+                        <div key={m.label} className={cn('p-3.5', i % 2 === 0 && 'border-r border-border', i + 2 < item.metrics.length && 'border-b border-border')}>
+                          <div className="flex items-center justify-between">
+                            <span className="text-xs font-medium text-muted-foreground">{m.label}</span>
+                            {m.icon && <m.icon className="h-3.5 w-3.5 text-muted-foreground" />}
+                          </div>
+                          <div className="mt-1.5 font-display text-xl tracking-tight tabular-nums text-foreground">
+                            {m.animateTo != null && m.format ? <CountUp to={m.animateTo} format={m.format} /> : m.value}
+                          </div>
+                        </div>
+                      ))}
+                </motion.div>
               )}
 
               {item.receipt && (
+                <motion.div variants={fade}>
                 <Section title="Latest receipt">
                   <div className="rounded-xl border border-border p-4">
                     {item.receipt.lines.map((l) => (
@@ -277,21 +321,41 @@ export default function ActivityDetailModal({ open, onOpenChange, item }: { open
                         <span className="font-display tabular-nums text-foreground">{item.receipt.total.value}</span>
                       </div>
                     )}
-                    {item.receipt.onShare && (
-                      <button type="button" onClick={item.receipt.onShare} className="mt-3 flex w-full items-center justify-center gap-1.5 rounded-lg border border-border py-2.5 text-sm font-medium text-foreground hover:bg-secondary">
-                        <Share2 className="h-4 w-4" /> Share receipt
+                    <div className="mt-3 flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => downloadReceiptPdf({ title: item.title, subtitle: item.subtitle, dateTime: item.dateTime, reference: item.reference, account: item.account, lines: item.receipt!.lines.map((l) => ({ label: l.label, value: l.value })), total: item.receipt!.total })}
+                        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-border py-2.5 text-sm font-medium text-foreground hover:bg-secondary"
+                      >
+                        <Download className="h-4 w-4" /> Download PDF
                       </button>
-                    )}
+                      {item.receipt.onShare && (
+                        <button type="button" onClick={item.receipt.onShare} aria-label="Share receipt" className="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-lg border border-border text-foreground hover:bg-secondary">
+                          <Share2 className="h-4 w-4" />
+                        </button>
+                      )}
+                    </div>
                   </div>
                 </Section>
+                </motion.div>
               )}
-            </>
+            </motion.div>
           ) : (
-            <div>
-              {item.history.length > 0 ? (
+            <motion.div key="history" variants={stagger} initial="hidden" animate="show">
+              {item.loading ? (
+                <div className="space-y-3">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <div key={i} className="flex items-center gap-3 py-1">
+                      <Skeleton className="h-9 w-9 rounded-full" />
+                      <div className="flex-1"><Skeleton className="h-3.5 w-28" /><Skeleton className="mt-1.5 h-3 w-16" /></div>
+                      <Skeleton className="h-4 w-12" />
+                    </div>
+                  ))}
+                </div>
+              ) : shownHistory.length > 0 ? (
                 <>
                   {groups.map((g) => (
-                    <div key={g.label || 'all'} className="mb-2">
+                    <motion.div variants={fade} key={g.label || 'all'} className="mb-2">
                       {g.label && <div className="px-1 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{g.label}</div>}
                       <div className="divide-y divide-border">
                         {g.entries.map((h) => (
@@ -313,16 +377,16 @@ export default function ActivityDetailModal({ open, onOpenChange, item }: { open
                           </div>
                         ))}
                       </div>
-                    </div>
+                    </motion.div>
                   ))}
-                  {item.onViewAll && (
-                    <button type="button" onClick={item.onViewAll} className="mt-2 w-full rounded-lg border border-border py-2.5 text-sm font-medium text-muted-foreground hover:bg-secondary hover:text-foreground">View all activity</button>
+                  {!showAllHistory && item.history.length > HISTORY_CAP && (
+                    <button type="button" onClick={() => setShowAllHistory(true)} className="mt-2 w-full rounded-lg border border-border py-2.5 text-sm font-medium text-muted-foreground hover:bg-secondary hover:text-foreground">View all {item.history.length}</button>
                   )}
                 </>
               ) : (
                 <div className="rounded-xl border border-border py-10 text-center text-sm text-muted-foreground">No activity yet.</div>
               )}
-            </div>
+            </motion.div>
           )}
         </div>
 

--- a/app/src/components/app-ui/BillDetailModal.tsx
+++ b/app/src/components/app-ui/BillDetailModal.tsx
@@ -40,6 +40,7 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
   const { openPay, streak, setReminders } = usePay();
   const { accelerated } = useMemberProfile();
   const [payments, setPayments] = useState<PayBillerPayment[]>([]);
+  const [loading, setLoading] = useState(true);
   const [meta, setMeta] = useState<MerchantMeta | null>(null);
   const [reminders, setLocalReminders] = useState(true);
   const [portal, setPortal] = useState<BillPortal | null>(null);
@@ -48,9 +49,10 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
   useEffect(() => {
     setLocalReminders(bill?.reminders ?? true);
     setMeta(null);
-    if (!bill || !address) { setPayments([]); return; }
+    if (!bill || !address) { setPayments([]); setLoading(false); return; }
     let cancelled = false;
-    void getPayBillerPayments(address, bill.id).then((p) => { if (!cancelled) setPayments(p); });
+    setLoading(true);
+    void getPayBillerPayments(address, bill.id).then((p) => { if (!cancelled) { setPayments(p); setLoading(false); } });
     void getMerchantMeta(address, bill.payee || bill.name).then((m) => { if (!cancelled) setMeta(m); });
     return () => { cancelled = true; };
   }, [bill, address]);
@@ -105,13 +107,14 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
         enabled: reminders,
         onToggle: (v: boolean) => { setLocalReminders(v); setReminders(bill.id, v); },
       },
+      loading,
       metrics: [
-        { label: 'Total paid', value: `$${nInt(total)}`, icon: Wallet },
-        { label: 'Credits earned', value: nInt(creditsEarned), icon: TrendingUp },
-        { label: 'Payments', value: String(count), icon: Hash },
+        { label: 'Total paid', value: `$${nInt(total)}`, animateTo: total, format: (n: number) => `$${nInt(n)}`, icon: Wallet },
+        { label: 'Credits earned', value: nInt(creditsEarned), animateTo: creditsEarned, format: (n: number) => nInt(n), icon: TrendingUp },
+        { label: 'Payments', value: String(count), animateTo: count, format: (n: number) => String(Math.round(n)), icon: Hash },
         months
           ? { label: 'Active since', value: `${months} mo`, icon: Calendar }
-          : { label: 'Avg payment', value: `$${nInt(avg)}`, icon: Calendar },
+          : { label: 'Avg payment', value: `$${nInt(avg)}`, animateTo: avg, format: (n: number) => `$${nInt(n)}`, icon: Calendar },
       ],
       historyTitle: 'Payment history',
       history: payments.map((p) => {
@@ -132,7 +135,7 @@ export default function BillDetailModal({ bill, onClose }: { bill: Bill | null; 
       ],
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [bill, payments, portalUrl, addressVal, reminders, streak, accelerated, openPay, onClose, setReminders]);
+  }, [bill, payments, loading, portalUrl, addressVal, reminders, streak, accelerated, openPay, onClose, setReminders]);
 
   return (
     <>

--- a/app/src/components/app-ui/TransactionDetailModal.tsx
+++ b/app/src/components/app-ui/TransactionDetailModal.tsx
@@ -71,9 +71,9 @@ export default function TransactionDetailModal({ tx, allItems, onClose }: { tx: 
       account: acctLabel(tx.source, address),
       dateTime: new Date(tx.ts).toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' }),
       metrics: [
-        { label: count > 1 ? 'Total' : 'Amount', value: usd0(total), icon: Wallet },
-        { label: 'Transactions', value: String(count), icon: Hash },
-        { label: 'Average', value: usd0(avg), icon: TrendingUp },
+        { label: count > 1 ? 'Total' : 'Amount', value: usd0(total), animateTo: total, format: usd0, icon: Wallet },
+        { label: 'Transactions', value: String(count), animateTo: count, format: (n) => String(Math.round(n)), icon: Hash },
+        { label: 'Average', value: usd0(avg), animateTo: avg, format: usd0, icon: TrendingUp },
         { label: 'Last', value: last.date, icon: Clock },
       ],
       receipt: {

--- a/app/src/lib/receiptPdf.ts
+++ b/app/src/lib/receiptPdf.ts
@@ -1,0 +1,75 @@
+/*
+ * Client-side receipt PDF for the bill/transaction detail view. jsPDF is lazy-imported so it only loads
+ * when a user actually downloads a receipt (keeps it out of the main bundle).
+ */
+export interface ReceiptPdfData {
+  title: string;
+  subtitle?: string;
+  dateTime?: string | null;
+  reference?: string | null;
+  account?: string | null;
+  lines: { label: string; value: string }[];
+  total?: { label: string; value: string };
+}
+
+export async function downloadReceiptPdf(data: ReceiptPdfData): Promise<void> {
+  const { jsPDF } = await import('jspdf');
+  const doc = new jsPDF({ unit: 'pt', format: 'a4' });
+  const W = doc.internal.pageSize.getWidth();
+  const L = 48;
+  const R = W - 48;
+  let y = 64;
+
+  doc.setFont('helvetica', 'bold').setFontSize(18).setTextColor(17);
+  doc.text('Clear', L, y);
+  doc.setFont('helvetica', 'normal').setFontSize(11).setTextColor(130);
+  doc.text('Receipt', R, y, { align: 'right' });
+
+  y += 24;
+  doc.setDrawColor(228).line(L, y, R, y);
+  y += 30;
+
+  doc.setFont('helvetica', 'bold').setFontSize(15).setTextColor(20);
+  doc.text(data.title, L, y);
+  if (data.subtitle) {
+    y += 16;
+    doc.setFont('helvetica', 'normal').setFontSize(10).setTextColor(130).text(data.subtitle, L, y);
+  }
+  y += 34;
+
+  const meta = ([['Date', data.dateTime], ['Reference', data.reference], ['Account', data.account]] as [string, string | null | undefined][])
+    .filter((m): m is [string, string] => Boolean(m[1]));
+  doc.setFontSize(10);
+  for (const [k, v] of meta) {
+    doc.setFont('helvetica', 'normal').setTextColor(130).text(k, L, y);
+    doc.setTextColor(30).text(v, R, y, { align: 'right' });
+    y += 18;
+  }
+
+  y += 10;
+  doc.setDrawColor(236).line(L, y, R, y);
+  y += 26;
+
+  doc.setFontSize(11);
+  for (const l of data.lines) {
+    doc.setFont('helvetica', 'normal').setTextColor(130).text(l.label, L, y);
+    doc.setTextColor(30).text(l.value, R, y, { align: 'right' });
+    y += 20;
+  }
+
+  if (data.total) {
+    y += 4;
+    doc.setDrawColor(236).line(L, y - 14, R, y - 14);
+    doc.setFont('helvetica', 'bold').setFontSize(13).setTextColor(17);
+    doc.text(data.total.label, L, y + 4);
+    doc.text(data.total.value, R, y + 4, { align: 'right' });
+    y += 30;
+  }
+
+  y += 26;
+  doc.setFont('helvetica', 'normal').setFontSize(9).setTextColor(155);
+  doc.text('Paid via Clear · useclear.org', L, y);
+
+  const slug = data.title.replace(/[^a-z0-9]+/gi, '-').replace(/^-+|-+$/g, '').toLowerCase() || 'clear';
+  doc.save(`receipt-${slug}.pdf`);
+}


### PR DESCRIPTION
Closes the three open detail-view threads.

- **Receipt PDF export** — lazy-loaded jsPDF builds a clean receipt (name, date, reference, account, line items, total) from the detail view; sits beside Share in the Latest-receipt block.
- **Motion pass** — metric numbers **count up** on open, tab content does a **staggered fade-in entrance** (framer-motion), and metrics/history show **loading skeletons** while a bill's payments fetch.
- **"View all"** on history — capped to 6 rows with an in-modal "View all N" expander.

jsPDF is dynamically imported (its own chunk, out of the main bundle). Typecheck + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)