### PR TITLE
Bridge: real KYC, virtual accounts, off-ramp funding fix, deposit webhooks

### DIFF
--- a/app/server/env.example
+++ b/app/server/env.example
@@ -124,6 +124,13 @@ BRIDGE_ONBOARDING_URL_BASE=
 BRIDGE_API_KEY=
 BRIDGE_API_BASE_URL=https://api.bridge.xyz/v0
 BRIDGE_ONBOARDING_REDIRECT_URI=
+# BRIDGE_WEBHOOK_PUBLIC_KEY: PEM (or base64 DER) public key Bridge returns when you create the webhook
+#   endpoint. Required to accept /api/webhooks/bridge — deposits into a member's virtual account are
+#   pushed from their own bank, so this webhook is the ONLY way we learn they happened.
+#   Point Bridge at: https://<backend-domain>/api/webhooks/bridge
+BRIDGE_WEBHOOK_PUBLIC_KEY=
+# Optional rotation set (comma-separated), used in addition to the above
+BRIDGE_WEBHOOK_PUBLIC_KEYS=
 # BRIDGE_API_TIMEOUT_MS=15000
 
 # Send Funds (claim escrow + recipient payout)

--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -33,6 +33,7 @@ import requestsRouter from './routes/requests.js';
 import onramperRouter from './routes/onramper.js';
 import onramperWebhookRouter from './routes/onramperWebhook.js';
 import coinbaseRampWebhookRouter from './routes/coinbaseRampWebhook.js';
+import bridgeWebhookRouter from './routes/bridgeWebhook.js';
 import rampRouter from './routes/ramp.js';
 import { startPriceUpdater } from './jobs/priceUpdater.js';
 import { startPortfolioSnapshotter } from './jobs/portfolioSnapshotter.js';
@@ -192,6 +193,7 @@ async function startServer() {
     app.use('/api/avatars', avatarRouter);
     app.use('/api/webhooks/onramper', onramperWebhookRouter); // public; verified via signature
     app.use('/api/webhooks/coinbase-ramp', coinbaseRampWebhookRouter); // public; verified via X-Hook0-Signature
+    app.use('/api/webhooks/bridge', bridgeWebhookRouter); // public; verified via X-Webhook-Signature (RSA)
     app.use('/api/stripe', requireAuth, stripeRouter);
     app.use('/api/members', requireAuth, membersRouter);
     app.use('/api/plaid', requireAuth, requireMemberCapability('canUsePlaid'), plaidRouter);

--- a/app/server/src/middleware/auth.ts
+++ b/app/server/src/middleware/auth.ts
@@ -13,6 +13,8 @@ type AuthenticatedWallet = {
   chainId?: string | number;
   profileUuid?: string;
   email?: string;
+  /** EVERY verified email on the account (email login + google/apple/etc. OAuth), lowercased. */
+  emails?: string[];
   smartWallet?: string; // the Privy smart wallet — the CANONICAL primary (where funds live)
   addresses?: string[]; // ALL verified addresses for this user (primary + smart + linked), normalized
   phone?: string; // the Privy account phone (login identity), if any
@@ -31,7 +33,7 @@ function getPrivy(): PrivyClient | null {
 }
 
 // userId(DID) -> resolved wallets. Cached so we don't call getUser on every request (rate-limited).
-type UserWallets = { addresses: Set<string>; smartWallet?: string; email?: string; phone?: string; expiresAt: number };
+type UserWallets = { addresses: Set<string>; smartWallet?: string; email?: string; emails: Set<string>; phone?: string; expiresAt: number };
 const userCache = new Map<string, UserWallets>();
 
 declare global {
@@ -72,21 +74,31 @@ type CollectedWallets = {
   addresses: Set<string>;
   smartWallet?: string;
   email?: string;
+  emails: Set<string>;
   phone?: string;
   hasEmbeddedEoa: boolean;
   hasExternalWallet: boolean;
 };
 
+const EMAILISH = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 function collectWallets(user: { linkedAccounts?: unknown[] }): CollectedWallets {
   const addresses = new Set<string>();
+  const emails = new Set<string>();
   let smartWallet: string | undefined;
   let email: string | undefined;
   let phone: string | undefined;
   let hasEmbeddedEoa = false;
   let hasExternalWallet = false;
 
+  const addEmail = (value: unknown) => {
+    if (typeof value !== 'string') return;
+    const normalized = value.trim().toLowerCase();
+    if (EMAILISH.test(normalized)) emails.add(normalized);
+  };
+
   for (const account of user.linkedAccounts ?? []) {
-    const acct = account as { type?: string; address?: string; number?: string; chainType?: string; walletClientType?: string };
+    const acct = account as { type?: string; address?: string; number?: string; chainType?: string; walletClientType?: string; email?: string };
     const isEvmWallet =
       (acct.type === 'wallet' || acct.type === 'smart_wallet') &&
       typeof acct.address === 'string' &&
@@ -100,11 +112,17 @@ function collectWallets(user: { linkedAccounts?: unknown[] }): CollectedWallets 
         else hasExternalWallet = true;
       }
     }
-    if (acct.type === 'email' && typeof acct.address === 'string') email = acct.address;
+    if (acct.type === 'email' && typeof acct.address === 'string') {
+      email = acct.address;
+      addEmail(acct.address);
+    }
+    // Social logins (google_oauth, apple_oauth, github_oauth, …) carry their own verified email —
+    // any of them may be the address the user already onboarded to Bridge with.
+    if (typeof acct.type === 'string' && acct.type.endsWith('_oauth')) addEmail(acct.email);
     if (acct.type === 'phone' && typeof acct.number === 'string') phone = acct.number;
   }
 
-  return { addresses, smartWallet, email, phone, hasEmbeddedEoa, hasExternalWallet };
+  return { addresses, smartWallet, email, emails, phone, hasEmbeddedEoa, hasExternalWallet };
 }
 
 async function loadUserWallets(privy: PrivyClient, userId: string): Promise<UserWallets> {
@@ -134,6 +152,7 @@ async function loadUserWallets(privy: PrivyClient, userId: string): Promise<User
     addresses: c.addresses,
     smartWallet: c.smartWallet,
     email: c.email,
+    emails: c.emails,
     phone: c.phone,
     expiresAt: Date.now() + AUTH_CACHE_TTL_MS,
   };
@@ -159,7 +178,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
     const claims = await privy.verifyAuthToken(token);
     const userId = claims.userId;
 
-    const { addresses, smartWallet, email, phone } = await loadUserWallets(privy, userId);
+    const { addresses, smartWallet, email, emails, phone } = await loadUserWallets(privy, userId);
 
     // Trust the frontend's active address only if it belongs to the verified user; else fall back to
     // the smart wallet (email/social funds) or the first linked wallet.
@@ -171,7 +190,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
       return sendUnauthorized(res, 'No wallet linked to this account', 'AUTH_NO_WALLET');
     }
 
-    req.auth = { walletAddress, profileUuid: userId, email, phone, smartWallet, addresses: [...addresses], token };
+    req.auth = { walletAddress, profileUuid: userId, email, emails: [...emails], phone, smartWallet, addresses: [...addresses], token };
     return next();
   } catch (error) {
     console.error('Authentication error:', error);

--- a/app/server/src/routes/bridge.ts
+++ b/app/server/src/routes/bridge.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { Router, Request, Response } from 'express';
 import { requireWalletMatch } from '../middleware/auth.js';
+import { bridgeCustomerStore } from '../services/bridgeCustomerStore.js';
 import {
   resolveCustomerForEmails,
   getCustomerSnapshot,
@@ -502,6 +503,12 @@ function sessionEmails(req: Request): string[] {
   return list.map((e) => String(e).trim().toLowerCase()).filter((e) => EMAIL_REGEX.test(e));
 }
 
+/** Remember which member this Bridge customer is, so webhooks can be attributed to a wallet. */
+function rememberCustomer(req: Request, customerId: string | undefined, email?: string): void {
+  const wallet = req.auth?.smartWallet || req.auth?.walletAddress || '';
+  if (customerId && wallet) void bridgeCustomerStore.link(customerId, wallet, email);
+}
+
 /**
  * GET /api/bridge/status → everything the app needs to decide whether money can move:
  * whether Bridge is configured, whether this member is already a Bridge customer (under ANY of their
@@ -525,6 +532,7 @@ router.get('/status', async (req: Request, res: Response) => {
       return;
     }
 
+    rememberCustomer(req, resolved.customerId, resolved.email);
     const snapshot = await getCustomerSnapshot(resolved.customerId);
     const verified = snapshot?.status === 'active';
 
@@ -603,6 +611,7 @@ router.post('/kyc-link', async (req: Request, res: Response) => {
       res.status(502).json({ error: 'Bridge returned no verification link.' });
       return;
     }
+    rememberCustomer(req, result.customerId ?? undefined, emails[0]);
     res.json(result);
   } catch (error) {
     console.error('[bridge/kyc-link]', error);
@@ -632,6 +641,7 @@ router.post('/virtual-account', async (req: Request, res: Response) => {
       return;
     }
 
+    rememberCustomer(req, resolved.customerId, resolved.email);
     const result = await ensureVirtualAccount({ customerId: resolved.customerId, walletAddress: wallet });
     if ('error' in result) {
       res.status(409).json({ error: result.error, reason: result.reason });

--- a/app/server/src/routes/bridge.ts
+++ b/app/server/src/routes/bridge.ts
@@ -1,6 +1,12 @@
 import { randomUUID } from 'crypto';
 import { Router, Request, Response } from 'express';
 import { requireWalletMatch } from '../middleware/auth.js';
+import {
+  resolveCustomerForEmails,
+  getCustomerSnapshot,
+  startKyc,
+  ensureVirtualAccount,
+} from '../services/bridgeCustomerService.js';
 import { isAddress } from 'ethers';
 
 const router = Router();
@@ -420,10 +426,14 @@ router.post('/onboarding-url', async (req: Request, res: Response) => {
 });
 
 /**
- * GET /api/bridge/virtual-account?email=...  → the user's Bridge virtual account (USDC funding via an
- * ACH account/routing number). Resolves the customer by email, then reads their virtual accounts.
- * Best-effort: returns { available: false } when Bridge isn't configured / no customer / no VA yet, so
- * the UI can fall back gracefully. (Field names read defensively against the Bridge v0 shape.)
+ * GET /api/bridge/virtual-account  → the signed-in member's Bridge virtual account (USDC funding via
+ * an ACH account/routing number).
+ *
+ * The customer is resolved from the emails Privy verified for THIS session (email login + Google/
+ * Apple OAuth) — never from a client-supplied address, since the response contains bank account and
+ * routing numbers and would otherwise let any authenticated caller enumerate other people's details.
+ * Best-effort: returns { available: false } when Bridge isn't configured / no customer / no VA yet,
+ * so the UI can fall back gracefully. (Field names read defensively against the Bridge v0 shape.)
  */
 type BridgeVirtualAccount = {
   id?: string;
@@ -440,23 +450,21 @@ type BridgeVirtualAccount = {
 
 router.get('/virtual-account', async (req: Request, res: Response) => {
   try {
-    const email = String(req.query.email ?? '').trim().toLowerCase();
-    if (!EMAIL_REGEX.test(email)) {
-      res.status(400).json({ error: 'A valid email is required' });
-      return;
-    }
     const bridgeApiKey = (process.env.BRIDGE_API_KEY || '').trim();
     if (!bridgeApiKey) {
       res.json({ available: false, reason: 'not_configured' });
       return;
     }
 
-    const kyc = await bridgeApiRequest<BridgeListKycLinksResponse>(
-      bridgeApiKey,
-      `/kyc_links?email=${encodeURIComponent(email)}&limit=1`,
-      { method: 'GET' },
-    );
-    const customerId = kyc.ok ? kyc.data.data?.[0]?.customer_id : undefined;
+    // Only emails this session's Privy user actually verified — see the note above.
+    const emails = (req.auth?.emails ?? [req.auth?.email ?? '']).filter((e) => EMAIL_REGEX.test(e));
+    if (emails.length === 0) {
+      res.json({ available: false, reason: 'no_email' });
+      return;
+    }
+
+    const resolved = await resolveCustomerForEmails(emails);
+    const customerId = resolved?.customerId;
     if (!customerId) {
       res.json({ available: false, reason: 'no_customer' });
       return;
@@ -485,6 +493,154 @@ router.get('/virtual-account', async (req: Request, res: Response) => {
     });
   } catch (error) {
     res.status(200).json({ available: false, reason: error instanceof Error ? error.message : 'error' });
+  }
+});
+
+/** Emails Privy verified for THIS session — the only addresses we'll look a customer up by. */
+function sessionEmails(req: Request): string[] {
+  const list = req.auth?.emails ?? (req.auth?.email ? [req.auth.email] : []);
+  return list.map((e) => String(e).trim().toLowerCase()).filter((e) => EMAIL_REGEX.test(e));
+}
+
+/**
+ * GET /api/bridge/status → everything the app needs to decide whether money can move:
+ * whether Bridge is configured, whether this member is already a Bridge customer (under ANY of their
+ * emails), their KYC state, and their virtual account if one exists. Never creates anything.
+ */
+router.get('/status', async (req: Request, res: Response) => {
+  try {
+    if (!(process.env.BRIDGE_API_KEY || '').trim()) {
+      res.json({ configured: false, verified: false, kycStatus: 'not_started', virtualAccount: null });
+      return;
+    }
+    const emails = sessionEmails(req);
+    if (emails.length === 0) {
+      res.json({ configured: true, verified: false, kycStatus: 'not_started', virtualAccount: null, reason: 'no_email' });
+      return;
+    }
+
+    const resolved = await resolveCustomerForEmails(emails);
+    if (!resolved) {
+      res.json({ configured: true, verified: false, kycStatus: 'not_started', virtualAccount: null, customerId: null });
+      return;
+    }
+
+    const snapshot = await getCustomerSnapshot(resolved.customerId);
+    const verified = snapshot?.status === 'active';
+
+    // Only read the virtual account — provisioning is an explicit POST so a status poll never writes.
+    let virtualAccount = null as null | Record<string, unknown>;
+    if (verified) {
+      const wallet = req.auth?.smartWallet || req.auth?.walletAddress || '';
+      if (wallet) {
+        const va = await ensureVirtualAccount({ customerId: resolved.customerId, walletAddress: wallet });
+        if ('account' in va) {
+          virtualAccount = {
+            accountNumber: va.account.accountNumber,
+            routingNumber: va.account.routingNumber,
+            bankName: va.account.bankName,
+            beneficiary: va.account.beneficiary,
+            paymentRails: va.account.paymentRails,
+          };
+        }
+      }
+    }
+
+    res.json({
+      configured: true,
+      customerId: resolved.customerId,
+      matchedEmail: resolved.email,
+      verified,
+      kycStatus: snapshot?.status ?? 'not_started',
+      tosAccepted: snapshot?.tosAccepted ?? false,
+      baseEndorsement: snapshot?.baseEndorsement ?? 'incomplete',
+      payinFiat: snapshot?.payinFiat ?? 'pending',
+      payoutFiat: snapshot?.payoutFiat ?? 'pending',
+      rejectionReason: snapshot?.rejectionReason ?? null,
+      virtualAccount,
+    });
+  } catch (error) {
+    console.error('[bridge/status]', error);
+    res.status(500).json({ error: 'Could not read verification status' });
+  }
+});
+
+/**
+ * POST /api/bridge/kyc-link → the hosted Bridge verification URL for this member (ToS first, then
+ * KYC). Reuses an existing Bridge customer when any of their emails already maps to one.
+ * Body: { fullName, customerType? }
+ */
+router.post('/kyc-link', async (req: Request, res: Response) => {
+  try {
+    if (!(process.env.BRIDGE_API_KEY || '').trim()) {
+      res.status(501).json({ error: 'Verification is not available yet.', notConfigured: true });
+      return;
+    }
+    const emails = sessionEmails(req);
+    if (emails.length === 0) {
+      res.status(400).json({ error: 'Add an email to your account before verifying.' });
+      return;
+    }
+    const { fullName, customerType } = req.body as { fullName?: string; customerType?: BridgeCustomerType };
+    const normalizedName = String(fullName ?? '').trim();
+    if (normalizedName.length < 2) {
+      res.status(400).json({ error: 'Your full legal name is required.' });
+      return;
+    }
+
+    const result = await startKyc({
+      emails,
+      email: emails[0],
+      fullName: normalizedName,
+      redirectUri: process.env.BRIDGE_ONBOARDING_REDIRECT_URI?.trim(),
+      customerType: customerType === 'business' ? 'business' : 'individual',
+    });
+    if ('error' in result) {
+      res.status(result.status >= 400 && result.status < 500 ? result.status : 502).json({ error: result.error });
+      return;
+    }
+    if (!result.url) {
+      res.status(502).json({ error: 'Bridge returned no verification link.' });
+      return;
+    }
+    res.json(result);
+  } catch (error) {
+    console.error('[bridge/kyc-link]', error);
+    res.status(500).json({ error: 'Could not start verification' });
+  }
+});
+
+/**
+ * POST /api/bridge/virtual-account → open (or fetch) this member's USD account, producing their
+ * account + routing numbers. Requires an approved Bridge customer; USD pushed here lands as USDC.
+ */
+router.post('/virtual-account', async (req: Request, res: Response) => {
+  try {
+    if (!(process.env.BRIDGE_API_KEY || '').trim()) {
+      res.status(501).json({ error: 'Bank accounts are not available yet.', notConfigured: true });
+      return;
+    }
+    const emails = sessionEmails(req);
+    const resolved = emails.length ? await resolveCustomerForEmails(emails) : null;
+    if (!resolved) {
+      res.status(409).json({ error: 'Verify your identity to open a USD account.', reason: 'no_customer' });
+      return;
+    }
+    const wallet = req.auth?.smartWallet || req.auth?.walletAddress || '';
+    if (!wallet || !isAddress(wallet)) {
+      res.status(400).json({ error: 'No wallet on this account to receive deposits.' });
+      return;
+    }
+
+    const result = await ensureVirtualAccount({ customerId: resolved.customerId, walletAddress: wallet });
+    if ('error' in result) {
+      res.status(409).json({ error: result.error, reason: result.reason });
+      return;
+    }
+    res.json({ available: true, ...result.account, accountLast4: result.account.accountNumber?.slice(-4) ?? null });
+  } catch (error) {
+    console.error('[bridge/virtual-account]', error);
+    res.status(500).json({ error: 'Could not open your USD account' });
   }
 });
 

--- a/app/server/src/routes/bridgeWebhook.ts
+++ b/app/server/src/routes/bridgeWebhook.ts
@@ -1,0 +1,95 @@
+import { Router, type Request, type Response } from 'express';
+import { sendBridgeWebhookVerifier } from '../services/sendBridgeWebhookVerifier.js';
+import { bridgeCustomerStore } from '../services/bridgeCustomerStore.js';
+import { emitRampStatus } from '../services/rampNotifications.js';
+
+/*
+ * Bridge webhooks (PUBLIC, signature-verified) — the app-closed-safe source of truth for money that
+ * moves without us initiating it.
+ *
+ * This matters most for DEPOSITS: a bank push into the member's virtual account is started at their
+ * bank, so nothing in our app knows it happened. Polling can't help (there's no local record to poll
+ * against) — the webhook is the only signal. Withdrawals also report here, which covers the window
+ * after we've sent the USDC and Bridge is still working the ACH.
+ *
+ * Point Bridge at:  https://<backend-domain>/api/webhooks/bridge
+ * Set the endpoint's PEM public key as BRIDGE_WEBHOOK_PUBLIC_KEY.
+ * Signature model: X-Webhook-Signature: t=<ms>,v0=<base64 RSA-SHA256 over `${t}.${rawBody}`>.
+ * Docs: https://apidocs.bridge.xyz/platform/orchestration/webhooks
+ */
+const router = Router();
+type RawBodyRequest = Request & { rawBody?: Buffer };
+
+/** Transfer/drain states that should tell the member something. Anything else is in-flight noise. */
+const TERMINAL_OUT: Record<string, 'completed' | 'failed'> = {
+  payment_processed: 'completed',
+  returned: 'failed',
+  undeliverable: 'failed',
+  refunded: 'failed',
+  refund_failed: 'failed',
+  canceled: 'failed',
+};
+
+function amountOf(obj: Record<string, unknown>): number {
+  const raw = obj.amount ?? obj.subtotal_amount ?? obj.final_amount;
+  const n = typeof raw === 'string' ? parseFloat(raw) : typeof raw === 'number' ? raw : 0;
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+router.post('/', async (req: RawBodyRequest, res: Response) => {
+  const verification = sendBridgeWebhookVerifier.verify({
+    rawBody: req.rawBody ?? (req.body ? JSON.stringify(req.body) : undefined),
+    signatureHeader: String(req.headers['x-webhook-signature'] || ''),
+  });
+  if (!verification.valid) {
+    // 400 (not 200) so Bridge retries with a fresh timestamp if this was a clock/staleness issue.
+    console.warn('[bridge/webhook] rejected:', verification.reason);
+    res.status(400).json({ error: verification.reason || 'invalid signature' });
+    return;
+  }
+
+  try {
+    const e = (req.body || {}) as Record<string, any>;
+    const category = String(e.event_category || '');
+    const objectStatus = String(e.event_object_status || '');
+    const obj = (e.event_object || {}) as Record<string, any>;
+    const customerId = String(obj.customer_id || e.event_developer_id || '');
+
+    const wallet = customerId ? await bridgeCustomerStore.walletFor(customerId) : null;
+    if (!wallet) {
+      // Unknown customer (or the pairing predates this table) — ack so Bridge stops retrying.
+      console.log('[bridge/webhook] no wallet for customer', { category, customerId: customerId.slice(0, 8) });
+      res.json({ received: true });
+      return;
+    }
+
+    const amount = amountOf(obj);
+    const ref = String(obj.id || e.event_object_id || `${category}-${e.event_id ?? ''}`);
+
+    if (category === 'virtual_account.activity') {
+      // A member pushed money into their USD account. `funds_received` is the deposit landing;
+      // `payment_processed` is Bridge having delivered the USDC on-chain.
+      const type = String(obj.type || objectStatus || '');
+      if (type === 'funds_received' || type === 'payment_processed') {
+        await emitRampStatus({ wallet, type: 'buy', status: 'completed', amount, ref: `bva:${ref}` });
+      } else if (type === 'refund' || type === 'refund_failed') {
+        await emitRampStatus({ wallet, type: 'buy', status: 'failed', amount, ref: `bva:${ref}` });
+      }
+    } else if (category === 'transfer' || category === 'liquidation_address.drain') {
+      // Withdrawals: we already sent the USDC, this is Bridge finishing the fiat leg.
+      const status = TERMINAL_OUT[String(obj.state || objectStatus || '')];
+      if (status) {
+        await emitRampStatus({ wallet, type: 'sell', status, amount, ref: `btr:${ref}` });
+      }
+    }
+    // `customer` events (KYC transitions) are read on demand via /api/bridge/status, so nothing to do.
+
+    res.json({ received: true });
+  } catch (error) {
+    // 200 so a parse issue doesn't trigger a retry storm — the signature already proved authenticity.
+    console.error('[bridge/webhook] handler error', error);
+    res.status(200).json({ received: true });
+  }
+});
+
+export default router;

--- a/app/server/src/routes/withdraw.ts
+++ b/app/server/src/routes/withdraw.ts
@@ -40,7 +40,15 @@ router.post('/:wallet', async (req: Request, res: Response) => {
       });
       return;
     }
-    res.json({ success: true, providerReference: result.providerReference, status: result.status });
+    // depositAddress/depositAmount are not optional extras: the client MUST send USDC there or the
+    // transfer never leaves `awaiting_funds`.
+    res.json({
+      success: true,
+      providerReference: result.providerReference,
+      status: result.status,
+      depositAddress: result.depositAddress,
+      depositAmount: result.depositAmount,
+    });
   } catch (error) {
     console.error('[withdraw]', error);
     res.status(500).json({ error: 'Failed to create withdrawal' });

--- a/app/server/src/routes/withdraw.ts
+++ b/app/server/src/routes/withdraw.ts
@@ -15,7 +15,7 @@ router.post('/:wallet', async (req: Request, res: Response) => {
   const w = wallet(req);
   if (!requireWalletMatch(req, res, w, 'wallet')) return;
 
-  const b = req.body as { amount?: number | string; plaidAccountId?: string; email?: string };
+  const b = req.body as { amount?: number | string; plaidAccountId?: string; rail?: string };
   const amountUsd = Number(b?.amount);
   if (!Number.isFinite(amountUsd) || amountUsd <= 0) {
     res.status(400).json({ error: 'A positive amount is required' });
@@ -25,9 +25,12 @@ router.post('/:wallet', async (req: Request, res: Response) => {
   try {
     const result = await withdrawToBank({
       wallet: w,
-      email: String(b?.email ?? '').trim().toLowerCase(),
+      // Resolved from the session, never the body — the caller can't point a payout at someone
+      // else's Bridge customer by passing their email.
+      emails: req.auth?.emails ?? (req.auth?.email ? [req.auth.email] : []),
       plaidAccountId: String(b?.plaidAccountId ?? ''),
       amountUsd,
+      rail: b?.rail === 'ach_same_day' ? 'ach_same_day' : 'ach',
     });
     if (!result.success) {
       // notConfigured → 503 so the UI can show a friendly "coming soon"; other failures → 400.

--- a/app/server/src/services/bridgeCustomerService.ts
+++ b/app/server/src/services/bridgeCustomerService.ts
@@ -22,31 +22,15 @@ import { bridge } from './billerPayoutService.js';
 const BRIDGE_CHAIN = (process.env.BRIDGE_PAYOUT_SOURCE_CHAIN || 'base').trim();
 
 /*
- * Our fee on INSTANT inbound deposits, as a base-100 percent string ("0.5" = 0.5%).
+ * Deposits are FREE by design — we take nothing on the way in; the revenue is the off-ramp fee.
+ * Bridge treats a blank fee field as 0.0 ("Fees are optional. Leaving the developer_fee or
+ * developer_fee_percent field blank is treated as a fee of 0.0"), so we simply set nothing.
  *
- * A member's own bank chooses the rail when they push, so the fee applies itself: a standard
- * `ach_push` stays free (the `default` bucket), while `fednow`/`wire` — the real-time rails — carry
- * this. Unset ⇒ we send no fee_config at all and every deposit is free.
- *
- * NOTE: `fee_config` is available by request only ("Contact Bridge to enable this feature for your
- * developer account") and CANNOT be sent alongside `developer_fee_percent`. If it isn't enabled on
- * the account, virtual-account creation fails while this is set — so leave it unset until Bridge
- * confirms, then flip it on.
+ * If inbound ever needs a fee: a flat rate across every rail is `developer_fee_percent` on the
+ * virtual account. Charging only the instant rails (fednow/wire) while `ach_push` stays free needs
+ * `fee_config.source` — `{ default: {...}, fednow: {...} }` — which is virtual-accounts-only,
+ * available from Bridge by request, and mutually exclusive with `developer_fee_percent`.
  */
-const INSTANT_ONRAMP_FEE_PERCENT = (process.env.BRIDGE_INSTANT_ONRAMP_FEE_PERCENT || '').trim();
-
-function onrampFeeConfig(): Record<string, unknown> | null {
-  if (!INSTANT_ONRAMP_FEE_PERCENT) return null;
-  return {
-    fee_config: {
-      source: {
-        default: { fee_percent: '0' }, // standard ACH push — free
-        fednow: { fee_percent: INSTANT_ONRAMP_FEE_PERCENT },
-        wire: { fee_percent: INSTANT_ONRAMP_FEE_PERCENT },
-      },
-    },
-  };
-}
 
 export type BridgeCustomerStatus =
   | 'active'
@@ -264,7 +248,6 @@ export async function ensureVirtualAccount(input: {
       body: JSON.stringify({
         source: { currency: 'usd' },
         destination: { currency: 'usdc', payment_rail: BRIDGE_CHAIN, address: input.walletAddress },
-        ...(onrampFeeConfig() ?? {}),
       }),
     },
   );

--- a/app/server/src/services/bridgeCustomerService.ts
+++ b/app/server/src/services/bridgeCustomerService.ts
@@ -1,0 +1,249 @@
+import { randomUUID } from 'crypto';
+import { bridge } from './billerPayoutService.js';
+
+/*
+ * Bridge customer + KYC + virtual account, resolved across EVERY email on a Clear account.
+ *
+ * A member can sign in with email, Google, or Apple — and may already be a Bridge customer under any
+ * of those addresses (they onboarded through another Bridge-powered app, or signed up here with a
+ * different login). So before creating anything we probe each verified email and reuse the first
+ * customer we find; only if none matches do we onboard them as new.
+ *
+ * Shapes follow Bridge v0 (apidocs.bridge.xyz). Notes that bit us / worth remembering:
+ *  - `GET /customers?email=` is the real lookup. `/kyc_links?email=` only finds customers that were
+ *    created THROUGH a KYC link, so it's a fallback, not the primary.
+ *  - customer.status uses `active`; kyc_links.kyc_status uses `approved`. Different enums, same idea.
+ *  - `Idempotency-Key` is REQUIRED on virtual-account + external-account creates.
+ *  - Fiat on-ramp is PUSH-ONLY. Bridge does not debit bank accounts (no ACH pull, no Plaid debit),
+ *    so a virtual account is the only inbound fiat rail: the member pushes to it.
+ */
+
+/** Chain Bridge should deliver USDC on — matches the payout source chain used elsewhere. */
+const BRIDGE_CHAIN = (process.env.BRIDGE_PAYOUT_SOURCE_CHAIN || 'base').trim();
+
+export type BridgeCustomerStatus =
+  | 'active'
+  | 'awaiting_questionnaire'
+  | 'awaiting_ubo'
+  | 'incomplete'
+  | 'not_started'
+  | 'offboarded'
+  | 'paused'
+  | 'rejected'
+  | 'under_review';
+
+export type CapabilityStatus = 'pending' | 'active' | 'inactive' | 'rejected';
+
+interface BridgeCustomer {
+  id?: string;
+  status?: BridgeCustomerStatus;
+  has_accepted_terms_of_service?: boolean;
+  capabilities?: Partial<Record<'payin_crypto' | 'payout_crypto' | 'payin_fiat' | 'payout_fiat', CapabilityStatus>>;
+  endorsements?: { name?: string; status?: string }[];
+  rejection_reasons?: { reason?: string; developer_reason?: string }[];
+}
+
+export interface ResolvedBridgeCustomer {
+  customerId: string;
+  /** Which of the account's emails matched — the one Bridge knows them by. */
+  email: string;
+}
+
+export interface CustomerSnapshot {
+  customerId: string;
+  status: BridgeCustomerStatus;
+  tosAccepted: boolean;
+  /** `base` endorsement — USD payments (ACH + wire + virtual accounts). */
+  baseEndorsement: 'incomplete' | 'approved' | 'revoked';
+  payinFiat: CapabilityStatus;
+  payoutFiat: CapabilityStatus;
+  rejectionReason: string | null;
+}
+
+export interface VirtualAccountDetails {
+  id: string;
+  status: string;
+  bankName: string | null;
+  accountNumber: string | null;
+  routingNumber: string | null;
+  beneficiary: string | null;
+  /** Inbound rails this account accepts, e.g. ["ach_push","wire"] (fednow when enabled). */
+  paymentRails: string[];
+}
+
+const normalizeEmail = (value: unknown): string => String(value ?? '').trim().toLowerCase();
+
+/** First Bridge customer found across the account's emails, or null if none of them are known. */
+export async function resolveCustomerForEmails(emails: string[]): Promise<ResolvedBridgeCustomer | null> {
+  const seen = new Set<string>();
+  for (const raw of emails) {
+    const email = normalizeEmail(raw);
+    if (!email || seen.has(email)) continue;
+    seen.add(email);
+
+    // Primary: the customers index. A miss (or a Bridge hiccup) on one email shouldn't stop the loop.
+    const byCustomer = await bridge<{ data?: BridgeCustomer[] }>(
+      `/customers?email=${encodeURIComponent(email)}&limit=1`,
+    );
+    const customerId = byCustomer.ok ? byCustomer.data?.data?.[0]?.id : undefined;
+    if (customerId) return { customerId, email };
+
+    // Fallback: customers created through a hosted KYC link.
+    const byKycLink = await bridge<{ data?: { customer_id?: string }[] }>(
+      `/kyc_links?email=${encodeURIComponent(email)}&limit=1`,
+    );
+    const linkCustomerId = byKycLink.ok ? byKycLink.data?.data?.[0]?.customer_id : undefined;
+    if (linkCustomerId) return { customerId: linkCustomerId, email };
+  }
+  return null;
+}
+
+/** Read a customer's verification state — what the money-movement gate keys off. */
+export async function getCustomerSnapshot(customerId: string): Promise<CustomerSnapshot | null> {
+  const result = await bridge<BridgeCustomer>(`/customers/${encodeURIComponent(customerId)}`);
+  if (!result.ok || !result.data) return null;
+  const c = result.data;
+  const base = c.endorsements?.find((e) => e.name === 'base')?.status;
+  return {
+    customerId,
+    status: c.status ?? 'not_started',
+    tosAccepted: Boolean(c.has_accepted_terms_of_service),
+    baseEndorsement: base === 'approved' || base === 'revoked' ? base : 'incomplete',
+    payinFiat: c.capabilities?.payin_fiat ?? 'pending',
+    payoutFiat: c.capabilities?.payout_fiat ?? 'pending',
+    rejectionReason: c.rejection_reasons?.[0]?.reason ?? null,
+  };
+}
+
+export interface KycLinkResult {
+  customerId: string | null;
+  /** Where to send the user next — ToS first when unsigned, else the KYC flow. */
+  url: string | null;
+  kycUrl: string | null;
+  tosUrl: string | null;
+  source: 'existing_customer' | 'new_customer';
+}
+
+/**
+ * Get the hosted Bridge verification link for this member, reusing their existing customer when one
+ * of their emails already maps to one. `email` is the address to onboard under when they're new.
+ */
+export async function startKyc(input: {
+  emails: string[];
+  email: string;
+  fullName: string;
+  redirectUri?: string;
+  customerType?: 'individual' | 'business';
+}): Promise<KycLinkResult | { error: string; status: number }> {
+  const existing = await resolveCustomerForEmails(input.emails);
+
+  if (existing) {
+    const redirectQuery = input.redirectUri ? `?redirect_uri=${encodeURIComponent(input.redirectUri)}` : '';
+    const [tos, kyc] = await Promise.all([
+      bridge<{ url?: string | null }>(`/customers/${encodeURIComponent(existing.customerId)}/tos_acceptance_link`),
+      bridge<{ url?: string | null }>(`/customers/${encodeURIComponent(existing.customerId)}/kyc_link${redirectQuery}`),
+    ]);
+    const tosUrl = (tos.ok && tos.data?.url) || null;
+    const kycUrl = (kyc.ok && kyc.data?.url) || null;
+    const snapshot = await getCustomerSnapshot(existing.customerId);
+    // Signed the ToS already → straight to KYC; otherwise ToS has to come first.
+    const url = snapshot?.tosAccepted ? kycUrl || tosUrl : tosUrl || kycUrl;
+    if (url) {
+      return { customerId: existing.customerId, url, kycUrl, tosUrl, source: 'existing_customer' };
+    }
+    // Fall through to creating a link if Bridge gave us nothing usable.
+  }
+
+  const created = await bridge<{ customer_id?: string; kyc_link?: string; tos_link?: string }>('/kyc_links', {
+    method: 'POST',
+    headers: { 'Idempotency-Key': randomUUID() },
+    body: JSON.stringify({
+      full_name: input.fullName,
+      email: normalizeEmail(input.email),
+      type: input.customerType === 'business' ? 'business' : 'individual',
+      ...(input.redirectUri ? { redirect_uri: input.redirectUri } : {}),
+    }),
+  });
+  if (!created.ok || !created.data) {
+    return { error: created.message || 'Could not start verification.', status: created.status || 502 };
+  }
+  const tosUrl = created.data.tos_link ?? null;
+  const kycUrl = created.data.kyc_link ?? null;
+  return {
+    customerId: created.data.customer_id ?? null,
+    url: tosUrl || kycUrl,
+    kycUrl,
+    tosUrl,
+    source: 'new_customer',
+  };
+}
+
+type BridgeVirtualAccount = {
+  id?: string;
+  status?: string;
+  source_deposit_instructions?: {
+    bank_name?: string;
+    bank_account_number?: string;
+    account_number?: string;
+    bank_routing_number?: string;
+    routing_number?: string;
+    bank_beneficiary_name?: string;
+    payment_rails?: string[];
+  };
+};
+
+function toDetails(va: BridgeVirtualAccount): VirtualAccountDetails | null {
+  const di = va.source_deposit_instructions;
+  const accountNumber = di?.bank_account_number || di?.account_number || null;
+  const routingNumber = di?.bank_routing_number || di?.routing_number || null;
+  if (!va.id || !accountNumber || !routingNumber) return null;
+  return {
+    id: va.id,
+    status: va.status ?? 'activated',
+    bankName: di?.bank_name ?? null,
+    accountNumber,
+    routingNumber,
+    beneficiary: di?.bank_beneficiary_name ?? null,
+    paymentRails: di?.payment_rails ?? [],
+  };
+}
+
+/**
+ * The member's USD virtual account, creating one if they don't have it yet. This is what produces
+ * their account + routing numbers: USD pushed to it is auto-converted to USDC on Base at `wallet`.
+ * Returns a reason instead of throwing so the UI can explain itself.
+ */
+export async function ensureVirtualAccount(input: {
+  customerId: string;
+  walletAddress: string;
+}): Promise<{ account: VirtualAccountDetails } | { error: string; reason: string }> {
+  const listed = await bridge<{ data?: BridgeVirtualAccount[] }>(
+    `/customers/${encodeURIComponent(input.customerId)}/virtual_accounts`,
+  );
+  if (listed.ok) {
+    for (const va of listed.data?.data ?? []) {
+      if (va.status && va.status !== 'activated') continue;
+      const details = toDetails(va);
+      if (details) return { account: details };
+    }
+  }
+
+  // None yet — Bridge requires the customer to be KYC-approved before it will open one.
+  const created = await bridge<BridgeVirtualAccount>(
+    `/customers/${encodeURIComponent(input.customerId)}/virtual_accounts`,
+    {
+      method: 'POST',
+      headers: { 'Idempotency-Key': `va-${input.customerId}-${BRIDGE_CHAIN}` },
+      body: JSON.stringify({
+        source: { currency: 'usd' },
+        destination: { currency: 'usdc', payment_rail: BRIDGE_CHAIN, address: input.walletAddress },
+      }),
+    },
+  );
+  if (!created.ok || !created.data) {
+    return { error: created.message || 'Could not open your USD account.', reason: 'create_failed' };
+  }
+  const details = toDetails(created.data);
+  if (!details) return { error: 'Bridge did not return deposit instructions.', reason: 'no_instructions' };
+  return { account: details };
+}

--- a/app/server/src/services/bridgeCustomerService.ts
+++ b/app/server/src/services/bridgeCustomerService.ts
@@ -21,6 +21,33 @@ import { bridge } from './billerPayoutService.js';
 /** Chain Bridge should deliver USDC on — matches the payout source chain used elsewhere. */
 const BRIDGE_CHAIN = (process.env.BRIDGE_PAYOUT_SOURCE_CHAIN || 'base').trim();
 
+/*
+ * Our fee on INSTANT inbound deposits, as a base-100 percent string ("0.5" = 0.5%).
+ *
+ * A member's own bank chooses the rail when they push, so the fee applies itself: a standard
+ * `ach_push` stays free (the `default` bucket), while `fednow`/`wire` — the real-time rails — carry
+ * this. Unset ⇒ we send no fee_config at all and every deposit is free.
+ *
+ * NOTE: `fee_config` is available by request only ("Contact Bridge to enable this feature for your
+ * developer account") and CANNOT be sent alongside `developer_fee_percent`. If it isn't enabled on
+ * the account, virtual-account creation fails while this is set — so leave it unset until Bridge
+ * confirms, then flip it on.
+ */
+const INSTANT_ONRAMP_FEE_PERCENT = (process.env.BRIDGE_INSTANT_ONRAMP_FEE_PERCENT || '').trim();
+
+function onrampFeeConfig(): Record<string, unknown> | null {
+  if (!INSTANT_ONRAMP_FEE_PERCENT) return null;
+  return {
+    fee_config: {
+      source: {
+        default: { fee_percent: '0' }, // standard ACH push — free
+        fednow: { fee_percent: INSTANT_ONRAMP_FEE_PERCENT },
+        wire: { fee_percent: INSTANT_ONRAMP_FEE_PERCENT },
+      },
+    },
+  };
+}
+
 export type BridgeCustomerStatus =
   | 'active'
   | 'awaiting_questionnaire'
@@ -237,6 +264,7 @@ export async function ensureVirtualAccount(input: {
       body: JSON.stringify({
         source: { currency: 'usd' },
         destination: { currency: 'usdc', payment_rail: BRIDGE_CHAIN, address: input.walletAddress },
+        ...(onrampFeeConfig() ?? {}),
       }),
     },
   );

--- a/app/server/src/services/bridgeCustomerStore.ts
+++ b/app/server/src/services/bridgeCustomerStore.ts
@@ -1,0 +1,71 @@
+import { getPayPool } from '../config/postgres.js';
+
+/*
+ * customer_id → wallet, so an inbound Bridge webhook can be routed to a member.
+ *
+ * Bridge identifies everything by its own `customer_id`; our notifications, balances and ledger are
+ * all keyed by wallet. Nothing in a webhook payload carries a wallet, so unless we record the pairing
+ * at the moment we resolve a customer for a signed-in session, a deposit event arrives unattributable.
+ *
+ * Written opportunistically (any authenticated Bridge call), read only by the webhook handler.
+ */
+
+let ensured = false;
+
+async function ensureTables(): Promise<void> {
+  const pool = getPayPool();
+  if (!pool || ensured) return;
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS bridge_customers (
+      customer_id TEXT PRIMARY KEY,
+      wallet TEXT NOT NULL,
+      email TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    CREATE INDEX IF NOT EXISTS bridge_customers_wallet_idx ON bridge_customers (wallet);
+  `);
+  ensured = true;
+}
+
+export const bridgeCustomerStore = {
+  /** Record (or refresh) which member a Bridge customer belongs to. Best-effort — never throws. */
+  async link(customerId: string, wallet: string, email?: string | null): Promise<void> {
+    const id = String(customerId || '').trim();
+    const w = String(wallet || '').trim().toLowerCase();
+    if (!id || !/^0x[a-f0-9]{40}$/.test(w)) return;
+    try {
+      const pool = getPayPool();
+      if (!pool) return;
+      await ensureTables();
+      await pool.query(
+        `INSERT INTO bridge_customers (customer_id, wallet, email)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (customer_id) DO UPDATE
+           SET wallet = EXCLUDED.wallet,
+               email = COALESCE(EXCLUDED.email, bridge_customers.email),
+               updated_at = now()`,
+        [id, w, email ? String(email).toLowerCase() : null],
+      );
+    } catch (error) {
+      // A missing mapping only costs a notification, so never fail the caller's request over it.
+      console.warn('[bridgeCustomerStore] link failed', (error as Error)?.message);
+    }
+  },
+
+  /** The member behind a Bridge customer, or null if we've never seen them. */
+  async walletFor(customerId: string): Promise<string | null> {
+    const id = String(customerId || '').trim();
+    if (!id) return null;
+    try {
+      const pool = getPayPool();
+      if (!pool) return null;
+      await ensureTables();
+      const r = await pool.query('SELECT wallet FROM bridge_customers WHERE customer_id = $1 LIMIT 1', [id]);
+      return (r.rows[0]?.wallet as string | undefined) ?? null;
+    } catch (error) {
+      console.warn('[bridgeCustomerStore] lookup failed', (error as Error)?.message);
+      return null;
+    }
+  },
+};

--- a/app/server/src/services/sendBridgeWebhookVerifier.ts
+++ b/app/server/src/services/sendBridgeWebhookVerifier.ts
@@ -39,8 +39,10 @@ function normalizePublicKey(rawKey: string): string {
 }
 
 function configuredPublicKeys(): string[] {
-  const single = (process.env.SEND_BRIDGE_WEBHOOK_PUBLIC_KEY || '').trim();
-  const csv = (process.env.SEND_BRIDGE_WEBHOOK_PUBLIC_KEYS || '')
+  // BRIDGE_WEBHOOK_PUBLIC_KEY is the general one (any Bridge endpoint); the SEND_* names predate it and
+  // stay supported. Same fallback shape as the API key (SEND_BRIDGE_PAYOUT_API_KEY || BRIDGE_API_KEY).
+  const single = (process.env.SEND_BRIDGE_WEBHOOK_PUBLIC_KEY || process.env.BRIDGE_WEBHOOK_PUBLIC_KEY || '').trim();
+  const csv = (process.env.SEND_BRIDGE_WEBHOOK_PUBLIC_KEYS || process.env.BRIDGE_WEBHOOK_PUBLIC_KEYS || '')
     .split(',')
     .map((value) => value.trim())
     .filter(Boolean);

--- a/app/server/src/services/withdrawService.ts
+++ b/app/server/src/services/withdrawService.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { createHash } from 'crypto';
-import { bridge, resolveCustomerId } from './billerPayoutService.js';
+import { bridge } from './billerPayoutService.js';
+import { resolveCustomerForEmails } from './bridgeCustomerService.js';
 import { plaidTokenStore } from './plaidTokenStore.js';
 import { getPlaidClient } from '../routes/plaid.js';
 
@@ -18,6 +19,16 @@ import { getPlaidClient } from '../routes/plaid.js';
  */
 
 const BRIDGE_USDC_CHAIN = (process.env.BRIDGE_PAYOUT_SOURCE_CHAIN || 'base').trim();
+
+/**
+ * Payout rails we expose. Bridge's outbound USD rails are `ach`, `ach_same_day` and `wire` — there is
+ * no instant/FedNow payout (FedNow is inbound only), so `ach_same_day` IS our "instant" tier.
+ * Standard ACH stays free; the fast rail carries our developer fee.
+ */
+export type WithdrawRail = 'ach' | 'ach_same_day';
+
+/** Our cut on the fast rail, as a Bridge `developer_fee_percent` string ("1" = 1%). */
+const INSTANT_FEE_PERCENT = (process.env.BRIDGE_INSTANT_WITHDRAW_FEE_PERCENT || '1').trim();
 
 export interface WithdrawResult {
   success: boolean;
@@ -58,15 +69,19 @@ async function resolveBankNumbers(
 /** Pay out USDC to the user's linked bank via Bridge: USDC pulled from wallet → ACH to the bank. */
 export async function withdrawToBank(input: {
   wallet: string;
-  email: string;
+  /** Every email on the account — any of them may be the one Bridge knows this member by. */
+  emails: string[];
   plaidAccountId: string;
   amountUsd: number;
+  rail?: WithdrawRail;
 }): Promise<WithdrawResult> {
-  if (!input.email) return { success: false, reason: 'Complete identity verification to withdraw.' };
+  const emails = input.emails.filter(Boolean);
+  if (emails.length === 0) return { success: false, reason: 'Complete identity verification to withdraw.' };
   if (!input.plaidAccountId) return { success: false, reason: 'Choose a bank to withdraw to.' };
   if (!(input.amountUsd > 0)) return { success: false, reason: 'Amount must be greater than zero.' };
 
-  const customerId = await resolveCustomerId(input.email);
+  const rail: WithdrawRail = input.rail === 'ach_same_day' ? 'ach_same_day' : 'ach';
+  const customerId = (await resolveCustomerForEmails(emails))?.customerId ?? null;
   if (!customerId) {
     // No Bridge customer (or Bridge unconfigured) → treat as "rail not ready yet".
     return { success: false, notConfigured: true, reason: 'Bank withdrawals are not available yet.' };
@@ -89,7 +104,11 @@ export async function withdrawToBank(input: {
       currency: 'usd',
       account_type: 'us',
       account_owner_name: numbers.ownerName,
-      account: { account_number: numbers.accountNumber, routing_number: numbers.routingNumber },
+      account: {
+        account_number: numbers.accountNumber,
+        routing_number: numbers.routingNumber,
+        checking_or_savings: 'checking',
+      },
     }),
   });
   if (!ext.ok || !ext.data?.id) {
@@ -103,7 +122,10 @@ export async function withdrawToBank(input: {
       amount: input.amountUsd.toFixed(2),
       on_behalf_of: customerId,
       source: { payment_rail: BRIDGE_USDC_CHAIN, currency: 'usdc', from_address: input.wallet },
-      destination: { payment_rail: 'ach', currency: 'usd', external_account_id: ext.data.id },
+      destination: { payment_rail: rail, currency: 'usd', external_account_id: ext.data.id },
+      // Standard ACH is free; the same-day rail carries our developer fee. Bridge withholds it and
+      // settles it to our fee account monthly — nothing to net out on our side.
+      ...(rail === 'ach_same_day' ? { developer_fee_percent: INSTANT_FEE_PERCENT } : {}),
     }),
   });
   if (!transfer.ok || !transfer.data?.id) {

--- a/app/server/src/services/withdrawService.ts
+++ b/app/server/src/services/withdrawService.ts
@@ -37,13 +37,25 @@ export interface WithdrawResult {
   reason?: string;
   /** True when the rail is not configured yet (Bridge/Plaid creds) — UI shows "coming soon", not an error. */
   notConfigured?: boolean;
+  /**
+   * Bridge's deposit address for this transfer. **The caller MUST send USDC here** — Bridge does not
+   * pull from self-custody wallets ("Bridge either pulls funds [bridge wallet / prefunded account] or
+   * generates deposit instructions when a third-party source (e.g. bank, external wallet) is
+   * specified"). Until it's funded the transfer sits in `awaiting_funds` and nothing reaches the bank.
+   */
+  depositAddress?: string;
+  /** Exact amount Bridge expects at that address. */
+  depositAmount?: string;
 }
 
-/** Plaid Auth: account_number + routing_number for a specific linked account the user owns. */
-async function resolveBankNumbers(
+/** Plaid Auth: account_number + routing_number + checking/savings for a linked account the user owns. */
+export async function resolveBankNumbers(
   wallet: string,
   plaidAccountId: string,
-): Promise<{ accountNumber: string; routingNumber: string; ownerName: string } | { error: string }> {
+): Promise<
+  | { accountNumber: string; routingNumber: string; ownerName: string; checkingOrSavings: 'checking' | 'savings' }
+  | { error: string }
+> {
   const client = getPlaidClient();
   if (!client || !plaidTokenStore.isConfigured()) {
     return { error: 'not_configured' };
@@ -61,7 +73,10 @@ async function resolveBankNumbers(
     const acct = resp.data.accounts?.find((a) => a.account_id === plaidAccountId);
     const ownerName = resp.data.accounts?.length ? (acct?.name || 'Account holder') : 'Account holder';
     if (!ach.account || !ach.routing) return { error: 'This bank did not return account/routing numbers.' };
-    return { accountNumber: ach.account, routingNumber: ach.routing, ownerName };
+    // Bridge wants the real account type; Plaid's subtype tells us. Anything that isn't explicitly
+    // savings (checking, money market, …) is treated as checking for ACH purposes.
+    const checkingOrSavings = acct?.subtype === 'savings' ? 'savings' : 'checking';
+    return { accountNumber: ach.account, routingNumber: ach.routing, ownerName, checkingOrSavings };
   }
   return { error: 'Could not find that linked bank account.' };
 }
@@ -107,7 +122,7 @@ export async function withdrawToBank(input: {
       account: {
         account_number: numbers.accountNumber,
         routing_number: numbers.routingNumber,
-        checking_or_savings: 'checking',
+        checking_or_savings: numbers.checkingOrSavings,
       },
     }),
   });
@@ -115,7 +130,11 @@ export async function withdrawToBank(input: {
     return { success: false, reason: ext.message || 'Could not register your bank with Bridge.' };
   }
 
-  const transfer = await bridge<{ id?: string; state?: string }>('/transfers', {
+  const transfer = await bridge<{
+    id?: string;
+    state?: string;
+    source_deposit_instructions?: { to_address?: string; amount?: string };
+  }>('/transfers', {
     method: 'POST',
     headers: { 'Idempotency-Key': randomUUID() },
     body: JSON.stringify({
@@ -123,6 +142,10 @@ export async function withdrawToBank(input: {
       on_behalf_of: customerId,
       source: { payment_rail: BRIDGE_USDC_CHAIN, currency: 'usdc', from_address: input.wallet },
       destination: { payment_rail: rail, currency: 'usd', external_account_id: ext.data.id },
+      // Bridge matches the incoming deposit on from_address by default. We send from the member's
+      // Privy SMART wallet, which needn't be the address we quote here, so accept any sender —
+      // Bridge "strongly recommends" this for crypto deposits for exactly this reason.
+      features: { allow_any_from_address: true },
       // Standard ACH is free; the same-day rail carries our developer fee. Bridge withholds it and
       // settles it to our fee account monthly — nothing to net out on our side.
       ...(rail === 'ach_same_day' ? { developer_fee_percent: INSTANT_FEE_PERCENT } : {}),
@@ -132,5 +155,18 @@ export async function withdrawToBank(input: {
     return { success: false, reason: transfer.message || 'Bridge could not create the withdrawal.' };
   }
 
-  return { success: true, providerReference: transfer.data.id, status: transfer.data.state };
+  const deposit = transfer.data.source_deposit_instructions;
+  if (!deposit?.to_address) {
+    // Without a deposit address there is nowhere to send the USDC, so the transfer could never settle.
+    // Fail loudly rather than report a withdrawal that will silently sit in `awaiting_funds`.
+    return { success: false, reason: 'Bridge did not return deposit instructions for this withdrawal.' };
+  }
+
+  return {
+    success: true,
+    providerReference: transfer.data.id,
+    status: transfer.data.state,
+    depositAddress: deposit.to_address,
+    depositAmount: deposit.amount || input.amountUsd.toFixed(2),
+  };
 }

--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -1,11 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
-import { ArrowLeft, Check, ChevronDown, CreditCard, Landmark, Loader2, Smartphone, ShieldCheck, Sparkles, Wallet, Zap, Send, type LucideIcon } from 'lucide-react';
+import { ArrowLeft, Check, ChevronDown, CreditCard, Landmark, Loader2, Smartphone, ShieldCheck, Sparkles, Wallet, type LucideIcon } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { useLinkedWallets } from '@/context/LinkedWalletsContext';
-import { useExternalAccounts } from '@/context/ExternalAccountsContext';
 import { track } from '@/lib/analytics';
-import { useBridge } from '@/context/BridgeContext';
-import { useKyc } from '@/context/KycContext';
 import DepositInstructions from '@/components/app-ui/DepositInstructions';
 import { usePrivy } from '@privy-io/react-auth';
 import { getRampBuyQuote, createRampBuySession, createRampBuyOrder, getRampConfig, getRampBuyStatus, rampEvent, type RampQuote } from '@/utils/apiClient';
@@ -53,15 +50,16 @@ function toQuoteVM(q: RampQuote, amount: number): QuoteVM {
 const rampPM = (methodId: string) => (methodId === 'applepay' ? 'applepay' : 'creditcard');
 
 /*
- * Bank funding rails. A bank deposit pulls fiat from a Plaid-linked account through the user's
- * Bridge USD virtual account (which auto-converts to USDC). Fees are illustrative.
- * SEAM: rails + fees come from Bridge; the source account is a Plaid-linked external account.
+ * Bank funding is a PUSH, not a pull. Bridge does not debit bank accounts — no ACH pull, no Plaid
+ * debit ("not integrate with Plaid to initiate money movement, including pulling or debiting from
+ * bank accounts") — so we cannot initiate a deposit for the member. Instead we hand them their
+ * Bridge virtual account's numbers and they push from their own bank. Deposits are free on every
+ * rail, and land in seconds when their bank sends instant (FedNow).
+ *
+ * That's why this path ends in deposit instructions rather than an amount + Confirm. The rail picker
+ * that used to live here (ACH free / same-day $1.50 / wire $15) was invented pricing with no backend
+ * behind it, describing a pull we can't perform.
  */
-const RAILS = [
-  { id: 'ach', name: 'ACH', speed: '1–3 business days', fee: 0, icon: Landmark },
-  { id: 'ach_sd', name: 'Same-day ACH', speed: 'Today by 6pm ET', fee: 1.5, icon: Zap },
-  { id: 'wire', name: 'Wire', speed: 'Within hours', fee: 15, icon: Send },
-] as const;
 
 const QUICK = [50, 100, 250, 500];
 const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -80,10 +78,6 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
   const [advanced, setAdvanced] = useState(false);
   const [walletOpen, setWalletOpen] = useState(false);
   const [done, setDone] = useState(false);
-  const [sourceId, setSourceId] = useState('');
-  const [railId, setRailId] = useState<string>('ach');
-  const [sourceOpen, setSourceOpen] = useState(false);
-  const [depositOpen, setDepositOpen] = useState(false);
   const [apiQuotes, setApiQuotes] = useState<QuoteVM[]>([]);
   const [quoteId, setQuoteId] = useState<string | undefined>(undefined); // locked-quote id for checkout
   const [rampConfigured, setRampConfigured] = useState<boolean | null>(null); // null = unknown yet
@@ -91,25 +85,14 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
   const [checkoutLoading, setCheckoutLoading] = useState(false);
   const [checkoutError, setCheckoutError] = useState<string | null>(null);
   const { wallets, primaryId, openManager } = useLinkedWallets();
-  const { accounts: banks, openManager: openBankManager } = useExternalAccounts();
-  const { virtualAccount } = useBridge();
-  const { verified, openKyc } = useKyc();
   const { user } = usePrivy();
   const buyerEmail = user?.email?.address || '';
   const buyerPhone = user?.phone?.number || '';
   const bal = useClearBalances();
-  // Card / Apple Pay on-ramps KYC at the provider; a bank/ACH deposit needs our KYC.
-  const proceed = () => {
-    if (methodId === 'bank' && !verified) openKyc(() => setStep('status'));
-    else setStep('status');
-  };
 
-  // Card / Apple Pay: create an Onramper checkout + open the provider's hosted flow. Bank = Bridge.
+  // Card / Apple Pay: create an Onramper checkout + open the provider's hosted flow. (Bank never
+  // reaches here — it's a push to the virtual account, with nothing for us to confirm.)
   const handleConfirm = async () => {
-    if (isBank) {
-      proceed();
-      return;
-    }
     if (!wallet.address || !selected.p.id) {
       setCheckoutError('Pick a linked wallet and provider first.');
       return;
@@ -188,10 +171,6 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
     setProviderId(null);
     setAdvanced(false);
     setWalletOpen(false);
-    setSourceId(banks[0]?.id ?? '');
-    setRailId('ach');
-    setSourceOpen(false);
-    setDepositOpen(false);
     setApiQuotes([]);
     setQuoteId(undefined);
     setPayUrl(null);
@@ -211,8 +190,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
   useEffect(() => {
     if (step !== 'status') return;
     setDone(false);
-    // Bank transfers settle via Bridge separately — keep the optimistic confirmation.
-    if (isBank || !wallet.address) {
+    if (!wallet.address) {
       const t = setTimeout(() => setDone(true), 1700);
       return () => clearTimeout(t);
     }
@@ -323,16 +301,8 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
       clearTimeout(t);
     };
   }, [open, isBank, amountValid, amount, methodId, wallet.address]);
-  const rail = RAILS.find((r) => r.id === railId) ?? RAILS[0];
-  const source = banks.find((b) => b.id === sourceId) ?? banks[0];
-  // Bridge: wire is ACH-only for Chase & Bank of America.
-  const wireBlocked = !!source && /chase|bank of america|bofa/i.test(source.name);
-  const fee = isBank ? rail.fee : selected.fee;
+  const fee = selected.fee;
   const payout = Math.max(0, amount - fee);
-
-  useEffect(() => {
-    if (wireBlocked && railId === 'wire') setRailId('ach');
-  }, [wireBlocked, railId]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -341,6 +311,9 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
           <div className="p-5">
             <div className="mb-5 text-base font-semibold text-foreground">Add money</div>
 
+            {/* A bank push carries whatever the member chooses to send, so we only ask for an amount
+                when we're actually charging them (card / Apple Pay). */}
+            <div className={cn(isBank && 'hidden')}>
             <label className="mb-2 block text-xs font-medium text-muted-foreground">Amount</label>
             <div className="relative">
               <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 font-display text-2xl text-muted-foreground">$</span>
@@ -368,8 +341,9 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
                 </button>
               ))}
             </div>
+            </div>
 
-            <label className="mb-2 mt-5 block text-xs font-medium text-muted-foreground">Pay with</label>
+            <label className={cn('mb-2 block text-xs font-medium text-muted-foreground', !isBank && 'mt-5')}>Pay with</label>
             <div className="space-y-2">
               {METHODS.map((m) => {
                 const Icon = m.icon;
@@ -399,36 +373,31 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
               })}
             </div>
 
-            {/* Direct deposit needs a provisioned Bridge virtual account — only surface it then. */}
-            {isBank && virtualAccount.status === 'active' && (
-              <div className="mt-3">
+            {/* A bank deposit is something the MEMBER pushes — we can't debit for them — so this
+                path ends here with their account numbers instead of an amount + Confirm.
+                DepositInstructions shows a "verify to activate" CTA until the account exists. */}
+            {isBank ? (
+              <div className="mt-4">
+                <DepositInstructions />
+                <p className="mt-3 flex items-start gap-1.5 text-[11px] text-muted-foreground">
+                  <Landmark className="mt-px h-3 w-3 shrink-0" />
+                  Send from your bank to these details — we don't charge for bank deposits. Most arrive in
+                  1–3 business days, or in seconds if your bank supports instant transfers (FedNow).
+                </p>
+              </div>
+            ) : (
+              <>
                 <button
                   type="button"
-                  onClick={() => setDepositOpen((o) => !o)}
-                  className="flex w-full items-center justify-between text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+                  disabled={!amountValid}
+                  onClick={() => setStep('review')}
+                  className="mt-5 w-full rounded-xl bg-primary py-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.99] disabled:opacity-40"
                 >
-                  <span className="inline-flex items-center gap-1">
-                    <Landmark className="h-3 w-3" /> Receive a direct deposit or push from your bank
-                  </span>
-                  <ChevronDown className={cn('h-3 w-3 transition-transform', depositOpen && 'rotate-180')} />
+                  Review
                 </button>
-                {depositOpen && (
-                  <div className="mt-2">
-                    <DepositInstructions />
-                  </div>
-                )}
-              </div>
+                <p className="mt-2 text-center text-[11px] text-muted-foreground">{amount > 10000 ? 'Max $10,000 per transaction' : 'Add $5–$10,000'}</p>
+              </>
             )}
-
-            <button
-              type="button"
-              disabled={!amountValid}
-              onClick={() => setStep('review')}
-              className="mt-5 w-full rounded-xl bg-primary py-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.99] disabled:opacity-40"
-            >
-              Review
-            </button>
-            <p className="mt-2 text-center text-[11px] text-muted-foreground">{amount > 10000 ? 'Max $10,000 per transaction' : 'Add $5–$10,000'}</p>
           </div>
         )}
 
@@ -496,51 +465,6 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
                 )}
               </div>
 
-              {isBank ? (
-                <div className="relative">
-                  <button
-                    type="button"
-                    onClick={() => setSourceOpen((o) => !o)}
-                    className="flex w-full items-center justify-between gap-2 rounded-xl border border-border px-3 py-2.5 text-left transition-colors hover:bg-secondary/40"
-                  >
-                    <span className="min-w-0">
-                      <span className="block text-[11px] text-muted-foreground">From</span>
-                      <span className="block truncate text-sm font-medium text-foreground">{source ? `${source.name} ••${source.mask}` : 'Link a bank'}</span>
-                    </span>
-                    <ChevronDown className={cn('h-4 w-4 shrink-0 text-muted-foreground transition-transform', sourceOpen && 'rotate-180')} />
-                  </button>
-                  {sourceOpen && (
-                    <div className="absolute z-10 mt-1 w-full overflow-hidden rounded-xl border border-border bg-popover shadow-md">
-                      {banks.map((b) => (
-                        <button
-                          key={b.id}
-                          type="button"
-                          onClick={() => {
-                            setSourceId(b.id);
-                            setSourceOpen(false);
-                          }}
-                          className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-secondary"
-                        >
-                          <span className="truncate font-medium text-foreground">
-                            {b.name} <span className="text-muted-foreground">••{b.mask}</span>
-                          </span>
-                          {b.id === source?.id && <Check className="h-4 w-4 shrink-0 text-foreground" />}
-                        </button>
-                      ))}
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setSourceOpen(false);
-                          openBankManager();
-                        }}
-                        className="flex w-full items-center gap-1.5 border-t border-border px-3 py-2 text-left text-xs font-medium text-muted-foreground hover:bg-secondary hover:text-foreground"
-                      >
-                        <Landmark className="h-3.5 w-3.5" /> Manage banks
-                      </button>
-                    </div>
-                  )}
-                </div>
-              ) : (
                 <button
                   type="button"
                   onClick={() => setStep('amount')}
@@ -552,41 +476,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
                   </span>
                   <span className="text-xs text-muted-foreground">Change</span>
                 </button>
-              )}
             </div>
-
-            {isBank && (
-              <div className="mt-2 space-y-1.5">
-                {RAILS.map((r) => {
-                  const RIcon = r.icon;
-                  const active = railId === r.id;
-                  const disabled = r.id === 'wire' && wireBlocked;
-                  return (
-                    <button
-                      key={r.id}
-                      type="button"
-                      disabled={disabled}
-                      onClick={() => setRailId(r.id)}
-                      className={cn(
-                        'flex w-full items-center gap-3 rounded-xl border px-3 py-2 text-left transition-colors',
-                        disabled
-                          ? 'cursor-not-allowed border-border opacity-50'
-                          : active
-                            ? 'border-foreground bg-secondary/50'
-                            : 'border-border hover:bg-secondary/40',
-                      )}
-                    >
-                      <RIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
-                      <span className="min-w-0 flex-1">
-                        <span className="block text-sm font-medium text-foreground">{r.name}</span>
-                        <span className="block text-[11px] text-muted-foreground">{disabled ? `Not available for ${source?.name}` : r.speed}</span>
-                      </span>
-                      <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{r.fee === 0 ? 'Free' : fmt(r.fee)}</span>
-                    </button>
-                  );
-                })}
-              </div>
-            )}
 
             {/* cost breakdown */}
             <div className="mt-4 space-y-1.5 rounded-xl bg-secondary/40 p-3 text-sm">
@@ -595,7 +485,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
                 <span className="tabular-nums text-foreground">{fmt(amount)}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-muted-foreground">{isBank ? `Fee · ${rail.name}` : 'Fee'}</span>
+                <span className="text-muted-foreground">Fee</span>
                 <span className="tabular-nums text-foreground">{fee === 0 ? 'Free' : fmt(fee)}</span>
               </div>
               <div className="flex justify-between border-t border-border pt-1.5 font-medium">
@@ -604,8 +494,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
               </div>
             </div>
 
-            {/* provider — auto best, advanced to change (card / Apple Pay only) */}
-            {!isBank && (
+            {/* provider — auto best, advanced to change */}
             <div className="mt-3">
               {quotesLoading ? (
                 <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
@@ -660,12 +549,11 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
                 </>
               )}
             </div>
-            )}
 
             <button
               type="button"
               onClick={handleConfirm}
-              disabled={checkoutLoading || (!isBank && (quotesLoading || !selected.p.id || !wallet.address))}
+              disabled={checkoutLoading || quotesLoading || !selected.p.id || !wallet.address}
               className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl bg-primary py-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.99] disabled:opacity-50"
             >
               {checkoutLoading ? <><Loader2 className="h-4 w-4 animate-spin" /> Starting…</> : `Add ${fmt(amount)}`}
@@ -673,9 +561,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
             {checkoutError && <p className="mt-2 text-center text-[11px] text-negative">{checkoutError}</p>}
             <p className="mt-2 flex items-center justify-center gap-1 text-center text-[11px] text-muted-foreground">
               <ShieldCheck className="h-3 w-3" />{' '}
-              {isBank
-                ? `Via your Clear USD account${virtualAccount.bankName ? ` (${virtualAccount.bankName})` : ''} · held as USDC on Base`
-                : 'Held as USDC, a regulated digital dollar, on Base'}
+              Held as USDC, a regulated digital dollar, on Base
             </p>
           </div>
         )}
@@ -714,9 +600,9 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
             {!done ? (
               <>
                 <Loader2 className="h-10 w-10 animate-spin text-muted-foreground" />
-                <div className="mt-4 text-base font-semibold text-foreground">{isBank ? 'Submitting your transfer…' : 'Connecting to secure checkout…'}</div>
+                <div className="mt-4 text-base font-semibold text-foreground">Connecting to secure checkout…</div>
                 <div className="mt-1 text-sm text-muted-foreground">
-                  {isBank ? `Initiating a ${rail.name} transfer from ${source?.name ?? 'your bank'}.` : `Finishing your payment with ${selected.p.name}.`}
+                  {`Finishing your payment with ${selected.p.name}.`}
                 </div>
               </>
             ) : (
@@ -726,8 +612,7 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
                 </div>
                 <div className="mt-4 text-base font-semibold text-foreground">You're all set</div>
                 <div className="mt-1 text-sm text-muted-foreground">
-                  <span className="font-medium text-foreground">{fmt(payout)}</span> is on its way to {wallet.label}
-                  {isBank ? ` via ${rail.name}` : ''}. We'll let you know when it lands.
+                  <span className="font-medium text-foreground">{fmt(payout)}</span> is on its way to {wallet.label}. We'll let you know when it lands.
                 </div>
                 <button
                   type="button"

--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { ArrowLeft, Check, ChevronDown, CreditCard, Landmark, Loader2, Smartphone, ShieldCheck, Sparkles, Wallet, type LucideIcon } from 'lucide-react';
+import { ArrowLeft, Building2, Check, ChevronDown, CreditCard, Landmark, Loader2, Smartphone, ShieldCheck, Sparkles, Wallet, type LucideIcon } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { useLinkedWallets } from '@/context/LinkedWalletsContext';
 import { track } from '@/lib/analytics';
@@ -30,7 +30,11 @@ interface PayMethod {
 const METHODS: PayMethod[] = [
   { id: 'card', name: 'Debit or credit card', icon: CreditCard, speed: 'Instant' },
   { id: 'applepay', name: 'Apple Pay', icon: Smartphone, speed: 'Instant' },
-  { id: 'bank', name: 'Bank transfer', icon: Landmark, speed: '1–3 business days' },
+  // Coinbase ACH is the cheap card alternative, but it's the one method that can't be a guest
+  // checkout — Coinbase requires a signed-in account and it only runs in their hosted widget. Say so
+  // up front rather than dumping the member on a login screen after they've committed to an amount.
+  { id: 'ach', name: 'Bank via Coinbase', icon: Landmark, speed: 'Lower fee · opens Coinbase, account required' },
+  { id: 'bank', name: 'Direct deposit or bank push', icon: Building2, speed: 'Free · sent from your bank' },
 ];
 
 /** A normalized quote for the UI: provider + USDC payout + total fee vs the entered amount. */
@@ -47,7 +51,8 @@ function toQuoteVM(q: RampQuote, amount: number): QuoteVM {
   const fee = fees > 0 ? fees : Math.max(0, amount - (q.cryptoAmount ?? amount));
   return { p: { id: q.provider, name: prettyRamp(q.provider) }, fee, payout: Math.max(0, amount - fee) };
 }
-const rampPM = (methodId: string) => (methodId === 'applepay' ? 'applepay' : 'creditcard');
+// The backend maps these onto Coinbase's enum (applepay→APPLE_PAY, ach→ACH_BANK_ACCOUNT, else CARD).
+const rampPM = (methodId: string) => (methodId === 'applepay' ? 'applepay' : methodId === 'ach' ? 'ach' : 'creditcard');
 
 /*
  * Bank funding is a PUSH, not a pull. Bridge does not debit bank accounts — no ACH pull, no Plaid
@@ -559,6 +564,14 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
               {checkoutLoading ? <><Loader2 className="h-4 w-4 animate-spin" /> Starting…</> : `Add ${fmt(amount)}`}
             </button>
             {checkoutError && <p className="mt-2 text-center text-[11px] text-negative">{checkoutError}</p>}
+            {methodId === 'ach' && (
+              <p className="mt-2 flex items-start gap-1.5 rounded-lg border border-border p-2.5 text-[11px] leading-relaxed text-muted-foreground">
+                <Landmark className="mt-px h-3 w-3 shrink-0" />
+                Coinbase handles bank transfers and will ask you to sign in and link your bank — a Coinbase
+                account is required. Bank deposits can take a few days to arrive. To skip the account, use
+                a card, or send a free transfer from your bank instead.
+              </p>
+            )}
             <p className="mt-2 flex items-center justify-center gap-1 text-center text-[11px] text-muted-foreground">
               <ShieldCheck className="h-3 w-3" />{' '}
               Held as USDC, a regulated digital dollar, on Base

--- a/app/src/components/app-ui/DepositInstructions.tsx
+++ b/app/src/components/app-ui/DepositInstructions.tsx
@@ -1,13 +1,25 @@
 import { useState } from 'react';
-import { Check, Copy, Landmark } from 'lucide-react';
+import { Check, Copy, Landmark, Loader2 } from 'lucide-react';
 import { useBridge } from '@/context/BridgeContext';
 import { useKyc } from '@/context/KycContext';
 
 /*
  * The user's Bridge USD virtual-account deposit instructions — used for direct deposit (paycheck),
- * a manual bank push, or wire. Money sent here is auto-converted to USDC in the primary wallet via
- * Bridge payment routes. Reads BridgeContext; shows a verify CTA until the account is provisioned.
+ * a manual bank push, or wire. Money sent here is auto-converted to USDC in the primary wallet.
+ *
+ * This is also the ONLY inbound fiat rail: Bridge does not debit bank accounts (no ACH pull), so a
+ * deposit is always something the member pushes from their bank. Verified but no account yet → we
+ * can open one on the spot (`provision`); unverified → the KYC CTA.
  */
+
+/** Bridge's rail ids → what a person would call them. */
+const RAIL_LABELS: Record<string, string> = {
+  ach_push: 'ACH',
+  ach_same_day: 'same-day ACH',
+  wire: 'wire',
+  fednow: 'instant (FedNow)',
+};
+const railLabel = (rail: string) => RAIL_LABELS[rail] ?? rail;
 
 function Row({ label, value }: { label: string; value: string }) {
   const [copied, setCopied] = useState(false);
@@ -34,36 +46,53 @@ function Row({ label, value }: { label: string; value: string }) {
 }
 
 export default function DepositInstructions() {
-  const { virtualAccount: va } = useBridge();
-  const { openKyc } = useKyc();
+  const { virtualAccount: va, provision } = useBridge();
+  const { openKyc, verified } = useKyc();
+  const [opening, setOpening] = useState(false);
 
   if (va.status !== 'active') {
+    // Verified already → we can open the USD account right here. Otherwise KYC comes first.
+    const onClick = async () => {
+      if (!verified) {
+        openKyc();
+        return;
+      }
+      setOpening(true);
+      try {
+        await provision();
+      } finally {
+        setOpening(false);
+      }
+    };
     return (
       <button
         type="button"
-        onClick={() => openKyc()}
-        className="flex w-full items-center gap-2.5 rounded-xl border border-dashed border-border p-3 text-left transition-colors hover:bg-secondary/40"
+        onClick={() => void onClick()}
+        disabled={opening}
+        className="flex w-full items-center gap-2.5 rounded-xl border border-dashed border-border p-3 text-left transition-colors hover:bg-secondary/40 disabled:opacity-60"
       >
         <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-info/10 text-info">
-          <Landmark className="h-4 w-4" />
+          {opening ? <Loader2 className="h-4 w-4 animate-spin" /> : <Landmark className="h-4 w-4" />}
         </span>
         <span className="min-w-0 flex-1">
           <span className="block text-sm font-medium text-foreground">Activate your account &amp; routing numbers</span>
-          <span className="block text-[11px] text-muted-foreground">Verify your identity to open a USD account via Bridge.</span>
+          <span className="block text-[11px] text-muted-foreground">
+            {verified ? 'Open your USD account via Bridge.' : 'Verify your identity to open a USD account via Bridge.'}
+          </span>
         </span>
-        <span className="shrink-0 text-xs font-semibold text-info">Verify</span>
+        <span className="shrink-0 text-xs font-semibold text-info">{verified ? (opening ? 'Opening…' : 'Activate') : 'Verify'}</span>
       </button>
     );
   }
 
   return (
     <div className="space-y-2">
-      <Row label="Account holder" value={va.beneficiary} />
+      {va.beneficiary && <Row label="Account holder" value={va.beneficiary} />}
       <Row label="Account number" value={va.accountNumber} />
       <Row label="Routing number" value={va.routingNumber} />
-      <Row label="Account type" value="Checking" />
       <p className="flex items-center gap-1.5 pt-0.5 text-[11px] text-muted-foreground">
-        <Landmark className="h-3.5 w-3.5" /> {va.bankName} · via Bridge — use for direct deposit, ACH or wire. Funds arrive as USDC.
+        <Landmark className="h-3.5 w-3.5" /> {va.bankName || 'Bridge'} — use for direct deposit
+        {va.paymentRails.length > 0 ? `, ${va.paymentRails.map(railLabel).join(' or ')}` : ', ACH or wire'}. Funds arrive as USDC.
       </p>
     </div>
   );

--- a/app/src/components/app-ui/KycModal.tsx
+++ b/app/src/components/app-ui/KycModal.tsx
@@ -1,16 +1,21 @@
 import { useEffect, useRef, useState } from 'react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
-import { ShieldCheck, IdCard, Camera, Check, Loader2, Lock, Sparkles, ScanLine } from 'lucide-react';
+import { ShieldCheck, IdCard, Camera, Check, Loader2, Lock, Sparkles, ScanLine, ExternalLink } from 'lucide-react';
 import { PERSONA_CONFIGURED, runPersonaInquiry } from '@/lib/personaInquiry';
+import { useBridge } from '@/context/BridgeContext';
+import { getBridgeStatus, startBridgeKyc } from '@/utils/apiClient';
 import { cn } from '@/lib/utils';
 
 /*
- * Identity verification gate (KYC). Required before moving money. When Persona is configured
- * (VITE_PERSONA_TEMPLATE_ID), the verifying step launches the real embedded Persona inquiry and
- * returns its inquiry id; otherwise it falls back to a mocked checklist so the prototype works.
+ * Identity verification gate (KYC). Required before moving money. Three paths, in priority order:
  *
- * The completed inquiry id is the reusable KYC "passport" handed to Bridge customer creation
- * (persona_inquiry_type) / Colossus — see BridgeContext + lib/integrations.
+ *  1. BRIDGE (production): we ask for their full legal name, get a hosted Bridge link (Terms of
+ *     Service first, then the KYC flow) and open it in a new tab, then poll until Bridge reports the
+ *     customer `active`. Bridge owns the verdict, so it survives reloads and matches what the backend
+ *     will actually permit. If any of their account emails already maps to a Bridge customer, the
+ *     backend reuses it instead of onboarding them twice.
+ *  2. Persona embedded inquiry (VITE_PERSONA_TEMPLATE_ID) — the pre-Bridge path.
+ *  3. A mocked checklist so the prototype works with neither configured.
  */
 export default function KycModal({
   open,
@@ -21,17 +26,59 @@ export default function KycModal({
   onOpenChange: (o: boolean) => void;
   onVerified: (inquiryId?: string) => void;
 }) {
-  const [step, setStep] = useState<'intro' | 'verifying' | 'done'>('intro');
+  const { configured: bridgeConfigured } = useBridge();
+  const [step, setStep] = useState<'intro' | 'name' | 'verifying' | 'done'>('intro');
   const [phase, setPhase] = useState(0);
   const [inquiryId, setInquiryId] = useState<string | undefined>(undefined);
+  const [fullName, setFullName] = useState('');
+  const [hostedUrl, setHostedUrl] = useState<string | null>(null);
+  const [starting, setStarting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const launchedRef = useRef(false);
 
   useEffect(() => {
     if (open) {
       setStep('intro');
       setInquiryId(undefined);
+      setHostedUrl(null);
+      setError(null);
     }
   }, [open]);
+
+  // Bridge: fetch the hosted link and open it. Popup blockers eat window.open inside an await, so we
+  // keep the URL around and show a manual "Open verification" link as the fallback.
+  const startBridge = async () => {
+    if (fullName.trim().length < 2) return;
+    setStarting(true);
+    setError(null);
+    const r = await startBridgeKyc(fullName.trim());
+    setStarting(false);
+    if (!r.url) {
+      setError(r.message || 'Could not start verification. Try again.');
+      return;
+    }
+    setHostedUrl(r.url);
+    window.open(r.url, '_blank', 'noopener,noreferrer');
+    setStep('verifying');
+  };
+
+  // Bridge: poll until the customer goes `active`. The user completes KYC in the other tab, so there
+  // is no callback to hang off of.
+  useEffect(() => {
+    if (step !== 'verifying' || !bridgeConfigured) return;
+    let active = true;
+    const id = setInterval(() => {
+      void getBridgeStatus()
+        .then((s) => {
+          if (active && s.verified) setStep('done');
+        })
+        .catch(() => {});
+    }, 4000);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, [step, bridgeConfigured]);
 
   useEffect(() => {
     if (step !== 'verifying') {
@@ -39,6 +86,7 @@ export default function KycModal({
       launchedRef.current = false;
       return;
     }
+    if (bridgeConfigured) return; // Bridge owns this step — see the poll above.
 
     // Real Persona embedded inquiry.
     if (PERSONA_CONFIGURED) {
@@ -70,7 +118,7 @@ export default function KycModal({
       clearTimeout(t2);
       clearTimeout(t3);
     };
-  }, [step]);
+  }, [step, bridgeConfigured]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -81,7 +129,7 @@ export default function KycModal({
               <ShieldCheck className="h-6 w-6" />
             </span>
             <h2 className="mt-3 font-display text-2xl tracking-tight text-foreground">Verify your identity</h2>
-            <p className="mt-1.5 text-sm text-muted-foreground">A quick check is required before you can move money. Takes about 2 minutes — powered by Persona.</p>
+            <p className="mt-1.5 text-sm text-muted-foreground">A quick check is required before you can move money. Takes about 2 minutes — powered by {bridgeConfigured ? 'Bridge' : 'Persona'}.</p>
 
             <div className="mt-4 space-y-2.5">
               <Need icon={IdCard} text="A government-issued photo ID" />
@@ -91,7 +139,7 @@ export default function KycModal({
 
             <button
               type="button"
-              onClick={() => setStep('verifying')}
+              onClick={() => setStep(bridgeConfigured ? 'name' : 'verifying')}
               className="mt-5 w-full rounded-xl bg-primary py-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.99]"
             >
               Start verification
@@ -110,15 +158,60 @@ export default function KycModal({
           </div>
         )}
 
+        {step === 'name' && (
+          <div className="p-5">
+            <div className="mb-1 text-base font-semibold text-foreground">Your legal name</div>
+            <p className="text-sm text-muted-foreground">Exactly as it appears on your government ID — Bridge matches it against your documents.</p>
+            <label className="mt-4 block">
+              <span className="mb-1.5 block text-xs font-medium text-muted-foreground">Full legal name</span>
+              <input
+                autoFocus
+                value={fullName}
+                onChange={(e) => setFullName(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') void startBridge(); }}
+                placeholder="Jordan Alex Rivera"
+                className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-foreground/30 focus:outline-none"
+              />
+            </label>
+            {error && <p className="mt-2 text-xs text-negative">{error}</p>}
+            <button
+              type="button"
+              onClick={() => void startBridge()}
+              disabled={fullName.trim().length < 2 || starting}
+              className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl bg-primary py-3 text-sm font-semibold text-primary-foreground transition-transform active:scale-[0.99] disabled:opacity-40"
+            >
+              {starting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              {starting ? 'Opening…' : 'Continue to verification'}
+            </button>
+            <p className="mt-3 text-center text-[11px] text-muted-foreground">Opens in a new tab. Come back here when you're done — we'll pick it up automatically.</p>
+          </div>
+        )}
+
         {step === 'verifying' && (
           <div className="p-5">
             <div className="mb-3 flex items-center justify-between">
               <span className="text-sm font-semibold text-foreground">Verifying identity</span>
               <span className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
-                <ScanLine className="h-3 w-3" /> Powered by Persona
+                <ScanLine className="h-3 w-3" /> Powered by {bridgeConfigured ? 'Bridge' : 'Persona'}
               </span>
             </div>
-            {PERSONA_CONFIGURED ? (
+            {bridgeConfigured ? (
+              <div className="flex flex-col items-center justify-center py-8 text-center">
+                <Loader2 className="h-9 w-9 animate-spin text-muted-foreground" />
+                <p className="mt-4 text-sm font-medium text-foreground">Waiting for your verification…</p>
+                <p className="mt-1 text-xs text-muted-foreground">Finish the steps in the Bridge tab. This updates on its own.</p>
+                {hostedUrl && (
+                  <a
+                    href={hostedUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-4 inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-secondary"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" /> Reopen verification
+                  </a>
+                )}
+              </div>
+            ) : PERSONA_CONFIGURED ? (
               <div className="flex flex-col items-center justify-center py-8 text-center">
                 <Loader2 className="h-9 w-9 animate-spin text-muted-foreground" />
                 <p className="mt-4 text-sm font-medium text-foreground">Opening secure verification…</p>

--- a/app/src/components/app-ui/PayModal.tsx
+++ b/app/src/components/app-ui/PayModal.tsx
@@ -163,7 +163,7 @@ export default function PayModal({
   useEffect(() => {
     if (!open || !email) return;
     let cancelled = false;
-    getBridgeVirtualAccount(email)
+    getBridgeVirtualAccount()
       .then((r) => {
         if (!cancelled) setVa(r);
       })

--- a/app/src/components/app-ui/WithdrawModal.tsx
+++ b/app/src/components/app-ui/WithdrawModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ArrowLeft, Check, ChevronDown, Landmark, Loader2, ShieldCheck, Sparkles, TriangleAlert, Wallet, Zap, type LucideIcon } from 'lucide-react';
+import { ArrowLeft, Check, ChevronDown, Clock, Landmark, Loader2, ShieldCheck, Sparkles, TriangleAlert, Wallet, Zap, type LucideIcon } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { useLinkedWallets } from '@/context/LinkedWalletsContext';
 import { useExternalAccounts } from '@/context/ExternalAccountsContext';
@@ -13,6 +13,7 @@ import { ACTIVE_CHAIN_ID, clearContracts } from '@/lib/clearNetwork';
 import { gaslessWalletTransfer } from '@/lib/gaslessMoney';
 import { track } from '@/lib/analytics';
 import { scTransferToken } from '@/lib/sendCalls';
+import { getSameDayCutoff, formatCountdown } from '@/lib/achCutoff';
 import { withdrawToBank, createRampSellSession, getRampSellStatus, rampEvent, type RampSellStatus, type Eip712TypedData } from '@/utils/apiClient';
 import { cn } from '@/lib/utils';
 
@@ -100,6 +101,9 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
   const [done, setDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [offrampStage, setOfframpStage] = useState<'idle' | 'waiting' | 'sending'>('idle');
+  // Re-evaluated every second while the same-day option is on screen so the countdown ticks and the
+  // promise flips to "next business day" the moment the cutoff passes mid-session.
+  const [cutoff, setCutoff] = useState(() => getSameDayCutoff());
   // Set while an off-ramp is awaiting the user's Coinbase confirmation; if they back out first, fire a
   // "Cash-out canceled" notification from this.
   const pendingSellRef = useRef<{ amount: number; wallet: string } | null>(null);
@@ -161,6 +165,13 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
     setBankOpen(false);
     setError(null);
   }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!open) return;
+    setCutoff(getSameDayCutoff());
+    const t = setInterval(() => setCutoff(getSameDayCutoff()), 1000);
+    return () => clearInterval(t);
+  }, [open]);
 
   useEffect(() => {
     if (step !== 'status') return;
@@ -339,7 +350,7 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
                     </span>
                     <span className="min-w-0 flex-1">
                       <span className="block text-sm font-medium text-foreground">{m.name}</span>
-                      <span className="block text-xs text-muted-foreground">{m.speed}{!m.soon && (m.instantFeeRate > 0 ? ` · ${(m.instantFeeRate * 100).toFixed(1)}% fee` : ' · Free')}</span>
+                      <span className="block text-xs text-muted-foreground">{m.id === 'bank_sd' && !cutoff.makesToday ? 'Next business day' : m.speed}{!m.soon && (m.instantFeeRate > 0 ? ` · ${(m.instantFeeRate * 100).toFixed(1)}% fee` : ' · Free')}</span>
                     </span>
                     <span className={cn('h-4 w-4 shrink-0 rounded-full border-2', active && !m.soon ? 'border-foreground bg-foreground' : 'border-border')}>
                       {active && !m.soon && <Check className="h-3 w-3 text-background" strokeWidth={3} />}
@@ -493,6 +504,37 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
                 <span className="tabular-nums text-foreground">{fmt(selected.payout)}</span>
               </div>
             </div>
+
+            {/* Same-day only actually lands today if Bridge can clear the conversion AND submit the
+                batch before its 2:30 PM ET cutoff — so say so plainly before they commit, in their
+                own timezone, and stop promising "same day" once the window has closed. */}
+            {methodId === 'bank_sd' && (
+              <div
+                className={cn(
+                  'mt-3 rounded-xl border p-3 text-[11px] leading-relaxed',
+                  cutoff.makesToday ? 'border-border text-muted-foreground' : 'border-info/40 bg-info/10 text-foreground',
+                )}
+              >
+                <div className="flex items-center justify-between gap-2 font-medium text-foreground">
+                  <span className="inline-flex items-center gap-1.5">
+                    <Clock className="h-3.5 w-3.5" />
+                    {cutoff.makesToday ? 'Arrives today' : 'Arrives next business day'}
+                  </span>
+                  {cutoff.makesToday && (
+                    <span className="shrink-0 tabular-nums font-semibold text-foreground">
+                      {formatCountdown(cutoff.msRemaining)} left
+                    </span>
+                  )}
+                </div>
+                <p className="mt-1.5">
+                  {cutoff.isWeekend
+                    ? `ACH doesn't process on weekends, so this settles the next business day. The same-day cutoff is ${cutoff.localLabel}.`
+                    : cutoff.makesToday
+                      ? `To settle today the conversion must clear and the batch must be submitted before the ${cutoff.localLabel} cutoff.`
+                      : `Today's ${cutoff.localLabel} cutoff has passed, so this settles the next business day.`}
+                </p>
+              </div>
+            )}
 
             <div className="mt-3">
               <button

--- a/app/src/components/app-ui/WithdrawModal.tsx
+++ b/app/src/components/app-ui/WithdrawModal.tsx
@@ -4,7 +4,6 @@ import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { useLinkedWallets } from '@/context/LinkedWalletsContext';
 import { useExternalAccounts } from '@/context/ExternalAccountsContext';
 import { useKyc } from '@/context/KycContext';
-import { useMemberProfile } from '@/hooks/useMemberProfile';
 import { useClearBalances } from '@/hooks/useClearBalances';
 import { useWallets } from '@privy-io/react-auth';
 import { useSmartWallets } from '@privy-io/react-auth/smart-wallets';
@@ -36,14 +35,18 @@ interface PayoutMethod {
   instantFeeRate: number;
   soon?: boolean;
 }
-// `bank`/`bank_sd` settle to a bank via the Bridge off-ramp (ACH) → need in-app KYC.
+// `bank`/`bank_sd` settle to a bank via the Bridge off-ramp → need in-app KYC.
 // `instant` (debit card) goes through Onramper's sell flow → Onramper handles KYC + payout.
+// Bridge has no instant fiat PAYOUT rail (FedNow is inbound only), so same-day ACH is the fast tier —
+// it carries our 1% developer fee, while standard ACH stays free.
 const METHODS: PayoutMethod[] = [
   { id: 'bank', name: 'Bank account', icon: Landmark, speed: '1–3 business days', instantFeeRate: 0 },
-  { id: 'bank_sd', name: 'Same-day to bank', icon: Zap, speed: 'Today by 6pm ET', instantFeeRate: 0.005 },
+  { id: 'bank_sd', name: 'Same-day to bank', icon: Zap, speed: 'Today by 6pm ET', instantFeeRate: 0.01 },
   { id: 'instant', name: 'Instant to debit card', icon: Zap, speed: 'Arrives in minutes', instantFeeRate: 0.015 },
 ];
 const BANK_METHODS = new Set(['bank', 'bank_sd']);
+/** Which Bridge payout rail each bank method maps to. */
+const BANK_RAIL: Record<string, 'ach' | 'ach_same_day'> = { bank: 'ach', bank_sd: 'ach_same_day' };
 
 interface Provider {
   id: string;
@@ -107,7 +110,6 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
   const { accounts, openManager: openAccounts } = useExternalAccounts();
   const banks = accounts.map((a) => ({ id: a.id, label: `${a.name} ••${a.mask}` }));
   const { verified, openKyc } = useKyc();
-  const { email } = useMemberProfile();
   const { address, embeddedWalletInfo } = useAppKitAccount();
   const { getClientForChain } = useSmartWallets();
   const bal = useClearBalances();
@@ -230,7 +232,7 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
 
         // Bank / same-day → Bridge ACH off-ramp.
         if (!bankId) throw new Error('Link a bank account to withdraw to.');
-        const res = await withdrawToBank(address, { amount, plaidAccountId: bankId, email: email ?? undefined });
+        const res = await withdrawToBank(address, { amount, plaidAccountId: bankId, rail: BANK_RAIL[methodId] ?? 'ach' });
         if (cancelled) return;
         if (!res.success) throw new Error(res.message || 'Withdrawal failed.');
         setDone(true);

--- a/app/src/components/app-ui/WithdrawModal.tsx
+++ b/app/src/components/app-ui/WithdrawModal.tsx
@@ -230,15 +230,35 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
           return;
         }
 
-        // Bank / same-day → Bridge ACH off-ramp.
+        // Bank / same-day → Bridge ACH off-ramp. Bridge does NOT pull from a self-custody wallet: it
+        // returns a deposit address and waits. So creating the transfer is only half the job — we then
+        // send the USDC ourselves, exactly like the Coinbase instant path above. Skipping this leaves
+        // the transfer parked in `awaiting_funds` forever while the UI claims success.
         if (!bankId) throw new Error('Link a bank account to withdraw to.');
         const res = await withdrawToBank(address, { amount, plaidAccountId: bankId, rail: BANK_RAIL[methodId] ?? 'ach' });
         if (cancelled) return;
         if (!res.success) throw new Error(res.message || 'Withdrawal failed.');
+        if (!res.depositAddress) throw new Error('Withdrawal could not be funded — nothing was sent. Try again.');
+
+        setOfframpStage('sending');
+        const bc = clearContracts(ACTIVE_CHAIN_ID);
+        if (!bc) throw new Error('Bank withdrawals are unavailable on this network.');
+        const bankIsSmartAccount = embeddedWalletInfo?.accountType === 'smartAccount';
+        const bankChainClient = bankIsSmartAccount ? await getClientForChain({ id: ACTIVE_CHAIN_ID }) : undefined;
+        await scTransferToken({
+          smartWalletClient: bankChainClient,
+          ownerWallet: address,
+          token: bc.usdc,
+          to: res.depositAddress as `0x${string}`,
+          amount: res.depositAmount || String(amount),
+          chainId: ACTIVE_CHAIN_ID,
+        });
+        if (cancelled) return;
+
         setDone(true);
         track('withdraw_completed', { method: 'bank' }); // no amounts/PII
-        // Optimistic: USDC leaves Cash now; reconciles when the off-ramp debit indexes. A linked-wallet
-        // withdraw just passed THROUGH Cash (move in, off-ramp out ≈ net 0), so skip the overlay there.
+        // Optimistic only AFTER the USDC actually left. A linked-wallet withdraw just passed THROUGH
+        // Cash (move in, off-ramp out ≈ net 0), so skip the overlay there.
         if (!sourceWallet?.external) bal.applyOptimistic(-amount, 0);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : 'Withdrawal failed.');

--- a/app/src/components/shell/AppShell.tsx
+++ b/app/src/components/shell/AppShell.tsx
@@ -58,8 +58,9 @@ export default function AppShell() {
   }, [collapsed]);
 
   return (
-    <KycProvider>
-      <BridgeProvider>
+    // Bridge wraps KYC: verification state comes FROM Bridge, so KycModal can read useBridge().
+    <BridgeProvider>
+      <KycProvider>
       <MemberProfileProvider>
       <OnboardingGate>
       <ClearBalancesProvider>
@@ -94,7 +95,7 @@ export default function AppShell() {
       </ClearBalancesProvider>
       </OnboardingGate>
       </MemberProfileProvider>
-      </BridgeProvider>
-    </KycProvider>
+      </KycProvider>
+    </BridgeProvider>
   );
 }

--- a/app/src/context/BridgeContext.tsx
+++ b/app/src/context/BridgeContext.tsx
@@ -1,22 +1,21 @@
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
-import { useKyc } from '@/context/KycContext';
-import * as bridge from '@/lib/integrations/bridge';
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useAppKitAccount } from '@/lib/walletCompat';
+import { getBridgeStatus, openBridgeVirtualAccount, type BridgeStatus } from '@/utils/apiClient';
 
 /*
- * Bridge customer + USD virtual account, modeled on Bridge's Customers API.
+ * Bridge customer + USD virtual account — the member's account & routing numbers.
  * Docs: https://apidocs.bridge.xyz/platform/customers/overview
  *
- * Real flow (SEAM): collect identity (Persona inquiry + onboarding) → POST /customers with
- * first/last name, email, birth_date, residential_address, signed_agreement_id (ToS) and
- * identifying_information, plus persona_inquiry_type / persona_idv_link so Bridge runs the KYC →
- * poll `kyc_status` (not_started → active/under_review → approved/rejected) → request the `base`
- * endorsement (USD/ACH+wire) → create a virtual account → GET its deposit instructions
- * (routing/account/bank). The `base` endorsement being `approved` is what unlocks the account.
+ * The backend (GET /api/bridge/status) resolves the Bridge customer from EVERY email Privy verified
+ * for this session, so a member who already onboarded to Bridge under a different address (Google vs
+ * email login, or via another Bridge-powered app) is matched instead of onboarded twice. Once their
+ * KYC is `active` it opens (or reads) their virtual account — USD pushed there arrives as USDC.
  *
- * Here it's mocked: provisioned automatically once KYC verifies. Replace the effect with the API.
+ * NOTE: fiat only ever moves INTO this account by push. Bridge does not debit bank accounts, so
+ * there is no "pull from my bank" rail — the deposit instructions are the on-ramp.
  */
 
-export type BridgeKycStatus = 'not_started' | 'active' | 'under_review' | 'approved' | 'rejected';
+export type BridgeKycStatus = 'not_started' | 'active' | 'under_review' | 'approved' | 'rejected' | 'incomplete' | 'paused' | 'offboarded';
 export type EndorsementStatus = 'incomplete' | 'approved' | 'revoked';
 
 export interface VirtualAccount {
@@ -25,61 +24,115 @@ export interface VirtualAccount {
   routingNumber: string;
   bankName: string;
   beneficiary: string;
+  /** Inbound rails the account accepts, e.g. ["ach_push","wire"]. */
+  paymentRails: string[];
 }
 
 interface BridgeValue {
+  configured: boolean;
   customerStatus: BridgeKycStatus;
   /** `base` endorsement = USD payments (ACH + wire + virtual accounts). */
   baseEndorsement: EndorsementStatus;
   virtualAccount: VirtualAccount;
   /** Convenience: the USD virtual account is usable. */
   ready: boolean;
+  loading: boolean;
+  /** Re-read status from Bridge (call after the member finishes hosted KYC). */
+  refresh: () => Promise<void>;
+  /** Explicitly open the USD account once verified — mints account + routing numbers. */
+  provision: () => Promise<void>;
 }
 
-const NONE: VirtualAccount = { status: 'none', accountNumber: '', routingNumber: '', bankName: '', beneficiary: '' };
+const NONE: VirtualAccount = { status: 'none', accountNumber: '', routingNumber: '', bankName: '', beneficiary: '', paymentRails: [] };
 
 const Ctx = createContext<BridgeValue | null>(null);
 
 export function useBridge(): BridgeValue {
   return (
-    useContext(Ctx) ?? { customerStatus: 'not_started', baseEndorsement: 'incomplete', virtualAccount: NONE, ready: false }
+    useContext(Ctx) ?? {
+      configured: false,
+      customerStatus: 'not_started',
+      baseEndorsement: 'incomplete',
+      virtualAccount: NONE,
+      ready: false,
+      loading: false,
+      refresh: async () => {},
+      provision: async () => {},
+    }
   );
 }
 
+function toVirtualAccount(va: BridgeStatus['virtualAccount']): VirtualAccount {
+  if (!va?.accountNumber || !va?.routingNumber) return NONE;
+  return {
+    status: 'active',
+    accountNumber: va.accountNumber,
+    routingNumber: va.routingNumber,
+    bankName: va.bankName ?? '',
+    beneficiary: va.beneficiary ?? '',
+    paymentRails: va.paymentRails ?? [],
+  };
+}
+
 export function BridgeProvider({ children }: { children: ReactNode }) {
-  const { verified, inquiryId } = useKyc();
+  const { isConnected } = useAppKitAccount();
+  const [configured, setConfigured] = useState(false);
   const [customerStatus, setCustomerStatus] = useState<BridgeKycStatus>('not_started');
   const [baseEndorsement, setBaseEndorsement] = useState<EndorsementStatus>('incomplete');
   const [virtualAccount, setVirtualAccount] = useState<VirtualAccount>(NONE);
+  const [loading, setLoading] = useState(false);
+  const inFlight = useRef(false);
 
-  // On KYC success: create the Bridge customer (passing the Persona inquiry), request the `base`
-  // endorsement, then create/fetch the virtual account. Live → backend; otherwise mock fallback.
+  const refresh = useCallback(async () => {
+    if (inFlight.current) return;
+    inFlight.current = true;
+    setLoading(true);
+    try {
+      const s = await getBridgeStatus();
+      setConfigured(s.configured);
+      setCustomerStatus((s.kycStatus as BridgeKycStatus) || 'not_started');
+      setBaseEndorsement(s.baseEndorsement ?? 'incomplete');
+      setVirtualAccount(toVirtualAccount(s.virtualAccount));
+    } catch {
+      // Leave the last known state — the UI falls back to the "verify to activate" CTA.
+    } finally {
+      inFlight.current = false;
+      setLoading(false);
+    }
+  }, []);
+
+  const provision = useCallback(async () => {
+    const r = await openBridgeVirtualAccount();
+    if (r.available && r.accountNumber && r.routingNumber) {
+      setVirtualAccount({
+        status: 'active',
+        accountNumber: r.accountNumber,
+        routingNumber: r.routingNumber,
+        bankName: r.bankName ?? '',
+        beneficiary: '',
+        paymentRails: [],
+      });
+    }
+    await refresh();
+  }, [refresh]);
+
   useEffect(() => {
-    if (!verified || customerStatus !== 'not_started') return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const customer = await bridge.createCustomer({ personaInquiryId: inquiryId });
-        if (cancelled) return;
-        setCustomerStatus(customer.kycStatus);
-        const endorsement = await bridge.ensureBaseEndorsement(customer.id);
-        if (cancelled) return;
-        setBaseEndorsement(endorsement);
-        const va = await bridge.ensureVirtualAccount(customer.id);
-        if (cancelled) return;
-        setVirtualAccount(va);
-      } catch {
-        // leave unprovisioned on failure — surfaces as the "Verify to activate" CTA.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [verified, customerStatus, inquiryId]);
+    if (!isConnected) return;
+    void refresh();
+  }, [isConnected, refresh]);
 
   return (
     <Ctx.Provider
-      value={{ customerStatus, baseEndorsement, virtualAccount, ready: virtualAccount.status === 'active' && baseEndorsement === 'approved' }}
+      value={{
+        configured,
+        customerStatus,
+        baseEndorsement,
+        virtualAccount,
+        ready: virtualAccount.status === 'active',
+        loading,
+        refresh,
+        provision,
+      }}
     >
       {children}
     </Ctx.Provider>

--- a/app/src/context/KycContext.tsx
+++ b/app/src/context/KycContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useRef, useState, type ReactNode } from 'react';
 import KycModal from '@/components/app-ui/KycModal';
+import { useBridge } from '@/context/BridgeContext';
 import { track } from '@/lib/analytics';
 
 export type KycStatus = 'unverified' | 'verified';
@@ -7,7 +8,7 @@ export type KycStatus = 'unverified' | 'verified';
 interface KycValue {
   status: KycStatus;
   verified: boolean;
-  /** Persona "passport" — reusable for Bridge/Colossus provisioning (mock id once verified). */
+  /** Bridge customer id once they exist — the reusable identity across Bridge products (cards, etc.). */
   inquiryId: string | null;
   /** Open the KYC flow; runs `onVerified` after a successful verification. */
   openKyc: (onVerified?: () => void) => void;
@@ -31,15 +32,22 @@ export function useKyc(): KycValue {
 }
 
 /**
- * KYC state for the redesign. Starts UNVERIFIED — money-movement actions (Add/Withdraw/Send/
- * Transfer/Pay/Borrow) are wrapped in `gate`, which opens the Persona KYC modal first and runs the
- * intended action on success. One verification unlocks everything (the reusable passport). Mock.
+ * KYC state, sourced from Bridge. Money-movement actions (Add/Withdraw/Send/Transfer/Pay/Borrow) are
+ * wrapped in `gate`, which opens the verification modal first and runs the intended action on success.
+ *
+ * The verdict is Bridge's: a member counts as verified when their Bridge customer status is `active`.
+ * That state lives on Bridge (not in this component), so it survives reloads and is consistent with
+ * what the backend will let them actually do. When Bridge isn't configured we fall back to the local
+ * flag so non-production environments still work.
  */
 export function KycProvider({ children }: { children: ReactNode }) {
-  const [status, setStatus] = useState<KycStatus>('unverified');
-  const [inquiryId, setInquiryId] = useState<string | null>(null);
+  const { configured, customerStatus, refresh } = useBridge();
+  const [localVerified, setLocalVerified] = useState(false);
   const [open, setOpen] = useState(false);
   const cbRef = useRef<(() => void) | null>(null);
+
+  const verified = configured ? customerStatus === 'active' : localVerified;
+  const status: KycStatus = verified ? 'verified' : 'unverified';
 
   const openKyc = (onVerified?: () => void) => {
     cbRef.current = onVerified ?? null;
@@ -47,13 +55,13 @@ export function KycProvider({ children }: { children: ReactNode }) {
     track('kyc_started');
   };
   const gate = (action: () => void) => {
-    if (status === 'verified') action();
+    if (verified) action();
     else openKyc(action);
   };
-  const handleVerified = (personaInquiryId?: string) => {
-    setStatus('verified');
+  const handleVerified = () => {
+    setLocalVerified(true);
     track('kyc_verified');
-    setInquiryId(personaInquiryId ?? `inq_${Date.now().toString(36)}`);
+    void refresh();
     setOpen(false);
     const cb = cbRef.current;
     cbRef.current = null;
@@ -61,7 +69,7 @@ export function KycProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <Ctx.Provider value={{ status, verified: status === 'verified', inquiryId, openKyc, gate }}>
+    <Ctx.Provider value={{ status, verified, inquiryId: null, openKyc, gate }}>
       {children}
       <KycModal open={open} onOpenChange={setOpen} onVerified={handleVerified} />
     </Ctx.Provider>

--- a/app/src/lib/achCutoff.ts
+++ b/app/src/lib/achCutoff.ts
@@ -1,0 +1,85 @@
+/*
+ * Same-day ACH cutoff. Bridge has to clear the USDC→USD conversion AND submit the ACH batch before
+ * its final 2:30 PM ET cutoff for a withdrawal to land the same day. Miss it (or withdraw on a
+ * weekend, when there's no ACH processing) and it settles the next business day instead.
+ *
+ * Everything here is computed in America/New_York and rendered in the member's OWN timezone, so
+ * someone in Los Angeles sees 11:30 AM and someone in London sees 7:30 PM.
+ */
+
+const CUTOFF_HOUR_ET = 14;
+const CUTOFF_MINUTE_ET = 30;
+const ET = 'America/New_York';
+
+/** Offset (ms) to add to a UTC instant to get the wall clock in `timeZone`. */
+function tzOffsetMs(date: Date, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).formatToParts(date);
+  const get = (type: string) => Number(parts.find((p) => p.type === type)?.value ?? 0);
+  // `hour` comes back as 24 at midnight in some engines — normalize so Date.UTC stays on the day.
+  const asUtc = Date.UTC(get('year'), get('month') - 1, get('day'), get('hour') % 24, get('minute'), get('second'));
+  return asUtc - date.getTime();
+}
+
+export interface SameDayCutoff {
+  /** The 2:30 PM ET cutoff for the current ET day, as an absolute instant. */
+  cutoffAt: Date;
+  /** True when a withdrawal submitted now can still make today's batch. */
+  makesToday: boolean;
+  /** ms until the cutoff; 0 once it has passed. */
+  msRemaining: number;
+  /** The cutoff in the member's local timezone, e.g. "11:30 AM PDT". */
+  localLabel: string;
+  /** What to actually promise the user. */
+  settles: 'same day' | 'next business day';
+  /** Weekends have no ACH processing at all, so the cutoff is moot. */
+  isWeekend: boolean;
+}
+
+export function getSameDayCutoff(now: Date = new Date()): SameDayCutoff {
+  const offset = tzOffsetMs(now, ET);
+  // Shift into ET wall-clock space so the UTC getters read as Eastern date parts.
+  const etWall = new Date(now.getTime() + offset);
+  const cutoffWall = Date.UTC(
+    etWall.getUTCFullYear(),
+    etWall.getUTCMonth(),
+    etWall.getUTCDate(),
+    CUTOFF_HOUR_ET,
+    CUTOFF_MINUTE_ET,
+    0,
+  );
+  const cutoffAt = new Date(cutoffWall - offset);
+
+  const etDay = etWall.getUTCDay();
+  const isWeekend = etDay === 0 || etDay === 6;
+  const msRemaining = Math.max(0, cutoffAt.getTime() - now.getTime());
+  const makesToday = !isWeekend && msRemaining > 0;
+
+  return {
+    cutoffAt,
+    makesToday,
+    msRemaining,
+    localLabel: cutoffAt.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit', timeZoneName: 'short' }),
+    settles: makesToday ? 'same day' : 'next business day',
+    isWeekend,
+  };
+}
+
+/** "1h 12m" / "8m 30s" — tightens to seconds in the last minutes so the urgency reads. */
+export function formatCountdown(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2335,8 +2335,22 @@ export async function runAutopayRule(
 export async function withdrawToBank(
   wallet: string,
   p: { amount: number; plaidAccountId: string; rail?: 'ach' | 'ach_same_day' },
-): Promise<{ success: boolean; providerReference?: string; status?: string; message?: string }> {
-  const r = await apiRequest<{ success: boolean; providerReference?: string; status?: string }>(
+): Promise<{
+  success: boolean;
+  providerReference?: string;
+  status?: string;
+  message?: string;
+  /** Bridge's deposit address — the caller MUST send USDC here to fund the transfer. */
+  depositAddress?: string;
+  depositAmount?: string;
+}> {
+  const r = await apiRequest<{
+    success: boolean;
+    providerReference?: string;
+    status?: string;
+    depositAddress?: string;
+    depositAmount?: string;
+  }>(
     `/api/withdraw/${wallet.toLowerCase()}`,
     { method: 'POST', body: JSON.stringify(p), timeout: 120000 },
   );

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -1341,9 +1341,59 @@ export interface BridgeVirtualAccount {
   accountLast4?: string | null;
 }
 
-/** The user's Bridge virtual account (USDC funding via ACH account/routing). { available:false } if none. */
-export async function getBridgeVirtualAccount(email: string): Promise<BridgeVirtualAccount> {
-  const r = await apiRequest<BridgeVirtualAccount>(`/api/bridge/virtual-account?email=${encodeURIComponent(email)}`);
+export interface BridgeStatus {
+  configured: boolean;
+  customerId?: string | null;
+  /** Which of the account's emails Bridge already knows them by, if any. */
+  matchedEmail?: string | null;
+  verified: boolean;
+  kycStatus: string;
+  tosAccepted?: boolean;
+  baseEndorsement?: 'incomplete' | 'approved' | 'revoked';
+  payinFiat?: 'pending' | 'active' | 'inactive' | 'rejected';
+  payoutFiat?: 'pending' | 'active' | 'inactive' | 'rejected';
+  rejectionReason?: string | null;
+  virtualAccount: {
+    accountNumber: string | null;
+    routingNumber: string | null;
+    bankName: string | null;
+    beneficiary: string | null;
+    paymentRails?: string[];
+  } | null;
+}
+
+/** Bridge verification + USD account state for the signed-in member. Never creates anything. */
+export async function getBridgeStatus(): Promise<BridgeStatus> {
+  const r = await apiRequest<BridgeStatus>('/api/bridge/status');
+  return r.error || !r.data
+    ? { configured: false, verified: false, kycStatus: 'not_started', virtualAccount: null }
+    : r.data;
+}
+
+/** Hosted Bridge verification link (ToS first, then KYC). Reuses an existing Bridge customer. */
+export async function startBridgeKyc(
+  fullName: string,
+): Promise<{ url?: string; kycUrl?: string | null; tosUrl?: string | null; customerId?: string | null; message?: string }> {
+  const r = await apiRequest<{ url: string; kycUrl: string | null; tosUrl: string | null; customerId: string | null }>(
+    '/api/bridge/kyc-link',
+    { method: 'POST', body: JSON.stringify({ fullName }) },
+  );
+  return r.error || !r.data ? { message: r.error || 'Could not start verification.' } : r.data;
+}
+
+/** Open (or fetch) the member's USD account — this is what mints their account + routing numbers. */
+export async function openBridgeVirtualAccount(): Promise<BridgeVirtualAccount & { message?: string }> {
+  const r = await apiRequest<BridgeVirtualAccount>('/api/bridge/virtual-account', { method: 'POST' });
+  return r.error || !r.data ? { available: false, message: r.error } : r.data;
+}
+
+/**
+ * The signed-in member's Bridge virtual account (USDC funding via ACH account/routing).
+ * { available:false } if none. The customer is resolved server-side from the emails Privy verified
+ * for this session — deliberately NOT a parameter, since the response carries bank details.
+ */
+export async function getBridgeVirtualAccount(): Promise<BridgeVirtualAccount> {
+  const r = await apiRequest<BridgeVirtualAccount>('/api/bridge/virtual-account');
   return r.error || !r.data ? { available: false } : r.data;
 }
 
@@ -2277,10 +2327,14 @@ export async function runAutopayRule(
   return r.data;
 }
 
-/** Withdraw (cash-out): USDC on Base → a Plaid-linked bank via Bridge off-ramp. */
+/**
+ * Withdraw (cash-out): USDC on Base → a Plaid-linked bank via Bridge off-ramp.
+ * `rail`: 'ach' (1–3 days, free) or 'ach_same_day' (today, carries our 1% developer fee).
+ * The Bridge customer is resolved server-side from the session's verified emails.
+ */
 export async function withdrawToBank(
   wallet: string,
-  p: { amount: number; plaidAccountId: string; email?: string },
+  p: { amount: number; plaidAccountId: string; rail?: 'ach' | 'ach_same_day' },
 ): Promise<{ success: boolean; providerReference?: string; status?: string; message?: string }> {
   const r = await apiRequest<{ success: boolean; providerReference?: string; status?: string }>(
     `/api/withdraw/${wallet.toLowerCase()}`,


### PR DESCRIPTION
Wires Bridge up properly: real hosted KYC, virtual-account provisioning, a corrected off-ramp, and the webhook that makes bank deposits visible.

## Identity
- `auth.ts` now collects **every** verified email on an account (email login + any `*_oauth`). Previously only the `email` login type was captured, so a Google- or Apple-only member had no email server-side at all and could never be matched to Bridge.
- `resolveCustomerForEmails()` probes each one so an existing Bridge customer is **reused** rather than onboarded twice. Primary lookup is `GET /customers?email=` (the `/kyc_links` index only finds link-created customers).

## KYC + virtual accounts
- `POST /api/bridge/kyc-link` returns the hosted ToS→KYC link, reusing an existing customer.
- `GET /api/bridge/status` reports verification state; `POST /api/bridge/virtual-account` opens the USD account that generates the member's account + routing numbers.

## Off-ramp correctness (behavioral change — moves real money)
Bridge **never pulls** from a self-custody wallet — it returns deposit instructions and waits. The previous code created a transfer and never funded it, so withdrawals parked in `awaiting_funds` forever while the UI reported success. Now `withdrawToBank` surfaces `source_deposit_instructions.to_address` and the client sends the USDC, with the optimistic balance decrement moved to **after** the send.
- `features.allow_any_from_address` (Bridge-recommended) since we send from the Privy smart wallet.
- `checking_or_savings` from Plaid's real subtype instead of hardcoded `checking`.
- Standard ACH free; `ach_same_day` carries `developer_fee_percent`.
- Same-day cutoff disclaimer + live countdown, DST-aware, in the member's local timezone.

## Deposits
- Bank funding is a **push** — Bridge does not debit bank accounts. The Add-money bank path now ends at the member's account/routing numbers instead of an invented rail picker (ACH free / same-day $1.50 / wire $15) that had no backend and implied a pull we can't perform.
- New Coinbase ACH option (~0.5% vs ~2.5% card), labeled for what it is: opens Coinbase, account required.
- `POST /api/webhooks/bridge` (signature-verified) emits deposit/withdrawal notifications. A push starts at the member's bank, so this is the only possible signal.
- `bridgeCustomerStore` maps `customer_id → wallet`; no webhook payload carries a wallet, so without it events are unattributable.

## Security fix
`GET /api/bridge/virtual-account` accepted an arbitrary `?email=` and returned that customer's account + routing numbers — any authenticated user could enumerate other people's bank details. It now uses only the session's Privy-verified emails.

## Required env (Railway)
- `BRIDGE_API_KEY` — set
- `BRIDGE_WEBHOOK_PUBLIC_KEY` — **not yet set**; deposit notifications fail closed until it is, and Bridge must point at `https://<backend-domain>/api/webhooks/bridge`

## Verification
Frontend typecheck + build green; server typecheck green. Cutoff logic unit-tested across DST, weekends and boundaries. **Not exercised against live Bridge** — the customer, virtual-account and transfer calls are shaped from the docs but unproven, which is what this deploy is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)