### PR TITLE
Accounts + Transactions: on-page layout (fewer cards)

### DIFF
--- a/app/src/components/app-ui/ClearDeedCard.tsx
+++ b/app/src/components/app-ui/ClearDeedCard.tsx
@@ -53,7 +53,7 @@ export default function ClearDeedCard({ className }: { className?: string }) {
   ].map((s) => ({ ...s, pct: srcTotal > 0 ? (s.value / srcTotal) * 100 : 0 }));
 
   return (
-    <div className={cn('relative flex flex-col overflow-hidden rounded-xl border border-border bg-card p-5', className)}>
+    <div className={cn('relative flex flex-col overflow-hidden rounded-xl border border-border p-5', className)}>
       {/* subtle flourish */}
       <div className="pointer-events-none absolute -right-10 -top-10 h-36 w-36 rounded-full bg-foreground/[0.04] blur-2xl" aria-hidden />
 

--- a/app/src/components/app-ui/DepositAccountCard.tsx
+++ b/app/src/components/app-ui/DepositAccountCard.tsx
@@ -78,7 +78,7 @@ export default function DepositAccountCard({ className }: { className?: string }
 
   return (
     <>
-      <div className={cn('overflow-hidden rounded-xl border border-border bg-card', className)}>
+      <div className={cn('overflow-hidden rounded-xl border border-border', className)}>
         <div className="flex items-center gap-2.5 border-b border-border px-5 py-3">
           <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
             <Building2 className="h-4 w-4" />

--- a/app/src/components/app-ui/RecentActivity.tsx
+++ b/app/src/components/app-ui/RecentActivity.tsx
@@ -103,7 +103,7 @@ export default function RecentActivity({ className, limit }: { className?: strin
     : filtered.slice((curPage - 1) * PAGE_SIZE, curPage * PAGE_SIZE);
 
   return (
-    <div className={cn('flex flex-col rounded-xl border border-border bg-card p-5', className)}>
+    <div className={cn('flex flex-col border-t border-border pt-5', className)}>
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-medium text-foreground">Recent activity</h3>
         {compact && (

--- a/app/src/components/app-ui/SpendHeatmap.tsx
+++ b/app/src/components/app-ui/SpendHeatmap.tsx
@@ -59,7 +59,7 @@ export default function SpendHeatmap({
   };
 
   return (
-    <div className={cn('flex flex-col rounded-xl border border-border bg-card p-5', className)}>
+    <div className={cn('flex flex-col rounded-xl border border-border p-5', className)}>
       <div className="mb-4 flex items-center justify-between">
         <span className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground">Spend this month</span>
         <div className="flex items-center gap-1">

--- a/app/src/components/app-ui/UpcomingCalendar.tsx
+++ b/app/src/components/app-ui/UpcomingCalendar.tsx
@@ -89,7 +89,7 @@ export default function UpcomingCalendar({
   };
 
   return (
-    <div className={cn('flex flex-col rounded-xl border border-border bg-card p-5', className)}>
+    <div className={cn('flex flex-col rounded-xl border border-border p-5', className)}>
       <div className="mb-4 flex items-center justify-between">
         <span className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground">Upcoming transactions</span>
         <div className="flex items-center gap-1">

--- a/app/src/components/app-ui/charts/BalanceAnalyticsChart.tsx
+++ b/app/src/components/app-ui/charts/BalanceAnalyticsChart.tsx
@@ -116,7 +116,7 @@ export default function BalanceAnalyticsChart({ className }: { className?: strin
   const up = change >= 0;
 
   return (
-    <div className={cn('flex flex-col rounded-xl border border-border bg-card p-5', className)}>
+    <div className={cn('flex flex-col rounded-xl border border-border p-5', className)}>
       <div className="flex flex-wrap gap-5 border-b border-border pb-3 text-sm">
         {METRICS.map((m) => (
           <button

--- a/app/src/components/app-ui/pay/BillActivity.tsx
+++ b/app/src/components/app-ui/pay/BillActivity.tsx
@@ -129,11 +129,11 @@ export default function BillActivity({ onSelect, bare }: { onSelect?: (id: strin
     </div>
   );
 
-  // Embedded in the detail pane's empty state it drops its own card, so we don't nest a box in a box.
   if (bare) return body;
 
+  // On the page, not a card — a divider separates it from the table above; pure info earns no box.
   return (
-    <div className="rounded-xl border border-border bg-card p-4 lg:p-5">
+    <div className="border-t border-border pt-4">
       <div className="mb-3 flex items-center gap-2">
         <span className="text-xs font-medium text-foreground">Activity</span>
         <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />

--- a/app/src/components/app-ui/pay/MonthProgress.tsx
+++ b/app/src/components/app-ui/pay/MonthProgress.tsx
@@ -47,7 +47,9 @@ export default function MonthProgress({ className }: { className?: string }) {
   const credits = summary?.equityThisMonth ?? 0;
 
   return (
-    <div className={cn('rounded-xl border border-border bg-card p-5', className)}>
+    // Transparent-bg card: it's a highlight (big figure + bar) so it keeps a grouping border, but no
+    // fill — it reads as part of the page, not a floating panel. See the on-page design principle.
+    <div className={cn('rounded-xl border border-border p-5', className)}>
       <div className="flex items-center justify-between gap-2">
         <span className="text-xs font-medium text-muted-foreground">This month's bills</span>
         <div className="flex shrink-0 items-center gap-1.5">


### PR DESCRIPTION
Applies the app-wide on-page principle to Accounts (and Transactions, via shared components).

Default is content on the page — hierarchy, spacing, dividers — with cards reserved for highlights and actions, and a transparent background when something must be carded.

- **RecentActivity** (full-width list): no card at all. A top divider separates it and content flows on the page. Shared with Transactions, so it lands on both.
- **Grid data modules → transparent** (border kept for grouping within the grid, fill dropped): `BalanceAnalyticsChart`, `UpcomingCalendar`, `SpendHeatmap`, `ClearDeedCard`, `DepositAccountCard`.
- **Left filled** as highlights/actions: `StatBar` (metrics), `CtaStack` (verify CTA), `QuickActions` tiles. Tooltips/popovers keep their fill (they float over content and need an opaque background).

Typecheck + build green. Not previewed — visual, so worth an eyeball on both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)