### PR TITLE
Bridge: stop proxying upstream 401 as our own auth failure

### DIFF
--- a/app/server/src/routes/bridge.ts
+++ b/app/server/src/routes/bridge.ts
@@ -362,9 +362,7 @@ router.post('/onboarding-url', async (req: Request, res: Response) => {
         );
 
         if (!createResult.ok) {
-          const status = createResult.status >= 400 && createResult.status < 500
-            ? createResult.status
-            : 502;
+          const status = upstreamStatus(createResult.status);
           return res.status(status).json({
             error: 'Failed to create Bridge onboarding link',
             message: createResult.message,
@@ -497,6 +495,18 @@ router.get('/virtual-account', async (req: Request, res: Response) => {
   }
 });
 
+/**
+ * Map an upstream Bridge status onto one we can safely return.
+ *
+ * NEVER pass 401/403 through: those are OUR auth codes, and the client reacts to a 401 by clearing
+ * the session and telling the member to sign in again. Bridge rejecting our API key would therefore
+ * present as "your session expired" — blaming the user for a server-side credential problem.
+ */
+function upstreamStatus(status: number): number {
+  if (status === 401 || status === 403) return 502; // Bridge rejected US, not the caller
+  return status >= 400 && status < 500 ? status : 502;
+}
+
 /** Emails Privy verified for THIS session — the only addresses we'll look a customer up by. */
 function sessionEmails(req: Request): string[] {
   const list = req.auth?.emails ?? (req.auth?.email ? [req.auth.email] : []);
@@ -604,7 +614,8 @@ router.post('/kyc-link', async (req: Request, res: Response) => {
       customerType: customerType === 'business' ? 'business' : 'individual',
     });
     if ('error' in result) {
-      res.status(result.status >= 400 && result.status < 500 ? result.status : 502).json({ error: result.error });
+      console.error('[bridge/kyc-link] upstream failure', { status: result.status, error: result.error });
+      res.status(upstreamStatus(result.status)).json({ error: result.error });
       return;
     }
     if (!result.url) {

--- a/app/server/src/services/bridgeCustomerService.ts
+++ b/app/server/src/services/bridgeCustomerService.ts
@@ -96,6 +96,11 @@ export async function resolveCustomerForEmails(emails: string[]): Promise<Resolv
     const byCustomer = await bridge<{ data?: BridgeCustomer[] }>(
       `/customers?email=${encodeURIComponent(email)}&limit=1`,
     );
+    // A rejected API key looks identical to "this member isn't a Bridge customer" from here, which
+    // is how a bad BRIDGE_API_KEY masqueraded as a brand-new user. Call it out in the logs.
+    if (!byCustomer.ok && (byCustomer.status === 401 || byCustomer.status === 403)) {
+      console.error('[bridge] API key rejected (%d) — check BRIDGE_API_KEY and BRIDGE_API_BASE_URL: %s', byCustomer.status, byCustomer.message);
+    }
     const customerId = byCustomer.ok ? byCustomer.data?.data?.[0]?.id : undefined;
     if (customerId) return { customerId, email };
 


### PR DESCRIPTION
`/kyc-link` forwarded Bridge's HTTP status verbatim:

```ts
res.status(result.status >= 400 && result.status < 500 ? result.status : 502)
```

When Bridge rejects **our** API key it answers **401**. We returned that 401 to the browser, and `apiClient` treats any 401 as terminal — `clearSiwxAuthToken()` plus "Authentication expired. Please reconnect and sign in again."

So an invalid `BRIDGE_API_KEY` presented as *the member's session expiring*, and signing in again could never fix it. Which is exactly the reported symptom: fresh sign-in, same error.

`/status` concealed the same fault a different way — `resolveCustomerForEmails` cannot distinguish a rejected key from "this person isn't a Bridge customer", so a bad key reported a brand-new unverified user with `configured: true`.

## Changes
- `upstreamStatus()` maps 401/403 → **502** (Bridge rejected *us*, not the caller). Other 4xx pass through; everything else is 502.
- Bridge's real error message is returned, so the KYC modal shows the actual cause instead of a session lie.
- `resolveCustomerForEmails` logs a rejected key explicitly, naming `BRIDGE_API_KEY` / `BRIDGE_API_BASE_URL`.

Server typecheck green.

**Note:** this makes the failure visible; it does not fix the credential itself. If Bridge is 401ing, the key or base URL still needs checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)