### PR TITLE
Pay redesign piece 1: real bill status

### DIFF
--- a/app/server/src/services/payLedgerStore.ts
+++ b/app/server/src/services/payLedgerStore.ts
@@ -172,6 +172,8 @@ export interface Biller {
   portalUrl: string | null;
   address: string | null;
   reminders: boolean;
+  /** ISO date of the most recent recorded payment, or null. Lets the UI tell "overdue" from "paid". */
+  lastPaidAt: string | null;
 }
 
 export interface PaySummary {
@@ -204,6 +206,7 @@ function rowToBiller(r: Record<string, unknown>): Biller {
     portalUrl: r.portal_url ? String(r.portal_url) : null,
     address: r.address ? String(r.address) : null,
     reminders: r.reminders !== false,
+    lastPaidAt: r.last_paid_at ? new Date(String(r.last_paid_at)).toISOString() : null,
   };
 }
 
@@ -242,8 +245,18 @@ export const payLedgerStore = {
     const pool = getPayPool();
     if (!pool) return [];
     await ensureTables();
+    // Join the newest payment per biller: without it the client can't distinguish a bill that's
+    // genuinely overdue from one that was paid days ago, so every past-due date reads as late.
     const r = await pool.query(
-      `SELECT * FROM pay_billers WHERE wallet = $1 AND archived_at IS NULL ORDER BY type = 'rent' DESC, due_day NULLS LAST`,
+      `SELECT b.*, p.last_paid_at
+         FROM pay_billers b
+         LEFT JOIN (
+           SELECT biller_id, MAX(paid_at) AS last_paid_at
+             FROM pay_payments WHERE wallet = $1 AND biller_id IS NOT NULL
+            GROUP BY biller_id
+         ) p ON p.biller_id = b.id
+        WHERE b.wallet = $1 AND b.archived_at IS NULL
+        ORDER BY b.type = 'rent' DESC, b.due_day NULLS LAST`,
       [wallet],
     );
     return r.rows.map(rowToBiller);

--- a/app/src/context/PayContext.tsx
+++ b/app/src/context/PayContext.tsx
@@ -49,10 +49,11 @@ export interface Bill {
   portalUrl: string | null; // biller's login/pay page → "Pay on their site"
   address: string | null; // mailing address (biller info; future mailed-check option)
   reminders: boolean; // due-date reminders on/off
+  lastPaidAt: string | null; // ISO of the newest recorded payment — tells "overdue" from "already paid"
 }
 
 /** Fields a user can set/edit on a biller (id/icon derived; source/payable/payout/reminders server-controlled). */
-export type BillerDraft = Omit<Bill, 'id' | 'icon' | 'source' | 'payable' | 'payoutLast4' | 'payoutBank' | 'reminders'>;
+export type BillerDraft = Omit<Bill, 'id' | 'icon' | 'source' | 'payable' | 'payoutLast4' | 'payoutBank' | 'reminders' | 'lastPaidAt'>;
 
 /** On-time streak fallback when no summary is loaded yet. */
 export const ON_TIME_STREAK = 0;
@@ -124,6 +125,7 @@ function billerToBill(b: PayBiller): Bill {
     portalUrl: b.portalUrl,
     address: b.address,
     reminders: b.reminders,
+    lastPaidAt: b.lastPaidAt ?? null,
   };
 }
 
@@ -275,7 +277,7 @@ export function PayProvider({ children }: { children: ReactNode }) {
   const addBiller = useCallback(
     (b: BillerDraft) => {
       const tempId = `bill${Date.now()}`;
-      setBills((bs) => [...bs, { ...b, id: tempId, icon: ICONS[b.type] ?? Receipt, source: 'manual', payable: false, payoutLast4: null, payoutBank: null, reminders: true }]);
+      setBills((bs) => [...bs, { ...b, id: tempId, icon: ICONS[b.type] ?? Receipt, source: 'manual', payable: false, payoutLast4: null, payoutBank: null, reminders: true, lastPaidAt: null }]);
       if (address) {
         void addPayBiller(address, { name: b.name, payee: b.payee, type: b.type, defaultAmount: b.amount, dueDay: b.dueDay, portalUrl: b.portalUrl, address: b.address })
           .then((created) => {

--- a/app/src/lib/billStatus.ts
+++ b/app/src/lib/billStatus.ts
@@ -1,0 +1,83 @@
+/*
+ * Where a bill stands right now.
+ *
+ * Bills are monthly and identified only by a day-of-month, so "is this late?" needs both the due day
+ * AND the last payment: a bill due on the 26th is not overdue on the 28th if it was paid on the 27th.
+ * Every module on the Pay page reads status from here so the list, the attention band and the detail
+ * pane can never disagree about the same bill.
+ */
+
+export type BillStatus = 'paid' | 'overdue' | 'due-soon' | 'upcoming' | 'undated';
+
+/** Days out at which a bill starts asking for attention. */
+export const DUE_SOON_DAYS = 7;
+
+export interface BillTiming {
+  status: BillStatus;
+  /** The due date that matters right now — this cycle's if unpaid, next cycle's if already paid. */
+  dueDate: Date | null;
+  /** Whole days until due; negative means that many days late. Null when the bill has no due day. */
+  daysUntil: number | null;
+  /** Short human phrasing: "Due in 4 days", "3 days late", "Paid Jul 2". */
+  label: string;
+}
+
+const DAY_MS = 86_400_000;
+const daysInMonth = (y: number, m: number) => new Date(y, m + 1, 0).getDate();
+const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+const shortDate = (d: Date) => d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+
+/** A due date in the given month, clamped so "the 31st" still resolves in February. */
+function dueIn(year: number, month: number, dueDay: number): Date {
+  return new Date(year, month, Math.min(dueDay, daysInMonth(year, month)));
+}
+
+export function billTiming(dueDay: number | null, lastPaidAt: string | null, now: Date = new Date()): BillTiming {
+  const paid = lastPaidAt ? new Date(lastPaidAt) : null;
+  const paidValid = paid && !Number.isNaN(paid.getTime()) ? paid : null;
+
+  if (!dueDay) {
+    return {
+      status: 'undated',
+      dueDate: null,
+      daysUntil: null,
+      label: paidValid ? `Paid ${shortDate(paidValid)}` : '',
+    };
+  }
+
+  const today = startOfDay(now);
+  const thisCycleDue = dueIn(today.getFullYear(), today.getMonth(), dueDay);
+  // A payment counts for this cycle if it landed on or after the 1st of the current month.
+  const cycleStart = new Date(today.getFullYear(), today.getMonth(), 1);
+  const paidThisCycle = !!paidValid && paidValid >= cycleStart;
+
+  if (paidThisCycle && paidValid) {
+    const nextDue = dueIn(today.getFullYear(), today.getMonth() + 1, dueDay);
+    return {
+      status: 'paid',
+      dueDate: nextDue,
+      daysUntil: Math.round((nextDue.getTime() - today.getTime()) / DAY_MS),
+      label: `Paid ${shortDate(paidValid)}`,
+    };
+  }
+
+  const daysUntil = Math.round((thisCycleDue.getTime() - today.getTime()) / DAY_MS);
+
+  if (daysUntil < 0) {
+    const late = Math.abs(daysUntil);
+    return { status: 'overdue', dueDate: thisCycleDue, daysUntil, label: `${late} ${late === 1 ? 'day' : 'days'} late` };
+  }
+  if (daysUntil === 0) return { status: 'due-soon', dueDate: thisCycleDue, daysUntil, label: 'Due today' };
+  if (daysUntil <= DUE_SOON_DAYS) {
+    return { status: 'due-soon', dueDate: thisCycleDue, daysUntil, label: `Due in ${daysUntil} ${daysUntil === 1 ? 'day' : 'days'}` };
+  }
+  return { status: 'upcoming', dueDate: thisCycleDue, daysUntil, label: `Due ${shortDate(thisCycleDue)}` };
+}
+
+/** Sort key: what needs attention first — overdue, then soonest due, with paid last. */
+export function billUrgency(t: BillTiming): number {
+  if (t.status === 'overdue') return -1000 + (t.daysUntil ?? 0);
+  if (t.status === 'paid') return 9000;
+  if (t.status === 'undated') return 8000;
+  return t.daysUntil ?? 5000;
+}

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2158,6 +2158,8 @@ export interface PayBiller {
   portalUrl: string | null;
   address: string | null;
   reminders: boolean;
+  /** ISO date of the most recent recorded payment, or null — distinguishes overdue from already paid. */
+  lastPaidAt: string | null;
 }
 
 export interface PaySummary {


### PR DESCRIPTION
Foundation for the rebuilt Pay page.

Nothing in the UI could tell an **overdue** bill from one **already paid** — `PayBiller` carried a due day but no payment info, so any bill past its due date read as late.

- `listBillers` now LEFT JOINs the newest `pay_payments` row per biller, surfacing `lastPaidAt` through to `Bill`.
- `lib/billStatus.ts` derives `paid` / `overdue` / `due-soon` / `upcoming` / `undated` from due day + last payment. A payment counts for the current cycle only if it landed on or after the 1st, so paying last month doesn't clear this month's bill.
- Day-of-month clamps to short months (the 31st resolves to Feb 28).
- `billUrgency()` gives one sort order so the list, attention band and detail pane can't disagree.

Verified across cycle boundaries, overdue, due-today and Feb clamping. Typecheck (both) + build green. No UI change yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)