### PR TITLE
Onboarding: ask for the missing contact method + surface headless Apple Pay failures

### DIFF
--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -117,7 +117,13 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
     void rampEvent({ type: 'buy', status: 'submitted', amount, walletAddress: wallet.address, ref });
     // Apple Pay on Coinbase → headless order rendered in an in-app iframe (needs verified email + phone).
     if (methodId === 'applepay' && selected.p.id === 'coinbase' && canPayInApp) {
-      const { paymentLinkUrl } = await createRampBuyOrder({ amount, walletAddress: wallet.address, email: buyerEmail, phone: buyerPhone });
+      const { paymentLinkUrl, error: orderError } = await createRampBuyOrder({ amount, walletAddress: wallet.address, email: buyerEmail, phone: buyerPhone });
+      // Falling through to the hosted tab silently is why "Apple Pay still opens a browser page" was
+      // impossible to diagnose — the reason was returned and then discarded. Coinbase most often
+      // rejects this because the embedding domain isn't allowlisted/verified in the CDP portal.
+      if (!paymentLinkUrl) {
+        console.warn('[ramp] in-app Apple Pay unavailable, falling back to the hosted page:', orderError);
+      }
       if (paymentLinkUrl) {
         setPayUrl(paymentLinkUrl);
         setStep('pay');

--- a/app/src/pages/auth/OnboardingView.tsx
+++ b/app/src/pages/auth/OnboardingView.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { usePrivy } from '@privy-io/react-auth';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Home, Sparkles, PiggyBank, Receipt, Landmark, ShieldCheck, ArrowRight, ArrowLeft, Check,
@@ -30,13 +31,14 @@ export interface OnboardingResult {
   termsAccepted: boolean;
 }
 
-type StepId = 'welcome' | 'fund' | 'goal' | 'finish';
-const STEPS: { id: StepId; label: string }[] = [
+type StepId = 'welcome' | 'contact' | 'fund' | 'goal' | 'finish';
+const BASE_STEPS: { id: StepId; label: string }[] = [
   { id: 'welcome', label: 'Welcome' },
   { id: 'fund', label: 'Fund' },
   { id: 'goal', label: 'Goal' },
   { id: 'finish', label: 'Done' },
 ];
+const CONTACT_STEP = { id: 'contact' as StepId, label: 'Contact' };
 
 const GOALS: { id: string; icon: LucideIcon; label: string; body: string }[] = [
   { id: 'home', icon: Home, label: 'Buy a home', body: 'Work toward a debt-free Clear Deed.' },
@@ -57,6 +59,19 @@ export default function OnboardingView({
   submitting: boolean;
   error: string | null;
 }) {
+  // Sign-ups give us ONE of email or phone. Coinbase needs both verified to keep Apple Pay inside
+  // the app, and we need an email to match an existing Bridge customer — so ask for whichever is
+  // missing, once, here. Skippable: it can also be added later from Settings -> Account.
+  const { user, linkEmail, linkPhone } = usePrivy();
+  const hasEmail = Boolean(user?.email?.address || user?.google?.email || user?.apple?.email);
+  const hasPhone = Boolean(user?.phone?.number);
+  // Frozen on mount so the step list can't reshuffle underneath the user mid-flow when they link.
+  const [needsContact] = useState(() => !hasEmail || !hasPhone);
+  const STEPS = useMemo(
+    () => (needsContact ? [BASE_STEPS[0], CONTACT_STEP, ...BASE_STEPS.slice(1)] : BASE_STEPS),
+    [needsContact],
+  );
+
   const [stepIdx, setStepIdx] = useState(0);
   const step = STEPS[stepIdx].id;
   const [linking, setLinking] = useState(false);
@@ -132,6 +147,37 @@ export default function OnboardingView({
                     <Step n={1} icon={Landmark} title="Link your bank" body="Add money in seconds, when you're ready." />
                     <Step n={2} icon={Sparkles} title="Set your goal" body="We'll tailor your path to ownership." />
                     <Step n={3} icon={Home} title="Start building equity" body="Every payment moves you forward." />
+                  </div>
+                </div>
+              )}
+
+              {step === 'contact' && (
+                <div>
+                  <h1 className="font-display text-[2.25rem] leading-[1.05] tracking-tight text-foreground">
+                    {hasEmail ? 'Add your phone' : 'Add your email'}
+                  </h1>
+                  <p className="mt-2 text-[15px] text-muted-foreground">
+                    {hasEmail
+                      ? 'A verified number lets you pay with Apple Pay without leaving the app, and keeps you posted when money moves.'
+                      : 'We use your email for receipts and to recognise you across our payment partners.'}
+                  </p>
+                  <div className="mt-8 space-y-3">
+                    <button
+                      type="button"
+                      onClick={() => (hasEmail ? linkPhone() : linkEmail())}
+                      className="flex w-full items-center gap-3 rounded-2xl border border-border p-4 text-left transition-colors hover:bg-secondary/50"
+                    >
+                      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-secondary text-foreground">
+                        <ShieldCheck className="h-5 w-5" />
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block text-[15px] font-medium text-foreground">
+                          {hasEmail ? 'Verify a phone number' : 'Verify an email address'}
+                        </span>
+                        <span className="block text-sm text-muted-foreground">Takes a few seconds — we'll send a code.</span>
+                      </span>
+                      {(hasEmail ? hasPhone : hasEmail) ? <Check className="h-5 w-5 shrink-0 text-positive" /> : <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
+                    </button>
                   </div>
                 </div>
               )}
@@ -229,7 +275,7 @@ export default function OnboardingView({
               >
                 {step === 'welcome' ? 'Get started' : 'Continue'} <ArrowRight className="h-4 w-4" />
               </button>
-              {(step === 'fund' || step === 'goal') && (
+              {(step === 'fund' || step === 'goal' || step === 'contact') && (
                 <button type="button" onClick={next} className="mt-2 w-full rounded-xl py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground">
                   Skip for now
                 </button>


### PR DESCRIPTION
## Onboarding contact step
A sign-up gives us **one** of email or phone. Coinbase needs **both** verified to keep Apple Pay in-app, and we need an email to match an existing Bridge customer. So whichever is missing is now asked for once during onboarding via Privy's `linkEmail` / `linkPhone`.

- Skippable, and still available from **Settings → Account**.
- Omitted entirely when both are already present.
- Step list frozen on mount, so it can't reshuffle under the user when they link mid-flow.

## Why Apple Pay still opened a browser page
`handleConfirm` destructured only `paymentLinkUrl` and dropped `error`:

```ts
const { paymentLinkUrl } = await createRampBuyOrder({...});
if (paymentLinkUrl) { /* in-app */ }
// else fall through to window.open — reason discarded
```

The backend returns a real message and `createRampBuyOrder` passes it back; the client threw it away. So a failing headless order silently became a hosted new tab — the exact reported symptom, with a phone linked. The URL in the screenshot (`pay.coinbase.com/buy/one-click`) confirms it took the hosted path.

The reason is now logged as `[ramp] in-app Apple Pay unavailable, falling back to the hosted page: …`.

**Most likely cause:** the embedding domain isn't allowlisted/verified in the CDP portal — a config step, not code. The console line will confirm.

Typecheck + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)