### PR TITLE
Fix: Bridge routes were gated on the verification they grant

### DIFF
--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -197,7 +197,12 @@ async function startServer() {
     app.use('/api/stripe', requireAuth, stripeRouter);
     app.use('/api/members', requireAuth, membersRouter);
     app.use('/api/plaid', requireAuth, requireMemberCapability('canUsePlaid'), plaidRouter);
-    app.use('/api/bridge', requireAuth, requireMemberCapability('canUseBridge'), bridgeRouter);
+    // NOTE: deliberately NOT behind requireMemberCapability('canUseBridge'). That capability is
+    // `verified`, and since Bridge now owns verification, gating these routes on it is circular: you
+    // could never reach /kyc-link to become verified because being unverified blocked the call.
+    // requireAuth still scopes every route to the signed-in member, and Bridge enforces its own KYC
+    // on anything that actually moves money (a virtual account can't be opened until it approves).
+    app.use('/api/bridge', requireAuth, bridgeRouter);
     app.use('/api/cards', requireAuth, cardsRouter);
     app.use('/api/send', sendRouter);
     app.use('/api/savings', requireAuth, savingsRouter);

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -1343,6 +1343,8 @@ export interface BridgeVirtualAccount {
 
 export interface BridgeStatus {
   configured: boolean;
+  /** Set when we couldn't reach /status at all — distinguishes "not set up" from "couldn't ask". */
+  error?: string;
   customerId?: string | null;
   /** Which of the account's emails Bridge already knows them by, if any. */
   matchedEmail?: string | null;
@@ -1365,9 +1367,14 @@ export interface BridgeStatus {
 /** Bridge verification + USD account state for the signed-in member. Never creates anything. */
 export async function getBridgeStatus(): Promise<BridgeStatus> {
   const r = await apiRequest<BridgeStatus>('/api/bridge/status');
-  return r.error || !r.data
-    ? { configured: false, verified: false, kycStatus: 'not_started', virtualAccount: null }
-    : r.data;
+  if (r.error || !r.data) {
+    // Every failure used to collapse into `configured: false`, so a 403, a 404 and a genuinely
+    // unconfigured backend were indistinguishable — which hid a permission deadlock behind a
+    // "verification unavailable" message. Keep the safe default, but say why.
+    console.warn('[bridge] status unavailable:', r.error);
+    return { configured: false, verified: false, kycStatus: 'not_started', virtualAccount: null, error: r.error };
+  }
+  return r.data;
 }
 
 /** Hosted Bridge verification link (ToS first, then KYC). Reuses an existing Bridge customer. */


### PR DESCRIPTION
**Deadlock.** `/api/bridge` was mounted behind `requireMemberCapability('canUseBridge')`, and:

```ts
canUseBridge: verified,   // memberStore.ts:913
```

Now that Bridge owns verification, that's circular — an unverified member got **403** on `/status` and `/kyc-link`, the exact endpoints required to *become* verified. `getBridgeStatus` swallowed the 403 into `configured: false`, so the app showed "Verification is unavailable" and money movement stayed locked with no path out.

It didn't surface earlier because the mock path verified people locally without ever calling Bridge, which then flipped the capability on.

## Fix
- Mount `/api/bridge` with `requireAuth` only. Nothing is actually loosened: routes remain scoped to the signed-in member, and Bridge enforces its own KYC on anything that moves money — a virtual account can't be opened until Bridge approves the customer.
- `getBridgeStatus` no longer collapses every failure into `configured: false`. It passes the reason through and logs it, so a 403 / 404 / genuinely-unconfigured backend are distinguishable instead of all rendering as the same generic message.

Typecheck (frontend + server) and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)