### PR TITLE
Clear Pay: mobile bottom sheet + safe-area padding

### DIFF
--- a/app/src/components/app-ui/ActivityDetailModal.tsx
+++ b/app/src/components/app-ui/ActivityDetailModal.tsx
@@ -198,7 +198,7 @@ export default function ActivityDetailModal({ open, onOpenChange, item }: { open
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent aria-label={item.title} className="gap-0 p-0">
+      <SheetContent aria-label={item.title} onDismiss={() => onOpenChange(false)} className="gap-0 p-0">
         {/* header — breadcrumb-style back button */}
         <div className="flex shrink-0 items-center justify-between px-3 py-2.5">
           <button type="button" onClick={() => onOpenChange(false)} className="inline-flex items-center gap-1 rounded-lg py-1.5 pl-1.5 pr-2.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground">
@@ -234,7 +234,7 @@ export default function ActivityDetailModal({ open, onOpenChange, item }: { open
         </div>
 
         {/* body */}
-        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 pt-4 pb-[max(1.25rem,env(safe-area-inset-bottom))]">
           {tab === 'details' ? (
             <motion.div key="details" variants={stagger} initial="hidden" animate="show" className="space-y-4">
               <motion.div variants={fade}>
@@ -392,7 +392,7 @@ export default function ActivityDetailModal({ open, onOpenChange, item }: { open
 
         {/* pay bar (bills only) */}
         {item.actions && item.actions.length > 0 && (
-          <div className="flex shrink-0 items-center gap-2 border-t border-border p-4">
+          <div className="flex shrink-0 items-center gap-2 border-t border-border px-4 pt-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
             {item.actions.map((a) =>
               a.icon ? (
                 <button key={a.label} type="button" aria-label={a.label} disabled={a.disabled} onClick={a.onClick} className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-secondary text-foreground transition-colors hover:bg-secondary/70 disabled:opacity-40"><a.icon className="h-5 w-5" /></button>

--- a/app/src/components/app-ui/BillPortalsModal.tsx
+++ b/app/src/components/app-ui/BillPortalsModal.tsx
@@ -127,7 +127,7 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
                 )}
               </div>
 
-              <div className="border-t border-border p-4">
+              <div className="border-t border-border px-4 pt-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
                 <button type="button" onClick={() => setMode('add')} className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-primary py-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.99]">
                   <Plus className="h-4 w-4" /> Add a bill
                 </button>
@@ -173,7 +173,7 @@ export default function BillPortalsModal({ open, onOpenChange }: { open: boolean
                 </div>
               </div>
 
-              <div className="border-t border-border p-4">
+              <div className="border-t border-border px-4 pt-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
                 <button type="button" onClick={save} disabled={!draft.name.trim()} className="w-full rounded-xl bg-primary py-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.99] disabled:opacity-40">
                   Save bill
                 </button>

--- a/app/src/components/ui/sheet.tsx
+++ b/app/src/components/ui/sheet.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import * as SheetPrimitive from '@radix-ui/react-dialog';
+import { motion, useDragControls, type PanInfo } from 'framer-motion';
 import { cn } from '@/lib/utils';
 
 /**
- * Right-side sheet (drawer): full-height panel anchored to the right on desktop, full-screen on mobile.
- * Radix Dialog under the hood (same primitive as our Dialog); the consumer renders its own header/close.
+ * Responsive sheet: a bottom sheet on mobile (slides up, rounded top, a pull handle you can drag down to
+ * dismiss) and a right-side drawer on desktop. Radix Dialog under the hood (same primitive as our Dialog).
  */
 const Sheet = SheetPrimitive.Root;
 const SheetClose = SheetPrimitive.Close;
@@ -16,34 +17,65 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     ref={ref}
-    className={cn(
-      'fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-      className,
-    )}
+    className={cn('fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0', className)}
     {...props}
   />
 ));
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
-const SheetContent = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(
-        'fixed inset-y-0 right-0 z-50 flex h-full w-full flex-col border-l border-border bg-background shadow-xl outline-none sm:max-w-[460px]',
-        'duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </SheetPrimitive.Content>
-  </SheetPortal>
-));
+function useIsMobile() {
+  const [m, setM] = React.useState(() => typeof window !== 'undefined' && window.matchMedia('(max-width: 639px)').matches);
+  React.useEffect(() => {
+    const mq = window.matchMedia('(max-width: 639px)');
+    const on = () => setM(mq.matches);
+    mq.addEventListener('change', on);
+    return () => mq.removeEventListener('change', on);
+  }, []);
+  return m;
+}
+
+interface SheetContentProps extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content> {
+  /** Called when the mobile bottom sheet is flung/dragged down past the dismiss threshold. */
+  onDismiss?: () => void;
+}
+
+const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Content>, SheetContentProps>(
+  ({ className, children, onDismiss, ...props }, ref) => {
+    const isMobile = useIsMobile();
+    const controls = useDragControls();
+    const pos = isMobile
+      ? 'inset-x-0 bottom-0 max-h-[92vh] rounded-t-2xl border-t data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom'
+      : 'inset-y-0 right-0 h-full w-full max-w-[460px] border-l data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right';
+
+    return (
+      <SheetPortal>
+        <SheetOverlay />
+        <SheetPrimitive.Content ref={ref} asChild {...props}>
+          <motion.div
+            drag={isMobile ? 'y' : false}
+            dragControls={controls}
+            dragListener={false}
+            dragConstraints={{ top: 0, bottom: 0 }}
+            dragElastic={{ top: 0, bottom: 0.6 }}
+            onDragEnd={(_e, info: PanInfo) => { if (isMobile && (info.offset.y > 110 || info.velocity.y > 500)) onDismiss?.(); }}
+            className={cn(
+              'fixed z-50 flex flex-col border-border bg-background shadow-xl outline-none duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out',
+              pos,
+              className,
+            )}
+          >
+            {isMobile && (
+              <div className="flex shrink-0 touch-none cursor-grab justify-center pb-1 pt-2.5 active:cursor-grabbing" onPointerDown={(e) => controls.start(e)}>
+                <div className="h-1.5 w-10 rounded-full bg-border" />
+              </div>
+            )}
+            {children}
+          </motion.div>
+        </SheetPrimitive.Content>
+      </SheetPortal>
+    );
+  },
+);
 SheetContent.displayName = SheetPrimitive.Content.displayName;
 
 export { Sheet, SheetClose, SheetContent };


### PR DESCRIPTION
Detail drawer becomes a **bottom sheet on mobile** (slides up, rounded top, a pull handle you drag down to dismiss) and stays a right-side drawer on desktop. Adds iOS **safe-area** bottom padding to the pay bar, body, and bill-manager footers so buttons/receipt no longer sit under (or get cut off by) the home indicator. Typecheck + build green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)