### PR TITLE
Hosted-only Coinbase by default; real deposit limits; withdraw balance check

### DIFF
--- a/app/server/src/routes/ramp.ts
+++ b/app/server/src/routes/ramp.ts
@@ -81,6 +81,25 @@ router.get('/config', (_req: Request, res: Response) => {
   res.json({ provider: p, configured: p === 'coinbase' ? coinbaseOnrampService.isConfigured() : Boolean(onramperKey()) });
 });
 
+// GET /api/ramp/buy/limits?country=&subdivision= → per-payment-method { min, max }, straight from
+// Coinbase. Returns {} when unavailable so the client keeps its conservative defaults.
+router.get('/buy/limits', async (req: Request, res: Response) => {
+  if (provider() !== 'coinbase' || !coinbaseOnrampService.isConfigured()) {
+    res.json({ limits: {} });
+    return;
+  }
+  try {
+    const limits = await coinbaseOnrampService.buyLimits({
+      country: String(req.query.country || 'US'),
+      subdivision: req.query.subdivision ? String(req.query.subdivision) : undefined,
+    });
+    res.json({ limits });
+  } catch (error: any) {
+    console.warn('[ramp/buy/limits]', error?.status, error?.message || error);
+    res.json({ limits: {} });
+  }
+});
+
 // GET /api/ramp/buy/quote?amount=&paymentMethod=&country=&subdivision=  → best/normalized buy quote
 router.get('/buy/quote', async (req: Request, res: Response) => {
   const amount = Number(req.query.amount);

--- a/app/server/src/services/coinbaseOnrampService.ts
+++ b/app/server/src/services/coinbaseOnrampService.ts
@@ -133,6 +133,27 @@ export const coinbaseOnrampService = {
   },
 
   /** Buy quote (fees + rate) for a fiat amount → USDC on Base. Normalized to the app's quote shape. */
+  /**
+   * Per-payment-method min/max for buying. Coinbase does NOT publish these — the docs say to read
+   * them at runtime from Get Buy Options — and they differ by method (a card minimum is not an ACH
+   * minimum). Hardcoding a floor guarantees either rejected checkouts or an artificially high limit.
+   */
+  async buyLimits(params: { country?: string; subdivision?: string } = {}): Promise<Record<string, { min: number; max: number }>> {
+    const q = new URLSearchParams({ country: (params.country ?? 'US').toUpperCase() });
+    if (params.subdivision) q.set('subdivision', params.subdivision.toUpperCase());
+    const data = await this.apiFetch('GET', `/onramp/v1/buy/options?${q.toString()}`);
+    const currencies: any[] = data?.payment_currencies ?? data?.paymentCurrencies ?? [];
+    const usd = currencies.find((c) => String(c?.id ?? '').toUpperCase() === 'USD') ?? currencies[0];
+    const out: Record<string, { min: number; max: number }> = {};
+    for (const l of usd?.limits ?? []) {
+      const id = String(l?.id ?? '').toUpperCase();
+      const min = Number(l?.min);
+      const max = Number(l?.max);
+      if (id && Number.isFinite(min) && Number.isFinite(max)) out[id] = { min, max };
+    }
+    return out;
+  },
+
   async buyQuote(params: {
     amount: number;
     fiat?: string;

--- a/app/src/components/app-ui/AddMoneyModal.tsx
+++ b/app/src/components/app-ui/AddMoneyModal.tsx
@@ -5,7 +5,7 @@ import { useLinkedWallets } from '@/context/LinkedWalletsContext';
 import { track } from '@/lib/analytics';
 import DepositInstructions from '@/components/app-ui/DepositInstructions';
 import { usePrivy } from '@privy-io/react-auth';
-import { getRampBuyQuote, createRampBuySession, createRampBuyOrder, getRampConfig, getRampBuyStatus, rampEvent, type RampQuote } from '@/utils/apiClient';
+import { getRampBuyQuote, createRampBuySession, createRampBuyOrder, getRampConfig, getRampBuyLimits, getRampBuyStatus, rampEvent, type RampQuote } from '@/utils/apiClient';
 import { useClearBalances } from '@/hooks/useClearBalances';
 import { cn } from '@/lib/utils';
 
@@ -28,10 +28,10 @@ interface PayMethod {
   speed: string;
 }
 const METHODS: PayMethod[] = [
-  // Coinbase's headless (in-app) API supports Apple Pay and Google Pay ONLY — card and ACH have no
-  // embedded flow, so they necessarily open Coinbase's hosted page. Say which is which.
+  // Every paid method runs on Coinbase's hosted page (see HEADLESS_ENABLED below for why the
+  // embedded Apple Pay flow is off), so none of them should imply otherwise.
   { id: 'card', name: 'Debit or credit card', icon: CreditCard, speed: 'Instant · opens Coinbase' },
-  { id: 'applepay', name: 'Apple Pay', icon: Smartphone, speed: 'Instant · stays in the app' },
+  { id: 'applepay', name: 'Apple Pay', icon: Smartphone, speed: 'Instant · opens Coinbase' },
   // Coinbase ACH is the cheap card alternative, but it's the one method that can't be a guest
   // checkout — Coinbase requires a signed-in account and it only runs in their hosted widget. Say so
   // up front rather than dumping the member on a login screen after they've committed to an amount.
@@ -68,6 +68,15 @@ const rampPM = (methodId: string) => (methodId === 'applepay' ? 'applepay' : met
  * behind it, describing a pull we can't perform.
  */
 
+/*
+ * Coinbase's in-app (headless) Apple Pay is OFF by default. The integration itself is correct, but it
+ * only works once two things are done in the CDP portal: enrollment in the Apple Pay Onramp API, and
+ * the embedding domain allowlisted + verified. Until then every attempt fails and silently drops the
+ * member on Coinbase's hosted page — worse than just sending them there directly, because it looks
+ * broken. Set VITE_COINBASE_HEADLESS=1 to re-enable once CDP access is sorted.
+ */
+const HEADLESS_ENABLED = import.meta.env.VITE_COINBASE_HEADLESS === '1';
+
 const QUICK = [50, 100, 250, 500];
 const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
@@ -88,18 +97,18 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
   const [apiQuotes, setApiQuotes] = useState<QuoteVM[]>([]);
   const [quoteId, setQuoteId] = useState<string | undefined>(undefined); // locked-quote id for checkout
   const [rampConfigured, setRampConfigured] = useState<boolean | null>(null); // null = unknown yet
+  const [limits, setLimits] = useState<Record<string, { min: number; max: number }>>({});
   const [quotesLoading, setQuotesLoading] = useState(false);
   const [checkoutLoading, setCheckoutLoading] = useState(false);
   const [checkoutError, setCheckoutError] = useState<string | null>(null);
   const { wallets, primaryId, openManager } = useLinkedWallets();
-  const { user, linkPhone } = usePrivy();
+  const { user } = usePrivy();
   // Same trap as the server-side email bug: `user.email` only exists for the EMAIL login type, so a
   // Google/Apple member had no email here and silently failed the headless check below.
   const buyerEmail = user?.email?.address || user?.google?.email || user?.apple?.email || '';
   const buyerPhone = user?.phone?.number || '';
-  // Coinbase requires a developer-verified email AND phone for the in-app (headless) flow. Without a
-  // phone we can't use it at all, which is why Apple Pay kept opening a new tab.
-  const canPayInApp = Boolean(buyerEmail && buyerPhone);
+  // Coinbase requires a developer-verified email AND phone for the in-app (headless) flow.
+  const canPayInApp = HEADLESS_ENABLED && Boolean(buyerEmail && buyerPhone);
   const bal = useClearBalances();
 
   // Card / Apple Pay: create an Onramper checkout + open the provider's hosted flow. (Bank never
@@ -202,6 +211,9 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
     if (!open) return;
     let cancelled = false;
     getRampConfig().then((c) => { if (!cancelled) setRampConfigured(c.configured); }).catch(() => { if (!cancelled) setRampConfigured(false); });
+    // Coinbase's minimums differ per payment method and aren't published, so read them rather than
+    // guessing — a hardcoded floor either blocks allowed deposits or lets through ones they'll reject.
+    getRampBuyLimits().then((l) => { if (!cancelled) setLimits(l); }).catch(() => {});
     return () => { cancelled = true; };
   }, [open]);
 
@@ -247,7 +259,12 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
   const amount = Number(amountStr) || 0;
   const method = METHODS.find((m) => m.id === methodId) ?? METHODS[0];
   const wallet = wallets.find((w) => w.id === walletId) ?? wallets[0] ?? { id: '', label: 'No wallet linked', address: '' };
-  const amountValid = amount >= 5 && amount <= 10000;
+  // Coinbase's enum for the selected method, so we can look up its real limits.
+  const COINBASE_PM: Record<string, string> = { card: 'CARD', applepay: 'APPLE_PAY', ach: 'ACH_BANK_ACCOUNT' };
+  const methodLimit = limits[COINBASE_PM[methodId] ?? ''];
+  const minAmount = methodLimit?.min ?? 5;
+  const maxAmount = methodLimit?.max ?? 10000;
+  const amountValid = amount >= minAmount && amount <= maxAmount;
   const isBank = methodId === 'bank';
 
   // Coinbase's headless onramp iframe posts `onramp_api.*` events ({ eventName, data }). Once the user
@@ -413,7 +430,9 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
                 >
                   Review
                 </button>
-                <p className="mt-2 text-center text-[11px] text-muted-foreground">{amount > 10000 ? 'Max $10,000 per transaction' : 'Add $5–$10,000'}</p>
+                <p className="mt-2 text-center text-[11px] text-muted-foreground">
+                  {amount > maxAmount ? `Max ${fmt(maxAmount)} per transaction` : `Add ${fmt(minAmount)}–${fmt(maxAmount)}`}
+                </p>
               </>
             )}
           </div>
@@ -577,27 +596,6 @@ export default function AddMoneyModal({ open, onOpenChange }: { open: boolean; o
               {checkoutLoading ? <><Loader2 className="h-4 w-4 animate-spin" /> Starting…</> : `Add ${fmt(amount)}`}
             </button>
             {checkoutError && <p className="mt-2 text-center text-[11px] text-negative">{checkoutError}</p>}
-            {/* Apple Pay is the only method Coinbase can embed, and it needs a verified phone. Offer to
-                add one instead of silently bouncing them to a new tab and leaving them wondering. */}
-            {methodId === 'applepay' && !canPayInApp && (
-              <div className="mt-2 rounded-lg border border-border p-2.5">
-                <p className="flex items-start gap-1.5 text-[11px] leading-relaxed text-muted-foreground">
-                  <Smartphone className="mt-px h-3 w-3 shrink-0" />
-                  {buyerPhone
-                    ? 'Add an email to your account to pay without leaving the app. Otherwise Apple Pay opens in a new tab.'
-                    : 'Coinbase needs a verified phone number to keep Apple Pay inside the app. Without one it opens in a new tab.'}
-                </p>
-                {!buyerPhone && (
-                  <button
-                    type="button"
-                    onClick={() => linkPhone()}
-                    className="mt-2 w-full rounded-full border border-border py-1.5 text-[11px] font-semibold text-foreground transition-colors hover:bg-secondary"
-                  >
-                    Add a phone number
-                  </button>
-                )}
-              </div>
-            )}
             {methodId === 'ach' && (
               <p className="mt-2 flex items-start gap-1.5 rounded-lg border border-border p-2.5 text-[11px] leading-relaxed text-muted-foreground">
                 <Landmark className="mt-px h-3 w-3 shrink-0" />

--- a/app/src/components/app-ui/SettingsModals.tsx
+++ b/app/src/components/app-ui/SettingsModals.tsx
@@ -207,8 +207,7 @@ export function AccountModal({ open, onOpenChange }: ModalProps) {
                   <span className="truncate">{accountPhone}</span>
                 </div>
               )}
-              {/* A verified phone is what lets Coinbase keep Apple Pay inside the app instead of
-                  handing the member off to a new tab — so it belongs here, not only mid-deposit. */}
+              {/* Used for payment receipts, security alerts and account recovery. */}
               {!accountPhone && (
                 <button
                   type="button"
@@ -218,7 +217,7 @@ export function AccountModal({ open, onOpenChange }: ModalProps) {
                   <Smartphone className="h-4 w-4 shrink-0 text-muted-foreground" />
                   <span className="min-w-0 flex-1">
                     <span className="block text-sm font-medium text-foreground">Add a phone number</span>
-                    <span className="block text-[11px] text-muted-foreground">Lets you pay with Apple Pay without leaving the app.</span>
+                    <span className="block text-[11px] text-muted-foreground">For payment receipts, security alerts and account recovery.</span>
                   </span>
                   <span className="shrink-0 text-xs font-semibold text-info">Add</span>
                 </button>

--- a/app/src/components/app-ui/WithdrawModal.tsx
+++ b/app/src/components/app-ui/WithdrawModal.tsx
@@ -288,7 +288,13 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
   const selected = (providerId ? quotes.find((q) => q.p.id === providerId) : null) ?? best;
   const wallet = wallets.find((w) => w.id === walletId) ?? wallets[0] ?? { id: '', label: 'No wallet linked', address: '' };
   const bank = banks.find((b) => b.id === bankId) ?? banks[0] ?? { id: '', label: 'No bank linked' };
-  const amountValid = amount >= 5 && amount <= 10000;
+  // You can only take out what's actually there. Withdrawing from the Clear wallet draws on Cash, so
+  // that balance is the ceiling; an external linked wallet is swept into Cash first, and we don't hold
+  // its balance here, so we can't cap that case client-side (Bridge/the transfer will reject it).
+  const selectedWallet = wallets.find((w) => w.id === walletId) ?? wallets[0];
+  const available = selectedWallet?.external ? null : bal.cash;
+  const overBalance = available != null && amount > available;
+  const amountValid = amount >= 5 && amount <= 10000 && !overBalance;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -323,6 +329,20 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
                   ${q}
                 </button>
               ))}
+              {available != null && available > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setAmountStr(String(Math.floor(available * 100) / 100))}
+                  className={cn(
+                    'flex-1 rounded-lg border py-1.5 text-sm font-medium transition-colors',
+                    amount > 0 && amount === Math.floor(available * 100) / 100
+                      ? 'border-foreground bg-foreground text-background'
+                      : 'border-border text-muted-foreground hover:bg-secondary',
+                  )}
+                >
+                  Max
+                </button>
+              )}
             </div>
 
             <label className="mb-2 mt-5 block text-xs font-medium text-muted-foreground">Withdraw to</label>
@@ -378,7 +398,15 @@ export default function WithdrawModal({ open, onOpenChange }: { open: boolean; o
                 Review
               </button>
             )}
-            <p className="mt-2 text-center text-[11px] text-muted-foreground">{amount > 10000 ? 'Max $10,000 per transaction' : 'Withdraw $5–$10,000'}</p>
+            <p className={cn('mt-2 text-center text-[11px]', overBalance ? 'text-negative' : 'text-muted-foreground')}>
+              {overBalance
+                ? `You only have ${fmt(available ?? 0)} available`
+                : amount > 10000
+                  ? 'Max $10,000 per transaction'
+                  : available != null
+                    ? `${fmt(available)} available · withdraw $5–$10,000`
+                    : 'Withdraw $5–$10,000'}
+            </p>
           </div>
         )}
 

--- a/app/src/pages/auth/OnboardingView.tsx
+++ b/app/src/pages/auth/OnboardingView.tsx
@@ -158,7 +158,7 @@ export default function OnboardingView({
                   </h1>
                   <p className="mt-2 text-[15px] text-muted-foreground">
                     {hasEmail
-                      ? 'A verified number lets you pay with Apple Pay without leaving the app, and keeps you posted when money moves.'
+                      ? "We'll text you when money moves, and use it to keep your account secure."
                       : 'We use your email for receipts and to recognise you across our payment partners.'}
                   </p>
                   <div className="mt-8 space-y-3">

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2708,6 +2708,16 @@ export async function createRampBuyOrder(p: {
   return { paymentLinkUrl: r.data.paymentLinkUrl, orderId: r.data.orderId };
 }
 
+/**
+ * Per-payment-method buy limits from Coinbase, keyed by their enum (CARD, APPLE_PAY,
+ * ACH_BANK_ACCOUNT). Empty when unavailable — callers should keep a conservative default rather than
+ * assume no limit. Coinbase doesn't publish these, so they must be read at runtime.
+ */
+export async function getRampBuyLimits(): Promise<Record<string, { min: number; max: number }>> {
+  const r = await apiRequest<{ limits: Record<string, { min: number; max: number }> }>('/api/ramp/buy/limits');
+  return r.error || !r.data?.limits ? {} : r.data.limits;
+}
+
 /** Record a ramp order's status + fire a notification (deposit started/complete, cash-out sent, …). */
 export async function rampEvent(p: {
   type: 'buy' | 'sell';


### PR DESCRIPTION
## 1. Hosted path by default
The in-app (headless) Apple Pay attempt now sits behind `VITE_COINBASE_HEADLESS` (off).

The integration itself is correct — the endpoint fix landed in #378 — but it *also* requires CDP enrollment in the Apple Pay Onramp API **and** an allowlisted + verified domain. Until both are done every attempt fails and silently drops the member on Coinbase's hosted page, which reads as broken. One predictable path beats a fallback that looks like a bug. Set the flag to `1` to re-enable once CDP access is sorted.

Method labels and the phone-linking copy (Settings + onboarding) no longer promise an in-app experience — the phone is now justified by alerts/receipts/recovery, which is true regardless.

## 2. Real deposit limits
Replaces the hardcoded `$5–$10,000`. Coinbase's minimums **differ per payment method and are deliberately unpublished** — their docs say to read them at runtime from Get Buy Options. A fixed floor either blocks deposits they'd allow or admits ones they'll reject at checkout.

New `GET /api/ramp/buy/limits` → `{ CARD: {min,max}, APPLE_PAY: {...}, ACH_BANK_ACCOUNT: {...} }`. The client falls back to the previous bounds when unavailable.

> Note: this means the floor may not be **$1** — for card/Apple Pay Coinbase documents ~$5. The UI now shows whatever they actually permit rather than our guess.

## 3. Withdrawals capped at balance
There was **no balance check at all** — a member could submit a withdrawal larger than their Cash and have it fail downstream, potentially *after* the USDC send. Adds an available-balance ceiling, an inline "you only have X available", and a **Max** chip.

External linked wallets are swept into Cash before the off-ramp and we don't hold their balance client-side, so those remain unvalidated here (the transfer rejects them).

Typecheck (frontend + server) and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)