### PR TITLE
PWA: refresh on resume + pull-to-refresh

### DIFF
--- a/app/src/components/app-ui/PullToRefresh.tsx
+++ b/app/src/components/app-ui/PullToRefresh.tsx
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Loader2, ArrowDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+/*
+ * Pull-to-refresh for the installed PWA / mobile web.
+ *
+ * Backgrounded apps get their timers suspended by the OS, so an installed PWA can sit on stale data
+ * with no obvious way to force a fetch — there's no browser reload button in standalone mode. The
+ * visibility listeners handle the resume case; this covers "I'm looking at it and want it fresh now".
+ *
+ * Refresh is broadcast as `clear:activity`, the event balances, transactions and wallet balances
+ * already listen to, so there's no separate refresh path to keep in sync.
+ *
+ * Touch only: it attaches nothing on pointer devices, where the browser's own reload exists.
+ */
+
+const THRESHOLD = 68; // px of pull (after resistance) that commits to a refresh
+const MAX_PULL = 104; // clamp so the indicator can't be dragged down the whole screen
+const RESISTANCE = 0.5; // drag feels weighted rather than 1:1 with the finger
+const MIN_SPIN_MS = 550; // keep the spinner up long enough to read as deliberate, not a flicker
+
+export default function PullToRefresh({ children }: { children: React.ReactNode }) {
+  const [pull, setPull] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+  // Touch handlers are bound once; refs let them read current values without rebinding per frame.
+  const startY = useRef<number | null>(null);
+  const pullRef = useRef(0);
+  const refreshingRef = useRef(false);
+
+  const setPullBoth = useCallback((v: number) => {
+    pullRef.current = v;
+    setPull(v);
+  }, []);
+
+  const runRefresh = useCallback(async () => {
+    refreshingRef.current = true;
+    setRefreshing(true);
+    setPullBoth(THRESHOLD);
+    window.dispatchEvent(new Event('clear:activity'));
+    await new Promise((r) => setTimeout(r, MIN_SPIN_MS));
+    refreshingRef.current = false;
+    setRefreshing(false);
+    setPullBoth(0);
+  }, [setPullBoth]);
+
+  useEffect(() => {
+    // Pointer devices have a reload button; don't intercept their gestures.
+    if (typeof window === 'undefined' || !('ontouchstart' in window)) return;
+
+    const onStart = (e: TouchEvent) => {
+      if (refreshingRef.current || window.scrollY > 0 || e.touches.length !== 1) {
+        startY.current = null;
+        return;
+      }
+      startY.current = e.touches[0].clientY;
+    };
+
+    const onMove = (e: TouchEvent) => {
+      if (startY.current == null || refreshingRef.current) return;
+      // Scrolled away from the top mid-gesture → hand it back to the browser.
+      if (window.scrollY > 0) {
+        startY.current = null;
+        setPullBoth(0);
+        return;
+      }
+      const dy = e.touches[0].clientY - startY.current;
+      if (dy <= 0) {
+        setPullBoth(0);
+        return; // upward drag is a normal scroll
+      }
+      const next = Math.min(MAX_PULL, dy * RESISTANCE);
+      setPullBoth(next);
+      // Only swallow the event once it's clearly a pull, so small jitters still scroll normally.
+      if (next > 4 && e.cancelable) e.preventDefault();
+    };
+
+    const onEnd = () => {
+      if (startY.current == null) return;
+      startY.current = null;
+      if (pullRef.current >= THRESHOLD) void runRefresh();
+      else setPullBoth(0);
+    };
+
+    document.addEventListener('touchstart', onStart, { passive: true });
+    document.addEventListener('touchmove', onMove, { passive: false });
+    document.addEventListener('touchend', onEnd, { passive: true });
+    document.addEventListener('touchcancel', onEnd, { passive: true });
+    return () => {
+      document.removeEventListener('touchstart', onStart);
+      document.removeEventListener('touchmove', onMove);
+      document.removeEventListener('touchend', onEnd);
+      document.removeEventListener('touchcancel', onEnd);
+    };
+  }, [runRefresh, setPullBoth]);
+
+  const armed = pull >= THRESHOLD;
+  const progress = Math.min(1, pull / THRESHOLD);
+
+  return (
+    <div className="relative">
+      <div
+        aria-hidden={pull === 0}
+        className="pointer-events-none absolute inset-x-0 top-0 z-40 flex justify-center"
+        style={{ transform: `translateY(${Math.max(0, pull - 34)}px)`, opacity: progress }}
+      >
+        <span
+          className={cn(
+            'flex h-9 w-9 items-center justify-center rounded-full border border-border bg-background shadow-sm',
+            armed && 'border-foreground/30',
+          )}
+        >
+          {refreshing ? (
+            <Loader2 className="h-4 w-4 animate-spin text-foreground" />
+          ) : (
+            <ArrowDown
+              className={cn('h-4 w-4 text-muted-foreground transition-transform', armed && 'rotate-180 text-foreground')}
+            />
+          )}
+        </span>
+      </div>
+
+      {/* Content follows the finger, then springs back once the gesture ends. */}
+      <div
+        style={{ transform: pull > 0 ? `translateY(${pull}px)` : undefined }}
+        className={cn(startY.current == null && 'transition-transform duration-200')}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/shell/AppShell.tsx
+++ b/app/src/components/shell/AppShell.tsx
@@ -5,6 +5,7 @@ import Sidebar from './Sidebar';
 import TopBar from './TopBar';
 import SideMenu from './SideMenu';
 import TabBar from './TabBar';
+import PullToRefresh from '@/components/app-ui/PullToRefresh';
 import { KycProvider } from '@/context/KycContext';
 import { BridgeProvider } from '@/context/BridgeContext';
 import { ClearBalancesProvider } from '@/hooks/useClearBalances';
@@ -77,9 +78,11 @@ export default function AppShell() {
 
         <div className={cn('transition-[padding] duration-200', collapsed ? 'lg:pl-[76px]' : 'lg:pl-64')}>
           <TopBar onToggleSidebar={() => setCollapsed((c) => !c)} onMenuOpen={() => setMenuOpen(true)} />
-          <main className="mx-auto w-full max-w-[1400px] px-5 pb-32 pt-6 lg:px-8 lg:pb-12">
-            <Outlet />
-          </main>
+          <PullToRefresh>
+            <main className="mx-auto w-full max-w-[1400px] px-5 pb-32 pt-6 lg:px-8 lg:pb-12">
+              <Outlet />
+            </main>
+          </PullToRefresh>
         </div>
 
           <TabBar />

--- a/app/src/hooks/useClearBalances.ts
+++ b/app/src/hooks/useClearBalances.ts
@@ -105,10 +105,21 @@ export function ClearBalancesProvider({ children }: { children: ReactNode }) {
   }, [refreshTokens, pending]);
 
   // Refresh when the tab/app regains focus so returning users see fresh data without a reload.
+  //
+  // `focus` alone is not enough on mobile. Resuming a backgrounded PWA (iOS especially) fires
+  // `visibilitychange` but frequently NOT `focus`, and the OS suspends timers while backgrounded so
+  // the poll above is dead too — which is why the app had to be fully closed and reopened to show
+  // anything new. Listening to both covers browser tabs and installed apps.
   useEffect(() => {
-    const onFocus = () => void refreshTokens(true);
-    window.addEventListener('focus', onFocus);
-    return () => window.removeEventListener('focus', onFocus);
+    const onWake = () => {
+      if (document.visibilityState === 'visible') void refreshTokens(true);
+    };
+    window.addEventListener('focus', onWake);
+    document.addEventListener('visibilitychange', onWake);
+    return () => {
+      window.removeEventListener('focus', onWake);
+      document.removeEventListener('visibilitychange', onWake);
+    };
   }, [refreshTokens]);
 
   // Refresh on a money action (send/transfer/deposit landed) — refetch now and again shortly, since the


### PR DESCRIPTION
## The stale-data bug
`useClearBalances` refetched only on `window` **focus**:

```ts
window.addEventListener('focus', onFocus);
```

Resuming a backgrounded PWA — iOS especially — fires **`visibilitychange`** but frequently **not** `focus`, and the OS **suspends timers** while backgrounded so the 
poll is dead too. Net effect: the app had to be fully closed and reopened to show anything new, exactly as reported. Now listens to both.

`useNotifications` already handled `visibilitychange` correctly; balances were the gap.

## Pull-to-refresh
In standalone mode there's no browser reload button, so there was no way to force a fetch while looking at the app.

- Broadcasts **`clear:activity`** — the event balances, transactions and linked-wallet balances already listen to — so there's no second refresh path to keep in sync.
- Touch-only; pointer devices keep their native reload.
- Resistance-damped drag, arms at 68px, indicator flips when committed, minimum spinner time so it reads as deliberate rather than a flicker.
- Only engages at `scrollY === 0`, releases back to the browser if you scroll away mid-gesture, and only calls `preventDefault` once it's clearly a pull — so normal scrolling is untouched.

Typecheck + build green.

**Not verified on a real device** — the gesture is inherently touch/iOS-specific and I can't exercise it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)