### PR TITLE
Charge approval, reconciliation, and the last two onboarding phases

### DIFF
--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -27,6 +27,7 @@ import portfolioRouter from './routes/portfolio.js';
 import payRouter from './routes/pay.js';
 import creditRouter from './routes/credit.js';
 import chargesRouter from './routes/charges.js';
+import { startChargeReconciler } from './services/chargeReconciler.js';
 import withdrawRouter from './routes/withdraw.js';
 import autopayRouter from './routes/autopay.js';
 import contactsRouter from './routes/contacts.js';
@@ -288,6 +289,10 @@ async function startServer() {
     startPortfolioSnapshotter().catch((error) => {
       console.error('⚠️ Portfolio snapshotter failed to start:', error);
     });
+    // Charges left mid-flight by a crash or a dropped RPC connection. Self-healing rather than
+    // something an operator has to remember, because the failure it repairs is invisible until a
+    // member complains that Approve did nothing.
+    startChargeReconciler();
     startAutopayRunner().catch((error) => {
       console.error('⚠️ Autopay runner failed to start:', error);
     });

--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -26,6 +26,7 @@ import avatarRouter from './routes/avatar.js';
 import portfolioRouter from './routes/portfolio.js';
 import payRouter from './routes/pay.js';
 import creditRouter from './routes/credit.js';
+import chargesRouter from './routes/charges.js';
 import withdrawRouter from './routes/withdraw.js';
 import autopayRouter from './routes/autopay.js';
 import contactsRouter from './routes/contacts.js';
@@ -224,6 +225,11 @@ async function startServer() {
     app.use('/api/portfolio', requireAuth, portfolioRouter);
     app.use('/api/pay', requireAuth, payRouter);
     app.use('/api/credit', requireAuth, creditRouter);
+    // Deliberately not `requireAuth` at the mount: `POST /api/charges` is a merchant device
+    // authenticating by signature, with no member session to check. The member-facing routes
+    // inside attach `requireAuth` themselves — see the note in routes/charges.ts for why that
+    // must not be left to the mount.
+    app.use('/api/charges', chargesRouter);
     app.use('/api/withdraw', requireAuth, withdrawRouter);
     app.use('/api/autopay', requireAuth, autopayRouter);
     app.use('/api/contacts', requireAuth, contactsRouter);

--- a/app/server/src/routes/charges.ts
+++ b/app/server/src/routes/charges.ts
@@ -1,0 +1,144 @@
+import { Router, type Request, type Response } from 'express';
+import { requireAuth, requireVerifiedWallet } from '../middleware/auth.js';
+import { chargeStore } from '../services/chargeStore.js';
+import {
+  approveCharge,
+  declineCharge,
+  raiseCharge,
+  CHARGE_TTL_SECONDS,
+} from '../services/chargeService.js';
+
+/*
+ * Charges: one route a merchant posts to, and three a member answers on.
+ *
+ * The asymmetry is the design. A merchant proves itself by signing — there is no merchant session,
+ * so `POST /` authenticates from the body. Every other route is the member's own session acting on
+ * their own charge, and each one re-checks that the charge is theirs rather than trusting the code:
+ * a code travels by text and text gets forwarded, so possession of one cannot be what authorises
+ * answering it.
+ *
+ * `requireAuth` is attached to those three routes individually rather than to the router, because
+ * the router cannot carry it — `POST /` has no session. That is not a stylistic choice, and getting
+ * it wrong is not a small bug: `requireVerifiedWallet` falls through to *true* when there is no
+ * `req.auth` at all, a compatibility path for routes that authenticate some other way. Without
+ * `requireAuth` in front of it, every ownership check below would pass for anyone holding a code.
+ */
+const chargesRouter = Router();
+
+/** What a member is allowed to see. Payout and the merchant's address are not their business. */
+function memberView(charge: {
+  code: string;
+  merchantName: string;
+  amountCents: number;
+  status: string;
+  splitInto: number | null;
+  planId: number | null;
+  txHash: string | null;
+  expiresAt: string;
+  createdAt: string;
+}) {
+  return {
+    code: charge.code,
+    merchantName: charge.merchantName,
+    amountCents: charge.amountCents,
+    status: charge.status,
+    splitInto: charge.splitInto,
+    planId: charge.planId,
+    txHash: charge.txHash,
+    expiresAt: charge.expiresAt,
+    createdAt: charge.createdAt,
+  };
+}
+
+/**
+ * A merchant raises a charge.
+ *
+ * Deliberately outside `requireAuth`: the caller is a merchant device, not a member session, and
+ * it authenticates with an EIP-712 signature the service verifies against the on-chain registry.
+ * Nothing here reads `req.auth`.
+ */
+chargesRouter.post('/', async (req: Request, res: Response) => {
+  const { merchant, merchantName, member, amountCents, nonce, issuedAt, signature } = req.body ?? {};
+
+  if (typeof merchant !== 'string' || typeof member !== 'string' || typeof signature !== 'string') {
+    res.status(400).json({ error: 'Invalid request', message: 'merchant, member and signature are required' });
+    return;
+  }
+
+  const result = await raiseCharge({
+    merchant,
+    merchantName: typeof merchantName === 'string' ? merchantName : '',
+    member,
+    amountCents: Number(amountCents),
+    nonce: typeof nonce === 'string' ? nonce : '',
+    issuedAt: Number(issuedAt),
+    signature,
+  });
+
+  if (!result.ok || !result.charge) {
+    // 400 rather than 401 across the board: a merchant device should not be able to tell a bad
+    // signature from an inactive registration from an over-cap amount by status code alone.
+    res.status(400).json({ error: 'Charge refused', message: result.reason ?? 'could not raise the charge' });
+    return;
+  }
+
+  res.status(201).json({
+    code: result.charge.code,
+    status: result.charge.status,
+    expiresAt: result.charge.expiresAt,
+    ttlSeconds: CHARGE_TTL_SECONDS,
+  });
+});
+
+/** The member opens it. Also what the merchant's "waiting" state is watching. */
+chargesRouter.get('/:code', requireAuth, async (req: Request, res: Response) => {
+  const charge = await chargeStore.get(req.params.code);
+  if (!charge) {
+    res.status(404).json({ error: 'Not found', message: 'No such charge.' });
+    return;
+  }
+  if (!requireVerifiedWallet(req, res, charge.memberWallet, 'charge')) return;
+
+  await chargeStore.markOpened(charge.code);
+  res.json(memberView(charge));
+});
+
+chargesRouter.post('/:code/approve', requireAuth, async (req: Request, res: Response) => {
+  const charge = await chargeStore.get(req.params.code);
+  if (!charge) {
+    res.status(404).json({ error: 'Not found', message: 'No such charge.' });
+    return;
+  }
+  if (!requireVerifiedWallet(req, res, charge.memberWallet, 'charge')) return;
+
+  const installments = Number(req.body?.installments);
+  if (!Number.isInteger(installments) || installments < 1) {
+    res.status(400).json({ error: 'Invalid split', message: 'installments must be a whole number.' });
+    return;
+  }
+
+  const result = await approveCharge(charge.code, charge.memberWallet, installments);
+  if (!result.ok || !result.charge) {
+    res.status(409).json({ error: 'Could not approve', message: result.reason ?? 'Approval failed.' });
+    return;
+  }
+  res.json(memberView(result.charge));
+});
+
+chargesRouter.post('/:code/decline', requireAuth, async (req: Request, res: Response) => {
+  const charge = await chargeStore.get(req.params.code);
+  if (!charge) {
+    res.status(404).json({ error: 'Not found', message: 'No such charge.' });
+    return;
+  }
+  if (!requireVerifiedWallet(req, res, charge.memberWallet, 'charge')) return;
+
+  const result = await declineCharge(charge.code, charge.memberWallet);
+  if (!result.ok || !result.charge) {
+    res.status(409).json({ error: 'Could not decline', message: result.reason ?? 'Decline failed.' });
+    return;
+  }
+  res.json(memberView(result.charge));
+});
+
+export default chargesRouter;

--- a/app/server/src/routes/credit.ts
+++ b/app/server/src/routes/credit.ts
@@ -2,6 +2,7 @@ import { Router, type Request, type Response } from 'express';
 import { requireWalletMatch } from '../middleware/auth.js';
 import { readChainCredit } from '../services/chain/creditReader.js';
 import { readChainEarn } from '../services/chain/earnReader.js';
+import { chargeStore } from '../services/chargeStore.js';
 
 /*
  * A member's credit line, assembled from the contracts that hold it.
@@ -39,10 +40,20 @@ creditRouter.get('/:wallet', async (req: Request, res: Response) => {
       return;
     }
 
+    const open = (credit.plans ?? []).filter((plan) => !plan.closed);
+
+    // The one thing on this route that is not from chain, and it is labelled as such below. A plan
+    // knows its merchant's address; only the charge that opened it knows the name a member would
+    // recognise. Best-effort: a shelf row with no name is a plan without a label, which is worse
+    // than the alternative but far better than failing the whole credit read over it.
+    const merchantNames = await chargeStore
+      .merchantNamesByPlanId(open.map((plan) => plan.planId))
+      .catch(() => ({} as Record<number, string>));
+
     res.json({
       wallet: wallet.toLowerCase(),
       tiers: credit.tiers ?? [],
-      plans: (credit.plans ?? []).filter((plan) => !plan.closed),
+      plans: open.map((plan) => ({ ...plan, merchantName: merchantNames[plan.planId] ?? null })),
       cycle: credit.cycle,
       // Named rather than implied: everything here came from chain, and the tiers the chain does
       // not know about are absent rather than zero. The caller decides what to do about that.

--- a/app/server/src/services/chain/creditReader.ts
+++ b/app/server/src/services/chain/creditReader.ts
@@ -97,6 +97,10 @@ export interface ChainTermPlan {
   installmentCents: number;
   /** What the schedule collects across its whole term, carry included. */
   scheduleTotalCents: number;
+  /** Unix seconds. The shelf shows the month a plan was opened beside its name. */
+  openedAt: number;
+  /** Carry in basis points per cycle — the rate the plan was written at, not today's. */
+  rateBps: number;
   closed: boolean;
 }
 
@@ -197,7 +201,7 @@ async function readPlans(
     const plans: ChainTermPlan[] = [];
     for (const id of ids) {
       const [plan, schedule] = await Promise.all([term.planAt(id), term.scheduleOf(id)]);
-      const [, principal, outstanding, repaid, , installments, , , closed] = plan;
+      const [, principal, outstanding, repaid, openedAt, installments, , ratePerCycle, closed] = plan;
       const [installmentAmount, scheduleTotal] = schedule;
       plans.push({
         planId: Number(id),
@@ -207,6 +211,8 @@ async function readPlans(
         installments: Number(installments),
         installmentCents: toCents(installmentAmount),
         scheduleTotalCents: toCents(scheduleTotal),
+        openedAt: Number(openedAt),
+        rateBps: Number(ratePerCycle),
         closed,
       });
     }

--- a/app/server/src/services/chargeReconciler.ts
+++ b/app/server/src/services/chargeReconciler.ts
@@ -1,0 +1,56 @@
+import { reconcileCharges } from './chargeService.js';
+
+/*
+ * The loop that ends a stuck charge's wait.
+ *
+ * Runs on a plain interval rather than a cron because the work is idempotent, cheap when there is
+ * nothing to do (one indexed query returning no rows), and only ever touches charges in
+ * `resolving` -- a set the approve path never writes to. There is no race to design around.
+ *
+ * Deliberately not eager. A charge is left alone for a couple of minutes first, because the
+ * ordinary case is simply a transaction taking longer than usual to mine, and reconciling one that
+ * was never actually stuck is work done to reach the same answer the approve call was about to
+ * reach by itself.
+ */
+const INTERVAL_MS = Number(process.env.CHARGE_RECONCILE_INTERVAL_MS || 60_000);
+const MIN_AGE_SECONDS = Number(process.env.CHARGE_RECONCILE_MIN_AGE_SECONDS || 120);
+
+let timer: ReturnType<typeof setInterval> | null = null;
+let running = false;
+
+export async function runChargeReconcileOnce(): Promise<void> {
+  // Overlap guard: a slow RPC must not have two passes walking the same rows. They would not
+  // corrupt anything -- `finish` only closes a row still resolving -- but it is wasted calls
+  // against a provider that is already struggling.
+  if (running) return;
+  running = true;
+  try {
+    const summary = await reconcileCharges(MIN_AGE_SECONDS);
+    if (summary.checked > 0) {
+      console.log(
+        `[charge] reconciled ${summary.checked}: ${summary.approved} approved, ` +
+          `${summary.released} released, ${summary.stillPending} still pending, ${summary.unknown} unresolved`,
+      );
+    }
+  } catch (error) {
+    console.error('[charge] reconcile pass failed', error instanceof Error ? error.message : error);
+  } finally {
+    running = false;
+  }
+}
+
+export function startChargeReconciler(): void {
+  if (timer) return;
+  // `unref` so this never holds the process open on shutdown. A pass interrupted mid-flight costs
+  // nothing: the next one asks the chain the same question and gets the same answer.
+  timer = setInterval(() => void runChargeReconcileOnce(), INTERVAL_MS);
+  timer.unref?.();
+  // One pass at boot, because the most likely reason a charge is stuck is that this process died.
+  void runChargeReconcileOnce();
+}
+
+export function stopChargeReconciler(): void {
+  if (!timer) return;
+  clearInterval(timer);
+  timer = null;
+}

--- a/app/server/src/services/chargeService.ts
+++ b/app/server/src/services/chargeService.ts
@@ -329,6 +329,9 @@ export async function approveCharge(
       cycle,
     );
     submitted = true;
+    // Persisted before the wait, not after. If this process dies in the next few seconds, the hash
+    // is the difference between a charge that reconciles itself and one that needs a person.
+    await chargeStore.markSubmitted(code, tx.hash);
     const receipt = await tx.wait();
 
     let planId: number | undefined;
@@ -366,4 +369,127 @@ export async function approveCharge(
     console.error('[charge] submitted but unconfirmed — left resolving for reconciliation:', code);
     return { ok: false, reason: 'We could not confirm this went through. Give us a moment before trying again.' };
   }
+}
+
+/**
+ * Charges left mid-flight, resolved against the chain.
+ *
+ * A charge goes `resolving` the moment it is claimed and stays there until the receipt comes back.
+ * If the process dies in that window — or the RPC connection drops, which from here looks exactly
+ * like a revert — nobody can say whether the plan was opened. Approving again could open a second
+ * plan for one repair; releasing it could do the same. So it waits, and this is what ends the wait.
+ *
+ * It asks one exact question rather than guessing: the transaction hash was written before the
+ * wait began, so there is a specific transaction to look up. Three answers and each is definite:
+ *
+ * - **mined and succeeded** → the plan exists; record it and mark the charge approved
+ * - **mined and reverted** → nothing was opened; hand the charge back so it can be answered again
+ * - **gone from the node entirely** → dropped without mining; hand it back
+ *
+ * A transaction still sitting in the mempool is left alone. That is the case a time-based rule
+ * would get wrong: an underpriced transaction can sit for a long while and then land, and a sweep
+ * that released the charge because "ten minutes is surely enough" would be the thing that opened
+ * the second plan.
+ *
+ * Safe to run concurrently and safe to run twice. `finish` only closes a row that is still
+ * `resolving`, so a second runner arriving behind the first does nothing.
+ */
+export interface ReconcileSummary {
+  checked: number;
+  approved: number;
+  released: number;
+  stillPending: number;
+  unknown: number;
+}
+
+export async function reconcileCharges(olderThanSeconds = 120): Promise<ReconcileSummary> {
+  const summary: ReconcileSummary = { checked: 0, approved: 0, released: 0, stillPending: 0, unknown: 0 };
+
+  const stuck = await chargeStore.listStuck(olderThanSeconds);
+  if (stuck.length === 0) return summary;
+
+  const termIssuerAddress = getContractAddress(chainId(), 'TermIssuer');
+  const rpc = provider();
+  const iface = new ethers.Interface(TERM_ISSUER_ABI);
+
+  for (const charge of stuck) {
+    summary.checked += 1;
+
+    // Claimed but never submitted — the process died between the two. Nothing can have happened
+    // on chain, so this one is simply answerable again.
+    if (!charge.txHash) {
+      await chargeStore.release(charge.code);
+      summary.released += 1;
+      continue;
+    }
+
+    try {
+      const receipt = await rpc.getTransactionReceipt(charge.txHash);
+
+      if (!receipt) {
+        // No receipt yet. Still in the mempool is a different thing from dropped, and only the
+        // second is safe to act on.
+        const tx = await rpc.getTransaction(charge.txHash);
+        if (tx) {
+          summary.stillPending += 1;
+        } else {
+          await chargeStore.release(charge.code);
+          summary.released += 1;
+        }
+        continue;
+      }
+
+      if (receipt.status === 0) {
+        await chargeStore.release(charge.code);
+        summary.released += 1;
+        continue;
+      }
+
+      let planId: number | undefined;
+      for (const log of receipt.logs) {
+        if (termIssuerAddress && log.address.toLowerCase() !== termIssuerAddress.toLowerCase()) continue;
+        try {
+          const parsed = iface.parseLog({ topics: [...log.topics], data: log.data });
+          if (parsed?.name === 'PlanOpened') planId = Number(parsed.args.planId);
+        } catch {
+          /* not our event */
+        }
+      }
+
+      // A successful receipt with no PlanOpened in it should not happen, and is not something to
+      // paper over with a release: the transaction succeeded, so releasing could open a second
+      // plan. Left alone and counted, so it shows up rather than being decided wrongly.
+      if (planId === undefined) {
+        console.error('[charge] mined without PlanOpened — leaving for review:', charge.code, charge.txHash);
+        summary.unknown += 1;
+        continue;
+      }
+
+      await chargeStore.finish(charge.code, {
+        status: 'approved',
+        splitInto: charge.splitInto ?? undefined,
+        planId,
+        txHash: charge.txHash,
+      });
+      summary.approved += 1;
+
+      // The member pressed Approve and never saw it land. Tell them it did.
+      await notificationStore
+        .emit({
+          wallet: charge.memberWallet,
+          kind: 'credit',
+          title: 'Your plan is open',
+          body: `${charge.merchantName} · ${(charge.amountCents / 100).toLocaleString('en-US', { style: 'currency', currency: 'USD' })}`,
+          data: { chargeCode: charge.code, planId },
+          dedupeKey: `charge-approved:${charge.code}`,
+        })
+        .catch(() => {});
+    } catch (error) {
+      // An unreadable chain is not an answer. Left as it is for the next run.
+      console.error('[charge] reconcile failed for', charge.code, error instanceof Error ? error.message : error);
+      summary.unknown += 1;
+    }
+  }
+
+  return summary;
 }

--- a/app/server/src/services/chargeService.ts
+++ b/app/server/src/services/chargeService.ts
@@ -1,0 +1,369 @@
+import { ethers } from 'ethers';
+import { getContractAddress } from '../config/contracts.js';
+import { savingsIntentService } from './savingsIntentService.js';
+import { chargeStore, type ChargeRow } from './chargeStore.js';
+import { notificationStore } from './notificationStore.js';
+import { sendNotificationService } from './sendNotificationService.js';
+import { memberStore } from './memberStore.js';
+
+/*
+ * Raising a charge, and a member answering it.
+ *
+ * The split is chosen on the member's phone and nowhere else -- a service writer must not be
+ * picking somebody's repayment terms -- so a merchant's request carries an amount and a member and
+ * nothing about how it will be repaid. `installments` only ever arrives on the approve call, from
+ * the member's own session.
+ *
+ * ## How a merchant proves who it is
+ *
+ * There is no merchant account system, and inventing one would mean inventing the credential
+ * store, the rotation and the recovery that go with it. There is already an on-chain
+ * `MerchantRegistry` keyed by address, with an active flag and a per-charge approval cap, so a
+ * merchant authenticates the way every other actor in this system does: it signs. The server
+ * recovers the address from an EIP-712 signature and asks the registry whether that address is a
+ * merchant in good standing.
+ *
+ * That gives the cap and the discount for free, and both are enforced here rather than trusted:
+ * the amount is checked against `approvalCapOf`, and the payout is computed from `discountBpsOf`
+ * rather than from anything the merchant sent.
+ */
+
+const MERCHANT_ABI = [
+  'function isActive(address merchant) view returns (bool)',
+  'function isRegistered(address merchant) view returns (bool)',
+  'function approvalCapOf(address merchant) view returns (uint256)',
+  'function discountBpsOf(address merchant) view returns (uint256)',
+];
+
+const TERM_ISSUER_ABI = [
+  'function openPlan(address member, address merchant, uint256 purchase, uint256 payout, uint256 ratePerCycle, uint64 cycleLength, uint32 installments, uint64 installmentLength) returns (uint256)',
+  'function isOfferedSplit(uint32 installments) pure returns (bool)',
+  'function termLimitOf(address) view returns (uint256)',
+  'function totalPrincipalOf(address member) view returns (uint256)',
+  'event PlanOpened(uint256 indexed planId, address indexed member, uint256 purchase, uint256 ratePerCycle, uint32 installments)',
+];
+
+const ISSUER_ABI = ['function cycleLength() view returns (uint64)'];
+
+/** A charge is answerable for a day. The reference says so on the screen, so it is not a knob. */
+export const CHARGE_TTL_SECONDS = 24 * 60 * 60;
+
+/** 2% a cycle on what is still owed — the figure the approval screen quotes. */
+const DEFAULT_RATE_BPS = 200;
+
+export function chainId(): number {
+  const raw = (process.env.SAVINGS_DEFAULT_CHAIN_ID || process.env.SEND_DEFAULT_CHAIN_ID || '').trim();
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 84532;
+}
+
+function operatorKey(): string | null {
+  const raw = (process.env.CREDIT_OPERATOR_PRIVATE_KEY || process.env.DEPLOYER_PRIVATE_KEY || '').trim();
+  if (!raw) return null;
+  return raw.startsWith('0x') ? raw : `0x${raw}`;
+}
+
+function provider(): ethers.JsonRpcProvider {
+  return new ethers.JsonRpcProvider(savingsIntentService.resolveRpcUrl(chainId()));
+}
+
+/**
+ * The typed data a merchant signs to raise a charge.
+ *
+ * `nonce` and `issuedAt` are in the payload because without them a captured signature is a
+ * reusable licence to charge the same member the same amount forever. The server checks the age
+ * and the registry checks the cap; together that bounds what a leaked signature can do to one
+ * charge inside a short window, against one member, under a cap the co-op set.
+ */
+export function chargeTypedData(input: {
+  merchant: string;
+  member: string;
+  amountCents: number;
+  nonce: string;
+  issuedAt: number;
+}) {
+  return {
+    domain: {
+      name: 'Clear Charge',
+      version: '1',
+      chainId: chainId(),
+      verifyingContract: getContractAddress(chainId(), 'MerchantRegistry') || ethers.ZeroAddress,
+    },
+    types: {
+      Charge: [
+        { name: 'merchant', type: 'address' },
+        { name: 'member', type: 'address' },
+        { name: 'amountCents', type: 'uint256' },
+        { name: 'nonce', type: 'string' },
+        { name: 'issuedAt', type: 'uint256' },
+      ],
+    },
+    message: {
+      merchant: input.merchant,
+      member: input.member,
+      amountCents: input.amountCents,
+      nonce: input.nonce,
+      issuedAt: input.issuedAt,
+    },
+  };
+}
+
+/** A signature older than this is refused however valid it is. */
+const SIGNATURE_MAX_AGE_SECONDS = 5 * 60;
+
+export interface RaiseResult {
+  ok: boolean;
+  charge?: ChargeRow;
+  reason?: string;
+}
+
+export async function raiseCharge(input: {
+  merchant: string;
+  merchantName: string;
+  member: string;
+  amountCents: number;
+  nonce: string;
+  issuedAt: number;
+  signature: string;
+}): Promise<RaiseResult> {
+  if (!Number.isInteger(input.amountCents) || input.amountCents <= 0) {
+    return { ok: false, reason: 'amount must be a positive whole number of cents' };
+  }
+
+  const age = Math.floor(Date.now() / 1000) - input.issuedAt;
+  if (!Number.isFinite(age) || age > SIGNATURE_MAX_AGE_SECONDS || age < -60) {
+    return { ok: false, reason: 'signature is stale' };
+  }
+
+  const typed = chargeTypedData(input);
+  let recovered: string;
+  try {
+    recovered = ethers.verifyTypedData(typed.domain, typed.types, typed.message, input.signature);
+  } catch {
+    return { ok: false, reason: 'signature could not be verified' };
+  }
+  // The signer *is* the merchant. Taking the address from the body and the signature separately
+  // would let anyone raise a charge in somebody else's name by signing it with their own key.
+  if (recovered.toLowerCase() !== input.merchant.trim().toLowerCase()) {
+    return { ok: false, reason: 'signature does not match the merchant' };
+  }
+
+  const registryAddress = getContractAddress(chainId(), 'MerchantRegistry');
+  if (!registryAddress) return { ok: false, reason: 'no merchant registry on this chain' };
+
+  let payoutCents: number;
+  try {
+    const registry = new ethers.Contract(registryAddress, MERCHANT_ABI, provider());
+    const [active, capRaw, discountBps] = await Promise.all([
+      registry.isActive(recovered) as Promise<boolean>,
+      registry.approvalCapOf(recovered) as Promise<bigint>,
+      registry.discountBpsOf(recovered) as Promise<bigint>,
+    ]);
+    if (!active) return { ok: false, reason: 'merchant is not active' };
+
+    // The cap is in token units (6dp); the charge is in cents. Compare in cents.
+    const capCents = Number(capRaw / 10_000n);
+    if (capCents > 0 && input.amountCents > capCents) {
+      return { ok: false, reason: 'amount is over this merchant’s approval cap' };
+    }
+
+    // Computed from the registry, never from the request. A merchant that could name its own
+    // payout could name the whole purchase and leave the co-op nothing.
+    payoutCents = input.amountCents - Math.floor((input.amountCents * Number(discountBps)) / 10_000);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error';
+    console.error('[charge] registry read failed', message);
+    // A failed read is not a pass. Raising a charge on an unreadable registry would mean charging
+    // on behalf of a merchant nobody could confirm is still one.
+    return { ok: false, reason: 'could not confirm the merchant right now' };
+  }
+
+  const charge = await chargeStore.create({
+    merchantAddress: recovered,
+    merchantName: input.merchantName.trim().slice(0, 80) || 'A Clear partner',
+    memberWallet: input.member,
+    amountCents: input.amountCents,
+    payoutCents,
+    chainId: chainId(),
+    ttlSeconds: CHARGE_TTL_SECONDS,
+  });
+  if (!charge) return { ok: false, reason: 'could not record the charge' };
+
+  await notifyMember(charge);
+  return { ok: true, charge };
+}
+
+/**
+ * The alert, in the reference's own words.
+ *
+ * "You have not been charged yet" is the whole message — it is what makes the other two sentences
+ * safe to read on a lock screen, and it is why the body is not summarised or shortened here.
+ */
+export async function notifyMember(charge: ChargeRow): Promise<void> {
+  const amount = (charge.amountCents / 100).toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  });
+  const base = (process.env.APP_PUBLIC_URL || 'https://app.useclear.org').replace(/\/+$/, '');
+
+  const approveUrl = `${base}/c/${charge.code}`;
+
+  // In-app and Web Push together, deduped on the code so a retried raise cannot alert twice.
+  await notificationStore.emit({
+    wallet: charge.memberWallet,
+    kind: 'request',
+    title: `${charge.merchantName} is charging ${amount}`,
+    body: 'Approve or decline. You have not been charged yet.',
+    data: { chargeCode: charge.code, url: approveUrl, amountCents: charge.amountCents },
+    dedupeKey: `charge:${charge.code}`,
+  });
+
+  // Then the text, which the reference treats as the primary channel — a member standing at a
+  // counter has not necessarily opened the app since they installed it. Null means they opted out
+  // of notifications, which is a decision to respect rather than a lookup that failed.
+  try {
+    const contact = await memberStore.getContactByWallet(charge.memberWallet);
+    if (!contact) return;
+    const destination = contact.phone ?? contact.email;
+    if (!destination) return;
+    await sendNotificationService.sendChargeAlert({
+      recipientType: contact.phone ? 'phone' : 'email',
+      recipientContact: destination,
+      merchantName: charge.merchantName,
+      amount,
+      approveUrl,
+    });
+  } catch (error) {
+    // Never fatal to raising a charge. The member already has it in-app and on their lock screen,
+    // and failing the merchant's request because Twilio was down would be the wrong trade.
+    console.error('[charge] contact alert failed', error instanceof Error ? error.message : error);
+  }
+}
+
+export interface ResolveResult {
+  ok: boolean;
+  charge?: ChargeRow;
+  reason?: string;
+}
+
+export async function declineCharge(code: string, member: string): Promise<ResolveResult> {
+  const existing = await chargeStore.get(code);
+  if (!existing) return { ok: false, reason: 'no such charge' };
+  if (existing.memberWallet !== member.trim().toLowerCase()) {
+    return { ok: false, reason: 'not your charge' };
+  }
+  const claimed = await chargeStore.claimForResolution(code);
+  if (!claimed) return { ok: false, reason: `charge is ${existing.status}` };
+  const done = await chargeStore.finish(code, { status: 'declined' });
+  return { ok: true, charge: done ?? undefined };
+}
+
+/**
+ * Approve: open the term plan, then record it.
+ *
+ * In that order, and the order is the point. The chain is what a member actually owes; this table
+ * only describes it. Writing `approved` first and opening the plan second would leave a charge
+ * that says it was approved and a member who owes nothing — or, on a retry, two plans.
+ */
+export async function approveCharge(
+  code: string,
+  member: string,
+  installments: number,
+): Promise<ResolveResult> {
+  const existing = await chargeStore.get(code);
+  if (!existing) return { ok: false, reason: 'no such charge' };
+  if (existing.memberWallet !== member.trim().toLowerCase()) {
+    return { ok: false, reason: 'not your charge' };
+  }
+
+  const termIssuerAddress = getContractAddress(chainId(), 'TermIssuer');
+  const revolvingAddress = getContractAddress(chainId(), 'RevolvingIssuer');
+  if (!termIssuerAddress) return { ok: false, reason: 'no term issuer on this chain' };
+
+  const key = operatorKey();
+  if (!key) return { ok: false, reason: 'no credit operator configured' };
+
+  const claimed = await chargeStore.claimForResolution(code);
+  if (!claimed) return { ok: false, reason: `charge is ${existing.status}` };
+
+  // Whether a transaction ever left this process. Everything about failure handling below turns
+  // on it: before it is set, nothing can have happened on chain and the charge is safe to hand
+  // back; after, it may have landed and handing it back could open a second plan for the same
+  // purchase. Not the same question as whether the call threw.
+  let submitted = false;
+
+  try {
+    const signer = new ethers.Wallet(key, provider());
+    const issuer = new ethers.Contract(termIssuerAddress, TERM_ISSUER_ABI, signer);
+
+    // Asked rather than assumed: the offered splits are a contract rule, and a UI listing one the
+    // chain does not take would fail at the last possible moment.
+    if (!(await issuer.isOfferedSplit(installments))) {
+      await chargeStore.release(code);
+      return { ok: false, reason: 'that split is not offered' };
+    }
+
+    // One clock. The cycle comes from the revolving issuer, which is what a member's own cycle is
+    // measured against — a plan on its own schedule would come due on a day nothing else does.
+    let cycle = 30n * 24n * 60n * 60n;
+    if (revolvingAddress) {
+      try {
+        cycle = await new ethers.Contract(revolvingAddress, ISSUER_ABI, provider()).cycleLength();
+      } catch {
+        /* fall back to the network default above */
+      }
+    }
+
+    // Contract amounts are 6dp; the table is in cents.
+    const purchase = BigInt(claimed.amountCents) * 10_000n;
+    const payout = BigInt(claimed.payoutCents) * 10_000n;
+
+    const tx = await issuer.openPlan(
+      claimed.memberWallet,
+      claimed.merchantAddress,
+      purchase,
+      payout,
+      BigInt(DEFAULT_RATE_BPS),
+      cycle,
+      installments,
+      cycle,
+    );
+    submitted = true;
+    const receipt = await tx.wait();
+
+    let planId: number | undefined;
+    for (const log of receipt?.logs ?? []) {
+      try {
+        const parsed = issuer.interface.parseLog({ topics: [...log.topics], data: log.data });
+        if (parsed?.name === 'PlanOpened') planId = Number(parsed.args.planId);
+      } catch {
+        /* not our event */
+      }
+    }
+
+    const done = await chargeStore.finish(code, {
+      status: 'approved',
+      splitInto: installments,
+      planId,
+      txHash: receipt?.hash ?? tx.hash,
+    });
+    return { ok: true, charge: done ?? undefined };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error';
+    console.error('[charge] openPlan failed for', code, message);
+
+    if (!submitted) {
+      // The transaction never left, so nothing was opened and the charge is answerable again.
+      await chargeStore.release(code);
+      return { ok: false, reason: message };
+    }
+
+    // It did leave, and we do not know whether it landed -- a dropped connection while waiting
+    // for a receipt looks exactly like a revert from here. The charge stays `resolving` on
+    // purpose. Somebody has to look, and that is the right cost: releasing it would let the same
+    // purchase be approved a second time, and a member owing twice for one repair is worse than
+    // a charge that needs a human.
+    console.error('[charge] submitted but unconfirmed — left resolving for reconciliation:', code);
+    return { ok: false, reason: 'We could not confirm this went through. Give us a moment before trying again.' };
+  }
+}

--- a/app/server/src/services/chargeStore.ts
+++ b/app/server/src/services/chargeStore.ts
@@ -295,6 +295,27 @@ export const chargeStore = {
     return r.rows.map(toRow);
   },
 
+  /**
+   * The merchant behind each plan.
+   *
+   * A plan on chain knows the merchant's address and not its name, and an address is not what a
+   * member recognises on their own shelf — "Mike's Tire" is. The name lives here because this is
+   * where a human typed it, so the shelf reads it back out of the charge that opened the plan.
+   */
+  async merchantNamesByPlanId(planIds: number[]): Promise<Record<number, string>> {
+    const pool = getPostgresPool();
+    if (!pool || planIds.length === 0) return {};
+    await ensureTables();
+    const r = await pool.query<{ plan_id: string; merchant_name: string; created_at: string }>(
+      `SELECT plan_id, merchant_name, created_at FROM ${TABLE}
+        WHERE plan_id = ANY($1::bigint[]) AND status = 'approved'`,
+      [planIds],
+    );
+    const out: Record<number, string> = {};
+    for (const row of r.rows) out[Number(row.plan_id)] = row.merchant_name;
+    return out;
+  },
+
   /** Put a claimed row back when the chain call failed — it never became anything. */
   async release(code: string): Promise<void> {
     const pool = getPostgresPool();

--- a/app/server/src/services/chargeStore.ts
+++ b/app/server/src/services/chargeStore.ts
@@ -1,0 +1,266 @@
+import crypto from 'crypto';
+import { getPostgresPool } from '../config/postgres.js';
+
+/*
+ * Charges a merchant has raised against a member's Clear account.
+ *
+ * A row is a *request*, not a debt. Nothing here moves money; approving one opens a term plan on
+ * chain and that is what a member owes. The distinction runs through the whole table -- the status
+ * column is the only thing that says whether a charge became anything, and it is written in one
+ * place after the chain call returns.
+ *
+ * The code is the address. It goes out by text, so it is short enough to read aloud and random
+ * enough that guessing one is not a way to see what somebody is being charged: 8 chars of
+ * Crockford-ish base32 over a crypto RNG is ~40 bits, and a wrong guess reveals nothing because
+ * the read is member-authenticated on top.
+ */
+const TABLE = 'charge_requests';
+let ensured = false;
+
+/**
+ * `resolving` is a real, visible state, not an implementation detail.
+ *
+ * It exists for the seconds between claiming a charge and the chain call returning. If the process
+ * dies in that window the row stays here, and that is deliberate: the alternative is releasing it
+ * back to pending, where a member could approve a charge whose plan had in fact already been
+ * opened. A stuck charge is visible and fixable; a duplicate term plan is somebody owing twice.
+ */
+export type ChargeStatus = 'pending' | 'resolving' | 'approved' | 'declined' | 'expired';
+
+export interface ChargeRow {
+  code: string;
+  merchantAddress: string;
+  merchantName: string;
+  memberWallet: string;
+  amountCents: number;
+  /** What the merchant receives, after their discount. The difference is the co-op's. */
+  payoutCents: number;
+  status: ChargeStatus;
+  /** Only once approved. */
+  splitInto: number | null;
+  planId: number | null;
+  txHash: string | null;
+  chainId: number;
+  expiresAt: string;
+  createdAt: string;
+  resolvedAt: string | null;
+  /** Set the first time the member opens it — the merchant's "waiting" state reads this. */
+  openedAt: string | null;
+}
+
+interface DbRow {
+  code: string;
+  merchant_address: string;
+  merchant_name: string;
+  member_wallet: string;
+  amount_cents: string | number;
+  payout_cents: string | number;
+  status: ChargeStatus;
+  split_into: number | null;
+  plan_id: string | number | null;
+  tx_hash: string | null;
+  chain_id: number;
+  expires_at: string;
+  created_at: string;
+  resolved_at: string | null;
+  opened_at: string | null;
+}
+
+// No I, L, O or U: read over a phone line, those are the ones that come back wrong.
+const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+export function generateChargeCode(length = 8): string {
+  const bytes = crypto.randomBytes(length);
+  let out = '';
+  for (let i = 0; i < length; i += 1) out += ALPHABET[bytes[i] % ALPHABET.length];
+  return out;
+}
+
+const normalizeWallet = (w: string) => w.trim().toLowerCase();
+
+async function ensureTables(): Promise<void> {
+  const pool = getPostgresPool();
+  if (!pool || ensured) return;
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS ${TABLE} (
+      code TEXT PRIMARY KEY,
+      merchant_address TEXT NOT NULL,
+      merchant_name TEXT NOT NULL,
+      member_wallet TEXT NOT NULL,
+      amount_cents BIGINT NOT NULL,
+      payout_cents BIGINT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      split_into INTEGER,
+      plan_id BIGINT,
+      tx_hash TEXT,
+      chain_id INTEGER NOT NULL,
+      expires_at TIMESTAMPTZ NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      resolved_at TIMESTAMPTZ,
+      opened_at TIMESTAMPTZ
+    );
+    CREATE INDEX IF NOT EXISTS charge_member_idx ON ${TABLE} (member_wallet, created_at DESC);
+    CREATE INDEX IF NOT EXISTS charge_merchant_idx ON ${TABLE} (merchant_address, created_at DESC);
+  `);
+  ensured = true;
+}
+
+/**
+ * Expiry is derived on read, never swept.
+ *
+ * A cron that marks rows expired is a second writer racing the approve path, and the window it
+ * races in is exactly the moment a member is pressing Approve on a charge about to lapse. The
+ * approve path re-checks the deadline inside its own transaction, so the read here is only ever
+ * telling the UI what it already knows.
+ */
+function withDerivedStatus(row: ChargeRow): ChargeRow {
+  if (row.status !== 'pending') return row;
+  if (Date.parse(row.expiresAt) <= Date.now()) return { ...row, status: 'expired' };
+  return row;
+}
+
+const toRow = (r: DbRow): ChargeRow =>
+  withDerivedStatus({
+    code: r.code,
+    merchantAddress: r.merchant_address,
+    merchantName: r.merchant_name,
+    memberWallet: r.member_wallet,
+    amountCents: Number(r.amount_cents),
+    payoutCents: Number(r.payout_cents),
+    status: r.status,
+    splitInto: r.split_into,
+    planId: r.plan_id == null ? null : Number(r.plan_id),
+    txHash: r.tx_hash,
+    chainId: r.chain_id,
+    expiresAt: r.expires_at,
+    createdAt: r.created_at,
+    resolvedAt: r.resolved_at,
+    openedAt: r.opened_at,
+  });
+
+const COLUMNS = `code, merchant_address, merchant_name, member_wallet, amount_cents, payout_cents,
+                 status, split_into, plan_id, tx_hash, chain_id, expires_at, created_at,
+                 resolved_at, opened_at`;
+
+export const chargeStore = {
+  isConfigured(): boolean {
+    return !!getPostgresPool();
+  },
+
+  async create(input: {
+    merchantAddress: string;
+    merchantName: string;
+    memberWallet: string;
+    amountCents: number;
+    payoutCents: number;
+    chainId: number;
+    ttlSeconds: number;
+  }): Promise<ChargeRow | null> {
+    const pool = getPostgresPool();
+    if (!pool) return null;
+    await ensureTables();
+
+    // Retry on the vanishingly unlikely collision rather than trusting the RNG blindly. Cheap,
+    // and the alternative is a merchant seeing somebody else's charge.
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const code = generateChargeCode();
+      const result = await pool.query<DbRow>(
+        `INSERT INTO ${TABLE}
+           (code, merchant_address, merchant_name, member_wallet, amount_cents, payout_cents,
+            chain_id, expires_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, now() + ($8 || ' seconds')::interval)
+         ON CONFLICT (code) DO NOTHING
+         RETURNING ${COLUMNS}`,
+        [
+          code,
+          normalizeWallet(input.merchantAddress),
+          input.merchantName,
+          normalizeWallet(input.memberWallet),
+          input.amountCents,
+          input.payoutCents,
+          input.chainId,
+          String(input.ttlSeconds),
+        ],
+      );
+      if (result.rows[0]) return toRow(result.rows[0]);
+    }
+    return null;
+  },
+
+  async get(code: string): Promise<ChargeRow | null> {
+    const pool = getPostgresPool();
+    if (!pool) return null;
+    await ensureTables();
+    const r = await pool.query<DbRow>(`SELECT ${COLUMNS} FROM ${TABLE} WHERE code = $1`, [
+      code.trim().toUpperCase(),
+    ]);
+    return r.rows[0] ? toRow(r.rows[0]) : null;
+  },
+
+  /** First open only — the merchant's "waiting" state distinguishes sent from seen. */
+  async markOpened(code: string): Promise<void> {
+    const pool = getPostgresPool();
+    if (!pool) return;
+    await ensureTables();
+    await pool.query(
+      `UPDATE ${TABLE} SET opened_at = now() WHERE code = $1 AND opened_at IS NULL`,
+      [code.trim().toUpperCase()],
+    );
+  },
+
+  /**
+   * Claim a pending, unexpired charge for resolution.
+   *
+   * The guard is in the WHERE clause rather than in a read-then-write, so two taps on Approve
+   * cannot both pass it. Returns null when the row was already resolved or has lapsed, and the
+   * caller must treat that as "somebody else got there first" rather than as an error — the
+   * expensive part is what comes after, and it must not run twice.
+   */
+  async claimForResolution(code: string): Promise<ChargeRow | null> {
+    const pool = getPostgresPool();
+    if (!pool) return null;
+    await ensureTables();
+    const r = await pool.query<DbRow>(
+      `UPDATE ${TABLE} SET status = 'resolving'
+        WHERE code = $1 AND status = 'pending' AND expires_at > now()
+        RETURNING ${COLUMNS}`,
+      [code.trim().toUpperCase()],
+    );
+    return r.rows[0] ? toRow(r.rows[0]) : null;
+  },
+
+  async finish(
+    code: string,
+    input: { status: ChargeStatus; splitInto?: number; planId?: number; txHash?: string },
+  ): Promise<ChargeRow | null> {
+    const pool = getPostgresPool();
+    if (!pool) return null;
+    await ensureTables();
+    const r = await pool.query<DbRow>(
+      // Only a row this request claimed. Without it a late retry could overwrite a charge that had
+      // already been resolved some other way.
+      `UPDATE ${TABLE}
+          SET status = $2, split_into = $3, plan_id = $4, tx_hash = $5, resolved_at = now()
+        WHERE code = $1 AND status = 'resolving'
+        RETURNING ${COLUMNS}`,
+      [
+        code.trim().toUpperCase(),
+        input.status,
+        input.splitInto ?? null,
+        input.planId ?? null,
+        input.txHash ?? null,
+      ],
+    );
+    return r.rows[0] ? toRow(r.rows[0]) : null;
+  },
+
+  /** Put a claimed row back when the chain call failed — it never became anything. */
+  async release(code: string): Promise<void> {
+    const pool = getPostgresPool();
+    if (!pool) return;
+    await ensureTables();
+    await pool.query(`UPDATE ${TABLE} SET status = 'pending' WHERE code = $1 AND status = 'resolving'`, [
+      code.trim().toUpperCase(),
+    ]);
+  },
+};

--- a/app/server/src/services/chargeStore.ts
+++ b/app/server/src/services/chargeStore.ts
@@ -254,6 +254,47 @@ export const chargeStore = {
     return r.rows[0] ? toRow(r.rows[0]) : null;
   },
 
+  /**
+   * Record the transaction the moment it is submitted, before waiting for it.
+   *
+   * This is what makes a crash recoverable rather than a puzzle. Without the hash, a charge stuck
+   * in `resolving` can only be reconciled by hunting for an event that looks about right — same
+   * member, same amount, roughly the same time — and "looks about right" is not good enough to
+   * decide whether somebody owes money. With it, reconciliation asks the chain one exact question.
+   */
+  async markSubmitted(code: string, txHash: string): Promise<void> {
+    const pool = getPostgresPool();
+    if (!pool) return;
+    await ensureTables();
+    await pool.query(
+      `UPDATE ${TABLE} SET tx_hash = $2 WHERE code = $1 AND status = 'resolving'`,
+      [code.trim().toUpperCase(), txHash],
+    );
+  },
+
+  /**
+   * Charges that have been resolving longer than they should be.
+   *
+   * Only ever `resolving`, which is why this cannot race the approve path: that path claims rows
+   * that are `pending`, and the two sets do not overlap. The separation is deliberate — a sweep
+   * that touched pending rows would be a second writer arriving exactly when a member is
+   * answering a charge about to lapse.
+   */
+  async listStuck(olderThanSeconds: number, limit = 50): Promise<ChargeRow[]> {
+    const pool = getPostgresPool();
+    if (!pool) return [];
+    await ensureTables();
+    const r = await pool.query<DbRow>(
+      `SELECT ${COLUMNS} FROM ${TABLE}
+        WHERE status = 'resolving'
+          AND created_at < now() - ($1 || ' seconds')::interval
+        ORDER BY created_at ASC
+        LIMIT $2`,
+      [String(olderThanSeconds), limit],
+    );
+    return r.rows.map(toRow);
+  },
+
   /** Put a claimed row back when the chain call failed — it never became anything. */
   async release(code: string): Promise<void> {
     const pool = getPostgresPool();

--- a/app/server/src/services/memberStore.ts
+++ b/app/server/src/services/memberStore.ts
@@ -2435,6 +2435,40 @@ export class MemberStore {
     return result.rows[0]?.membership_plan ?? null;
   }
 
+  /**
+   * A member's contact details, found by any wallet they hold.
+   *
+   * The reverse of the directory lookup, and needed for the same reason a charge alert exists:
+   * something has to reach a member who is not looking at the app. Matched across every active
+   * wallet rather than the primary alone, because the wallet a charge is raised against is
+   * whichever one the merchant was given.
+   *
+   * Returns null when they have opted out of notifications. Not an empty contact — the caller
+   * should be able to tell "we have no way to reach them" apart from "they asked us not to".
+   */
+  async getContactByWallet(
+    walletAddress: string,
+  ): Promise<{ email: string | null; phone: string | null } | null> {
+    await this.ensureReady();
+    const addr = normalizeWalletAddress(walletAddress);
+    const pool = this.mustPool();
+    const result = await withRetry(async () => {
+      return pool.query<{ email: string | null; phone: string | null; notifications_opt_in: boolean }>(
+        `SELECT p.email, p.phone, p.notifications_opt_in
+           FROM ${TABLE_PROFILE_PRIVATE} p
+           JOIN ${TABLE_MEMBERS} m ON m.id = p.member_id
+          WHERE m.primary_wallet = $1
+             OR m.id = (SELECT member_id FROM ${TABLE_WALLETS}
+                         WHERE wallet_address = $1 AND status = 'ACTIVE' LIMIT 1)
+          LIMIT 1`,
+        [addr],
+      );
+    });
+    const row = result.rows[0];
+    if (!row || !row.notifications_opt_in) return null;
+    return { email: row.email ?? null, phone: row.phone ?? null };
+  }
+
   private async resolveMemberByAuthInput(input: ResolveMemberAuthInput): Promise<MemberRecord | null> {
     const authSubject = normalizeOptionalString(input.authSubject ?? null, 255) ?? null;
     if (authSubject) {

--- a/app/server/src/services/sendNotificationService.ts
+++ b/app/server/src/services/sendNotificationService.ts
@@ -9,7 +9,7 @@ export interface SendNotificationResult {
 }
 
 type NotificationChannel = 'email' | 'sms';
-type NotificationKind = 'claim_link' | 'otp';
+type NotificationKind = 'claim_link' | 'otp' | 'charge_alert';
 
 type GenericWebhookResponse = {
   provider?: string;
@@ -108,6 +108,48 @@ class SendNotificationService {
     };
   }
 
+  /**
+   * The text a member gets when a merchant raises a charge.
+   *
+   * On this service rather than a second one because the transport is the transport -- provider
+   * mode, Twilio wiring, webhook fallback and the mock are all here, and a charge alert that went
+   * out through its own copy would be a second thing to configure and a second thing to forget.
+   * The class name is now narrower than what it does; that is worth less than one dispatcher.
+   *
+   * Best-effort by design: the in-app notification and Web Push have already been emitted by the
+   * time this runs, so a Twilio outage must not fail the charge. It is reported, not thrown.
+   */
+  async sendChargeAlert(params: {
+    recipientType: RecipientType;
+    recipientContact: string;
+    merchantName: string;
+    amount: string;
+    approveUrl: string;
+  }): Promise<SendNotificationResult | null> {
+    const channel: NotificationChannel = params.recipientType === 'email' ? 'email' : 'sms';
+    try {
+      const dispatchResult = await this.dispatchNotification({
+        channel,
+        kind: 'charge_alert',
+        destination: params.recipientContact,
+        payload: {
+          merchantName: params.merchantName,
+          amount: params.amount,
+          approveUrl: params.approveUrl,
+        },
+      });
+      return {
+        provider: dispatchResult.provider,
+        providerMessageId: dispatchResult.providerMessageId,
+        destinationHash: hashDestination(params.recipientContact.trim().toLowerCase()),
+        status: dispatchResult.status,
+      };
+    } catch (error) {
+      console.error('[charge] alert dispatch failed', error instanceof Error ? error.message : error);
+      return null;
+    }
+  }
+
   private async dispatchNotification(params: {
     channel: NotificationChannel;
     kind: NotificationKind;
@@ -132,6 +174,14 @@ class SendNotificationService {
     if (params.kind === 'otp') {
       const otp = params.payload.otp || '';
       return `Your claim verification code is ${otp}.`;
+    }
+
+    if (params.kind === 'charge_alert') {
+      // The reference's own wording. "You have not been charged yet" is the whole message — it is
+      // what makes the rest safe to read on a lock screen — so it is not shortened to fit a
+      // segment count.
+      const { merchantName = '', amount = '', approveUrl = '' } = params.payload;
+      return `${merchantName} is charging ${amount} to your Clear account.\n\nApprove or decline: ${approveUrl}\n\nYou have not been charged yet.`;
     }
 
     const claimUrl = params.payload.claimUrl || '';

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -18,6 +18,7 @@ import { ShareTarget } from "@/pages/auth/ShareTarget";
 import ClaimFunds from "@/pages/auth/ClaimFunds";
 import OnboardingRoute from "@/pages/auth/OnboardingRoute";
 import CounterOnboardingRoute from "@/pages/auth/CounterOnboardingRoute";
+import ChargeApprovalRoute from "@/pages/app/ChargeApprovalRoute";
 import WalletLinkPage from "@/pages/auth/WalletLink";
 import { PWAInitializer } from "@/components/PWAInitializer";
 import AppShell from "@/components/shell/AppShell";
@@ -103,6 +104,10 @@ function App() {
                         exists when they begin. `?total=` carries the sale for display only --
                         see CounterOnboardingRoute on why it can never authorize one. */}
                     <Route path="/s/:shop" element={<CounterOnboardingRoute />} />
+                    {/* `/c/<code>` — the link in the charge alert. Outside the protected shell
+                        because the route sends an unauthenticated member to sign in and come
+                        back, which reads better than the shell bouncing them somewhere else. */}
+                    <Route path="/c/:code" element={<ChargeApprovalRoute />} />
                     <Route path="/wallet-link" element={<WalletLinkPage />} />
                     
                     {/* Share Target - Public */}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,7 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { AnimatePresence } from "framer-motion";
-import LoginPage from "@/pages/auth/LoginPage";
 import ProtectedRoute from "@/components/ProtectedRoute";
 import SplashScreen from "@/components/SplashScreen";
 import { ThemeProvider } from "@/context/ThemeContext";
@@ -19,6 +18,7 @@ import ClaimFunds from "@/pages/auth/ClaimFunds";
 import OnboardingRoute from "@/pages/auth/OnboardingRoute";
 import CounterOnboardingRoute from "@/pages/auth/CounterOnboardingRoute";
 import ChargeApprovalRoute from "@/pages/app/ChargeApprovalRoute";
+import LoginRoute from "@/pages/auth/LoginRoute";
 import WalletLinkPage from "@/pages/auth/WalletLink";
 import { PWAInitializer } from "@/components/PWAInitializer";
 import AppShell from "@/components/shell/AppShell";
@@ -96,7 +96,7 @@ function App() {
                   
                   <Routes>
                     {/* Login Page - Public */}
-                    <Route path="/login" element={<LoginPage />} />
+                    <Route path="/login" element={<LoginRoute />} />
                     <Route path="/onboarding" element={<OnboardingRoute />} />
                     {/* The counter entry. `/s/<shop>` is what a shop's code opens, and it is a
                         separate route rather than a mode of /onboarding because the two flows

--- a/app/src/PreviewApp.tsx
+++ b/app/src/PreviewApp.tsx
@@ -24,6 +24,7 @@ import SettingsPage from '@/pages/app/SettingsPage';
 import OnboardingFlow, { type OnboardingStep } from '@/pages/auth/OnboardingFlow';
 import CounterOnboarding, { COUNTER_STEPS, type CounterStep } from '@/pages/auth/CounterOnboarding';
 import { useInstallMode } from '@/hooks/useInstallMode';
+import ChargeApproval from '@/pages/app/ChargeApproval';
 import {
   HOME_IN_USE,
   HOME_DAY_ONE,
@@ -198,6 +199,48 @@ function TermPlansPreview() {
   );
 }
 
+/** A charge arriving — the approval screen and the state after it. */
+function ChargeApprovalPreview() {
+  const [splitInto, setSplitInto] = useState(4);
+  const [approved, setApproved] = useState(false);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <ChargeApproval
+        merchantName="Mike's Tire"
+        amount={940}
+        splitInto={splitInto}
+        onSplitChange={setSplitInto}
+        perCycleLimit={850}
+        clearsFromLabel="Chase ····4471"
+        firstPaymentOn="Dec 14"
+        doneBy={() => 'Mar 14'}
+        onApprove={() => setApproved(true)}
+        onDecline={() => setApproved(false)}
+        onBack={() => setApproved(false)}
+        approved={approved}
+      />
+
+      <div className="fixed inset-x-0 bottom-0 z-[60] flex justify-center gap-1 border-t-[0.5px] border-border bg-background/90 p-2 backdrop-blur-sm">
+        {(['approve', 'approved'] as const).map((s) => (
+          <button
+            key={s}
+            type="button"
+            onClick={() => setApproved(s === 'approved')}
+            className={`rounded-md border-[0.5px] px-2 py-1 text-[11px] ${
+              approved === (s === 'approved')
+                ? 'border-tier-boost text-tier-boost-fg'
+                : 'border-border text-muted-foreground'
+            }`}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 /**
  * The counter path — five steps, outside the app chrome like the direct one.
  *
@@ -292,6 +335,7 @@ export default function PreviewApp() {
         <Routes>
           <Route path="/onboarding" element={<OnboardingPreview />} />
           <Route path="/onboarding-counter" element={<CounterOnboardingPreview />} />
+          <Route path="/charge" element={<ChargeApprovalPreview />} />
 
           <Route
             path="*"

--- a/app/src/lib/creditMapping.ts
+++ b/app/src/lib/creditMapping.ts
@@ -1,4 +1,6 @@
 import type {
+  TermPlan,
+  TermPlans,
   CreditTier,
   TierKey,
   Credit,
@@ -7,7 +9,7 @@ import type {
   LimitBackingRow,
 } from '@/lib/clearModel';
 import { money } from '@/lib/money';
-import type { CreditTierRow, CreditCycleRow } from '@/utils/apiClient';
+import type { CreditTierRow, CreditCycleRow, CreditTermPlanRow } from '@/utils/apiClient';
 
 /**
  * Turning the contracts' tiers into the ones a member reads.
@@ -189,4 +191,54 @@ export function toLimitBacking(rows: CreditTierRow[], fallback: LimitBacking): L
 
   if (assetBacked.length === 0 && unsecured.length === 0) return fallback;
   return { assetBacked, unsecured };
+}
+
+
+/**
+ * The term-plan shelf, from the plans the contracts hold.
+ *
+ * The last placeholder on Home, and the one that made day one's two arrivals unreachable: the page
+ * already reverses its order for a member who has a plan, and until now no member could have one
+ * the page could see. A counter arrival now leads with their repair because they actually have a
+ * repair.
+ *
+ * Only open plans arrive here — the route filters closed ones out — so everything below describes
+ * something still being paid.
+ *
+ * The locked rows in `fallback` are kept. They are not placeholder data standing in for something
+ * unread: partner credit and an ELPA are real products a member has not unlocked yet, and the
+ * spec is explicit that they are visible from the first minute with their own unlock conditions.
+ * Dropping them because the chain returned one plan would delete the point of the component.
+ */
+export function toTermPlans(rows: CreditTermPlanRow[], fallback: TermPlans): TermPlans {
+  const locked = fallback.plans.filter((plan) => plan.lockedNote);
+
+  const live: TermPlan[] = rows.map((row) => {
+    const cyclesLeft =
+      row.installmentCents > 0
+        ? Math.max(0, Math.ceil(row.outstandingCents / row.installmentCents))
+        : undefined;
+
+    return {
+      id: String(row.planId),
+      // An address is not what somebody recognises on their own shelf. Without a name the plan is
+      // still shown — a row labelled generically beats a row that silently disappears.
+      name: row.merchantName ?? 'Term plan',
+      openedOn: row.openedAt
+        ? new Date(row.openedAt * 1000).toLocaleDateString('en-US', { month: 'short' })
+        : undefined,
+      balance: fromCents(row.principalCents),
+      splitInto: row.installments,
+      perCycle: fromCents(row.installmentCents),
+      cyclesLeft,
+      rate: rateLabel(row.rateBps),
+      ratePerCycle: row.rateBps / 10_000,
+    };
+  });
+
+  // Nothing read is not the same as nothing owed. An empty array from a route that answered is a
+  // member with no plans, and that is exactly what day one looks like — so it is kept, not
+  // treated as a failed read. The route reports an unreadable chain as 503 and the caller never
+  // gets here.
+  return { ...fallback, plans: [...live, ...locked] };
 }

--- a/app/src/lib/termPlanMapping.test.ts
+++ b/app/src/lib/termPlanMapping.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+import { toTermPlans } from '@/lib/creditMapping';
+import { HOME_DAY_ONE } from '@/data/clearPlaceholder';
+import type { CreditTermPlanRow } from '@/utils/apiClient';
+
+const plan = (over: Partial<CreditTermPlanRow> = {}): CreditTermPlanRow => ({
+  planId: 7,
+  principalCents: 94_000,
+  outstandingCents: 94_000,
+  repaidCents: 0,
+  installments: 4,
+  installmentCents: 24_675,
+  scheduleTotalCents: 98_700,
+  openedAt: Math.floor(Date.UTC(2026, 5, 14) / 1000),
+  rateBps: 200,
+  merchantName: "Mike's Tire",
+  closed: false,
+  ...over,
+});
+
+describe('the term-plan shelf, from chain', () => {
+  test('carries the figures the shelf quotes', () => {
+    const [row] = toTermPlans([plan()], HOME_DAY_ONE.termPlans).plans;
+    expect(row.name).toBe("Mike's Tire");
+    expect(row.balance).toBe(940);
+    expect(row.splitInto).toBe(4);
+    expect(row.perCycle).toBeCloseTo(246.75, 2);
+    expect(row.rate).toBe('2% / cycle');
+    expect(row.ratePerCycle).toBeCloseTo(0.02, 4);
+  });
+
+  test('cycles left comes from what is still owed, not from the split', () => {
+    // Half repaid is two cycles left of four, and the shelf must not keep saying four.
+    const [row] = toTermPlans([plan({ outstandingCents: 47_000 })], HOME_DAY_ONE.termPlans).plans;
+    expect(row.cyclesLeft).toBe(2);
+  });
+
+  test('a plan with no merchant name is still shown', () => {
+    // A row labelled generically beats a row that silently disappears — the member owes it either
+    // way, and a shelf that hides a debt is worse than one that names it poorly.
+    const [row] = toTermPlans([plan({ merchantName: null })], HOME_DAY_ONE.termPlans).plans;
+    expect(row.name).toBe('Term plan');
+    expect(row.balance).toBe(940);
+  });
+
+  test('the locked products survive a real plan arriving', () => {
+    // Partner credit and an ELPA are products nobody has unlocked yet, not fields that failed to
+    // load. Dropping them because the chain returned one plan would delete the component's point.
+    const lockedBefore = HOME_DAY_ONE.termPlans.plans.filter((p) => p.lockedNote).length;
+    expect(lockedBefore).toBeGreaterThan(0);
+    const after = toTermPlans([plan()], HOME_DAY_ONE.termPlans).plans.filter((p) => p.lockedNote);
+    expect(after.length).toBe(lockedBefore);
+  });
+
+  test('no plans is a real answer, not a failed read', () => {
+    // Day one for a direct arrival. The route answers 503 when it could not read the chain, so an
+    // empty array here means a member with nothing owed.
+    const result = toTermPlans([], HOME_DAY_ONE.termPlans);
+    expect(result.plans.every((p) => p.lockedNote)).toBe(true);
+  });
+
+  test('a zero installment does not divide by zero', () => {
+    const [row] = toTermPlans([plan({ installmentCents: 0 })], HOME_DAY_ONE.termPlans).plans;
+    expect(row.cyclesLeft).toBeUndefined();
+  });
+});
+
+/*
+ * Day one's two arrivals. HomePage reverses its order on whether an active plan exists, so this is
+ * the join that makes a counter arrival actually look like one.
+ */
+describe('day one leads with whichever one they are here for', () => {
+  test('a counter member has an active plan for HomePage to lead with', () => {
+    const { plans } = toTermPlans([plan()], HOME_DAY_ONE.termPlans);
+    expect(plans.some((p) => !p.lockedNote && (p.balance ?? 0) > 0)).toBe(true);
+  });
+
+  test('a direct member has none, so saving leads', () => {
+    const { plans } = toTermPlans([], HOME_DAY_ONE.termPlans);
+    expect(plans.some((p) => !p.lockedNote && (p.balance ?? 0) > 0)).toBe(false);
+  });
+});

--- a/app/src/pages/_archive/LoginPage.tsx
+++ b/app/src/pages/_archive/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAppKitAuth } from '@/hooks/useAppKitAuth';
-import LoginView from './LoginView';
+import LoginView from '../auth/LoginView';
 
 export default function LoginPage() {
   // Navigate as soon as the user is AUTHENTICATED — don't also wait for `isConnected` (an address).

--- a/app/src/pages/app/ChargeApproval.tsx
+++ b/app/src/pages/app/ChargeApproval.tsx
@@ -1,0 +1,194 @@
+import { ChevronLeft, Check } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import SplitChooser from '@/components/clear/SplitChooser';
+import { splitQuote } from '@/lib/clearModel';
+import { money } from '@/lib/money';
+
+/**
+ * A charge arrives — the member side.
+ *
+ * Every transaction after the first, and also how somebody who signed up in a waiting room
+ * receives their charge. The counter onboarding covers a first-timer; this covers the rest.
+ *
+ * **The split is chosen here, on the member's phone, and nowhere else.** A service writer must not
+ * be picking somebody's repayment terms, which is why the merchant's request carries an amount and
+ * a member and nothing about repayment — the merchant device has no control that could set it.
+ *
+ * Limit and Clears-from sit on this screen because it is the moment a member most wants to check
+ * them, and they use the same footer as the Term plans shelf so it is one pattern rather than two.
+ *
+ * Presentational, like the onboarding flows. `ChargeApprovalRoute` fetches, approves and declines.
+ */
+
+function FooterCell({
+  label,
+  value,
+  onSelect,
+  className = '',
+}: {
+  label: string;
+  value: string;
+  onSelect?: () => void;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={!onSelect}
+      className={`text-left ${className}`}
+    >
+      <p className="mb-0.5 text-[10px] uppercase tracking-[0.4px] text-muted-foreground">{label}</p>
+      <p className="text-[11.5px]">
+        {value}
+        {onSelect && <span className="text-muted-foreground"> &rsaquo;</span>}
+      </p>
+    </button>
+  );
+}
+
+export interface ChargeApprovalProps {
+  merchantName: string;
+  /** Whole units, not cents — `money` and `SplitChooser` both work in units. */
+  amount: number;
+  splitInto: number;
+  onSplitChange: (splitInto: number) => void;
+  splitOptions?: number[];
+  ratePerCycle?: number;
+  rate?: string;
+  /** Null while unread — the cell says so rather than inventing a figure. */
+  perCycleLimit?: number | null;
+  clearsFromLabel?: string;
+  firstPaymentOn?: string;
+  doneBy: (splitInto: number) => string;
+  busy?: boolean;
+  error?: string | null;
+  onApprove: () => void;
+  onDecline: () => void;
+  onBack?: () => void;
+  /** Set once approved — the screen becomes the confirmation rather than navigating away. */
+  approved?: boolean;
+}
+
+export default function ChargeApproval({
+  merchantName,
+  amount,
+  splitInto,
+  onSplitChange,
+  splitOptions = [1, 2, 4, 12],
+  ratePerCycle = 0.02,
+  rate = '2% / cycle',
+  perCycleLimit = null,
+  clearsFromLabel = 'Balance only',
+  firstPaymentOn,
+  doneBy,
+  busy = false,
+  error = null,
+  onApprove,
+  onDecline,
+  onBack,
+  approved = false,
+}: ChargeApprovalProps) {
+  if (approved) {
+    return (
+      <div className="mx-auto w-full max-w-[360px] px-5 py-8">
+        <div className="px-0 pb-1 pt-3.5 text-center">
+          <div className="mx-auto mb-3 flex h-11 w-11 items-center justify-center rounded-full bg-positive/15">
+            <Check className="h-[22px] w-[22px] text-positive" strokeWidth={2.4} />
+          </div>
+          <p className="text-2xl font-medium">{money(amount, { cents: true })}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {merchantName} · {splitInto === 1 ? 'in full' : `split in ${splitInto}`}
+          </p>
+        </div>
+
+        <div className="my-4 rounded-xl border-[0.5px] border-border px-3.5 py-3">
+          <div className="flex items-baseline justify-between text-[12.5px]">
+            <span className="text-foreground-secondary">First payment</span>
+            <span className="tabular-nums">
+              {/* The same figure the split chooser quoted a moment ago, from the same function.
+                  Dividing the amount by the split would drop the carry and tell a member their
+                  first payment is smaller than the one that will actually be taken — the last
+                  number they read before agreeing, and the one they will budget against. */}
+              {money(splitQuote(amount, splitInto, ratePerCycle).perCycle, { cents: true })}
+              {firstPaymentOn ? ` on ${firstPaymentOn}` : ''}
+            </span>
+          </div>
+          <div className="mt-1.5 flex items-baseline justify-between text-[12.5px]">
+            <span className="text-foreground-secondary">Clears from</span>
+            <span>{clearsFromLabel}</span>
+          </div>
+        </div>
+
+        {/* The one moment a member is most receptive to the point of the whole co-op: they have
+            just agreed to pay carry, and the way not to is one sentence long. */}
+        <div className="rounded-xl border-[0.5px] border-tier-savings/40 bg-tier-savings/10 px-3.5 py-3">
+          <p className="mb-1 text-[11px] tracking-[0.2px] text-tier-savings-fg">
+            MAKE THE NEXT ONE FREE
+          </p>
+          <p className="text-xs leading-relaxed">
+            Save anything at all and you borrow against your own money instead — at no cost.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-[360px] px-5 py-8">
+      <div className="mb-3.5 flex items-center gap-2.5">
+        {onBack && (
+          <button type="button" onClick={onBack} aria-label="Back" className="text-foreground-secondary">
+            <ChevronLeft className="h-[17px] w-[17px]" />
+          </button>
+        )}
+        <span className="text-[15px] font-medium">Approve a charge</span>
+      </div>
+
+      <p className="mb-0.5 text-xs text-foreground-secondary">{merchantName} wants to charge</p>
+      <p className="mb-4 font-display text-[34px] font-medium leading-none tracking-[-0.5px]">
+        {money(amount, { cents: true })}
+      </p>
+
+      <div className="mb-3 rounded-xl border-[0.5px] border-border px-3.5 py-3">
+        <SplitChooser
+          amount={amount}
+          options={splitOptions}
+          ratePerCycle={ratePerCycle}
+          rate={rate}
+          splitInto={splitInto}
+          onChange={onSplitChange}
+          doneBy={doneBy}
+        />
+      </div>
+
+      <div className="mb-3.5 grid grid-cols-2 border-t-[0.5px] border-border pt-2.5">
+        <FooterCell
+          label="Limit"
+          value={
+            perCycleLimit == null ? 'Not set' : `${money(perCycleLimit, { cents: true })}/cycle`
+          }
+          className="pr-3.5"
+        />
+        <FooterCell
+          label="Clears from"
+          value={clearsFromLabel}
+          className="border-l-[0.5px] border-border pl-3.5"
+        />
+      </div>
+
+      {error && <p className="mb-2.5 text-[11px] leading-relaxed text-negative">{error}</p>}
+
+      <Button size="sm" className="mb-[7px] w-full" onClick={onApprove} disabled={busy}>
+        {busy ? 'One moment…' : 'Approve'}
+      </Button>
+      <Button variant="clear" size="sm" className="w-full" onClick={onDecline} disabled={busy}>
+        Not now
+      </Button>
+
+      <p className="mt-2.5 text-center text-[11px] leading-relaxed text-muted-foreground">
+        Expires in 24 hours. Nothing is charged until you approve.
+      </p>
+    </div>
+  );
+}

--- a/app/src/pages/app/ChargeApprovalRoute.tsx
+++ b/app/src/pages/app/ChargeApprovalRoute.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { track } from '@/lib/analytics';
+import {
+  approveCharge,
+  declineCharge,
+  getCharge,
+  getCredit,
+  type ChargeView,
+} from '@/utils/apiClient';
+import { useAppKitAuth } from '@/hooks/useAppKitAuth';
+import ChargeApproval from './ChargeApproval';
+
+/**
+ * `/c/<code>` — the link in the text a member gets when a merchant raises a charge.
+ *
+ * The code identifies the charge and nothing more. It travels by text and text gets forwarded, so
+ * the server re-checks on every call that the charge belongs to the caller's own wallet; a member
+ * who opens somebody else's link gets a 404-shaped answer rather than a screen.
+ *
+ * Approving is the only thing here that costs anything, and it is deliberately not optimistic. The
+ * screen waits for the chain call, because a confirmation shown before the plan exists is a
+ * promise the app cannot keep — and the reference's own line, "nothing is charged until you
+ * approve", cuts both ways.
+ */
+export default function ChargeApprovalRoute() {
+  const { code = '' } = useParams<{ code: string }>();
+  const { isAuthenticated, address } = useAppKitAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [charge, setCharge] = useState<ChargeView | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [splitInto, setSplitInto] = useState(4);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [perCycleLimit, setPerCycleLimit] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      // Signing in is the gate, not the code. Coming back here afterwards is the whole point of
+      // the link, so the destination rides along in `state.from` — the same shape ProtectedRoute
+      // uses and the only one LoginPage reads. A `?next=` here would be silently ignored and drop
+      // somebody on the home screen wondering where their charge went.
+      navigate('/login', { state: { from: location }, replace: true });
+      return;
+    }
+    let cancelled = false;
+    void getCharge(code)
+      .then((found) => {
+        if (cancelled) return;
+        setCharge(found);
+        if (found?.splitInto) setSplitInto(found.splitInto);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [code, isAuthenticated, navigate, location]);
+
+  /**
+   * The limit shown on the footer, read from the contracts rather than guessed.
+   *
+   * Left null when the read fails. "Not set" is the honest thing to show when we could not ask —
+   * a number invented here would be sitting next to a decision somebody is about to make.
+   */
+  useEffect(() => {
+    if (!address) return;
+    let cancelled = false;
+    void getCredit(address).then((credit) => {
+      if (cancelled || !credit) return;
+      const available = credit.tiers
+        .filter((tier) => tier.active)
+        .reduce((sum, tier) => sum + Math.max(0, tier.limitCents - tier.usedCents), 0);
+      setPerCycleLimit(available / 100);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [address]);
+
+  const amount = useMemo(() => (charge ? charge.amountCents / 100 : 0), [charge]);
+
+  const onApprove = useCallback(async () => {
+    if (!charge) return;
+    setBusy(true);
+    setError(null);
+    const result = await approveCharge(charge.code, splitInto);
+    setBusy(false);
+    if (result.error || !result.charge) {
+      setError(result.error ?? 'We could not approve this charge.');
+      return;
+    }
+    setCharge(result.charge);
+    track('charge_approved', { installments: splitInto }); // split only, no amount and no merchant
+  }, [charge, splitInto]);
+
+  const onDecline = useCallback(async () => {
+    if (!charge) return;
+    setBusy(true);
+    setError(null);
+    const result = await declineCharge(charge.code);
+    setBusy(false);
+    if (result.error || !result.charge) {
+      setError(result.error ?? 'We could not decline this charge.');
+      return;
+    }
+    track('charge_declined', {});
+    navigate('/', { replace: true });
+  }, [charge, navigate]);
+
+  if (loading) {
+    return <p className="px-5 py-8 text-center text-[13px] text-muted-foreground">Loading…</p>;
+  }
+
+  if (!charge) {
+    return (
+      <div className="mx-auto w-full max-w-[360px] px-5 py-8 text-center">
+        <p className="mb-1.5 text-[19px] font-medium">Nothing to approve</p>
+        <p className="text-[13px] leading-relaxed text-foreground-secondary">
+          This charge has already been dealt with, or it was never yours.
+        </p>
+      </div>
+    );
+  }
+
+  // Every state that is not "waiting on you" says which one it is. A single "unavailable" would
+  // leave somebody unsure whether they had already paid.
+  if (charge.status !== 'pending' && charge.status !== 'approved') {
+    const explain =
+      charge.status === 'expired'
+        ? 'This charge expired. Ask the shop to send a new one — nothing was charged.'
+        : charge.status === 'declined'
+          ? 'You declined this charge. Nothing was charged.'
+          : 'This one is still going through. Give it a moment before trying again.';
+    return (
+      <div className="mx-auto w-full max-w-[360px] px-5 py-8 text-center">
+        <p className="mb-1.5 text-[19px] font-medium">{charge.merchantName}</p>
+        <p className="text-[13px] leading-relaxed text-foreground-secondary">{explain}</p>
+      </div>
+    );
+  }
+
+  return (
+    <ChargeApproval
+      merchantName={charge.merchantName}
+      amount={amount}
+      splitInto={charge.splitInto ?? splitInto}
+      onSplitChange={setSplitInto}
+      perCycleLimit={perCycleLimit}
+      doneBy={(n) => `${n} cycle${n === 1 ? '' : 's'} from now`}
+      busy={busy}
+      error={error}
+      onApprove={onApprove}
+      onDecline={onDecline}
+      onBack={() => navigate('/')}
+      approved={charge.status === 'approved'}
+    />
+  );
+}

--- a/app/src/pages/app/HomeRoute.tsx
+++ b/app/src/pages/app/HomeRoute.tsx
@@ -5,7 +5,7 @@ import { useClearBalances } from '@/hooks/useClearBalances';
 import { useClearTransactions } from '@/hooks/useClearTransactions';
 import { useAppKitAccount } from '@/lib/walletCompat';
 import { toActivityRow } from '@/lib/activityMapping';
-import { toCredit, toCycle, toLimitBacking } from '@/lib/creditMapping';
+import { toCredit, toCycle, toLimitBacking, toTermPlans } from '@/lib/creditMapping';
 import {
   getCredit,
   getLithicAccount,
@@ -40,7 +40,10 @@ import {
  * contract changes and none did -- `carryOf`, `creditPeriods` and `collateralValueOf` were already
  * there, which is worth remembering before proposing an upgrade next time.
  *
- * What remains placeholder is term plans, and that waits on nothing but a member having one.
+ * Term plans are real too now, which is what makes day one's two arrivals reachable: the page
+ * reverses its order for a member who has an active plan, and a counter member who approved a
+ * charge now has one. The locked rows beneath are kept — partner credit and an ELPA are products
+ * nobody has unlocked yet, not fields that failed to load.
  *
  * The account numbers are fetched and never cached to disk: they are bank details, and the server
  * reads them from Lithic on demand for the same reason.
@@ -128,6 +131,10 @@ export default function HomeRoute() {
           credit: toCredit(credit.tiers, HOME_DAY_ONE.credit),
           cycle: toCycle(credit.cycle, HOME_DAY_ONE.cycle),
           backing: toLimitBacking(credit.tiers, HOME_DAY_ONE.backing),
+          // The last placeholder on this page, and the one that made day one's two arrivals
+          // unreachable: HomePage already reverses its order for a member who has a plan, and
+          // until now no member could have one it could see.
+          termPlans: toTermPlans(credit.plans, HOME_DAY_ONE.termPlans),
         }
       : {}),
   };

--- a/app/src/pages/app/chargeApproval.test.ts
+++ b/app/src/pages/app/chargeApproval.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROUTE = readFileSync(join(import.meta.dir, 'ChargeApprovalRoute.tsx'), 'utf8');
+const SCREEN = readFileSync(join(import.meta.dir, 'ChargeApproval.tsx'), 'utf8');
+const SERVER = join(import.meta.dir, '../../../server/src');
+const SERVICE = readFileSync(join(SERVER, 'services/chargeService.ts'), 'utf8');
+const STORE = readFileSync(join(SERVER, 'services/chargeStore.ts'), 'utf8');
+const ROUTES = readFileSync(join(SERVER, 'routes/charges.ts'), 'utf8');
+
+/*
+ * The rule the whole feature exists to enforce: a service writer must not be picking somebody's
+ * repayment terms. If a merchant could ever set the split, this feature would be worse than not
+ * having it.
+ */
+describe('the split is chosen on the member’s phone', () => {
+  test('a merchant’s request carries no repayment terms', () => {
+    const raise = SERVICE.slice(SERVICE.indexOf('export async function raiseCharge'), SERVICE.indexOf('export async function notifyMember'));
+    expect(raise).not.toContain('installments');
+    expect(raise).not.toContain('splitInto');
+  });
+
+  test('installments only arrive on approve, from the member’s own session', () => {
+    expect(ROUTES).toContain("chargesRouter.post('/:code/approve', requireAuth");
+    const approve = ROUTES.slice(ROUTES.indexOf("post('/:code/approve'"), ROUTES.indexOf("post('/:code/decline'"));
+    expect(approve).toContain('req.body?.installments');
+  });
+});
+
+/*
+ * A code travels by text, and text gets forwarded. Possession of one cannot be what authorises
+ * answering it.
+ */
+describe('a code is not a credential', () => {
+  test('every member route sits behind requireAuth', () => {
+    for (const route of ["get('/:code'", "post('/:code/approve'", "post('/:code/decline'"]) {
+      const at = ROUTES.indexOf(route);
+      expect(at).toBeGreaterThan(-1);
+      expect(ROUTES.slice(at, at + 120)).toContain('requireAuth');
+    }
+  });
+
+  test('and re-checks the charge belongs to the caller', () => {
+    // Three routes, three checks. requireVerifiedWallet falls through to true when there is no
+    // req.auth at all, which is why the requireAuth test above is not redundant with this one.
+    const checks = ROUTES.split('requireVerifiedWallet(req, res, charge.memberWallet').length - 1;
+    expect(checks).toBe(3);
+  });
+
+  test('the merchant route is the only one without a session', () => {
+    const post = ROUTES.slice(ROUTES.indexOf("chargesRouter.post('/'"), ROUTES.indexOf("chargesRouter.get('/:code'"));
+    expect(post).not.toContain('requireAuth');
+    expect(post).not.toContain('req.auth');
+  });
+});
+
+/*
+ * A merchant proves itself by signing. The checks below are what stop that being a formality.
+ */
+describe('merchant authentication', () => {
+  test('the signer is the merchant, not whoever the body names', () => {
+    expect(SERVICE).toContain('recovered.toLowerCase() !== input.merchant.trim().toLowerCase()');
+  });
+
+  test('a signature expires', () => {
+    // Without an age bound a captured signature is a standing licence to charge the same member
+    // the same amount forever.
+    expect(SERVICE).toContain('SIGNATURE_MAX_AGE_SECONDS');
+    expect(SERVICE).toContain("reason: 'signature is stale'");
+  });
+
+  test('an unreadable registry is not a pass', () => {
+    expect(SERVICE).toContain("reason: 'could not confirm the merchant right now'");
+  });
+
+  test('inactive merchants are refused', () => {
+    expect(SERVICE).toContain("if (!active) return { ok: false, reason: 'merchant is not active' }");
+  });
+
+  test('the payout comes from the registry, never from the request', () => {
+    // A merchant that could name its own payout could name the whole purchase.
+    expect(SERVICE).toContain('discountBps');
+    const raise = SERVICE.slice(SERVICE.indexOf('export async function raiseCharge'), SERVICE.indexOf('export async function notifyMember'));
+    expect(raise).not.toContain('input.payoutCents');
+  });
+});
+
+/*
+ * Approving opens a real term plan. These are the tests about not opening two.
+ */
+describe('a purchase becomes at most one plan', () => {
+  test('the charge is claimed in the WHERE clause, not read-then-written', () => {
+    expect(STORE).toContain("WHERE code = $1 AND status = 'pending' AND expires_at > now()");
+  });
+
+  test('the plan is opened before the row is marked approved', () => {
+    const approve = SERVICE.slice(SERVICE.indexOf('export async function approveCharge'));
+    expect(approve.indexOf('issuer.openPlan(')).toBeLessThan(approve.indexOf("status: 'approved'"));
+  });
+
+  test('a submitted-but-unconfirmed call is never released', () => {
+    // A dropped connection while waiting for a receipt looks exactly like a revert from here.
+    // Releasing on that would let the same purchase be approved a second time.
+    expect(SERVICE).toContain('if (!submitted) {');
+    const approve = SERVICE.slice(SERVICE.indexOf('export async function approveCharge'));
+    expect(approve.indexOf('submitted = true;')).toBeLessThan(approve.indexOf('await tx.wait()'));
+  });
+
+  test('finish only closes a row this request claimed', () => {
+    expect(STORE).toContain("WHERE code = $1 AND status = 'resolving'");
+  });
+});
+
+describe('expiry', () => {
+  test('is derived on read rather than swept', () => {
+    // A sweeping cron would be a second writer racing the approve path, in exactly the window a
+    // member is pressing Approve on a charge about to lapse.
+    expect(STORE).toContain('function withDerivedStatus');
+    expect(STORE).not.toContain('setInterval');
+  });
+
+  test('and is re-checked when the charge is claimed', () => {
+    expect(STORE).toContain('expires_at > now()');
+  });
+});
+
+describe('what the member is shown', () => {
+  test('the approval screen never sees the payout or the merchant address', () => {
+    expect(ROUTES).toContain('function memberView');
+    const view = ROUTES.slice(ROUTES.indexOf('function memberView'), ROUTES.indexOf('* A merchant raises a charge'));
+    expect(view).not.toContain('payoutCents');
+    expect(view).not.toContain('merchantAddress');
+  });
+
+  test('the limit is left unset rather than invented when unread', () => {
+    expect(ROUTE).toContain('perCycleLimit');
+    expect(SCREEN).toContain("perCycleLimit == null ? 'Not set'");
+  });
+
+  test('every resolved state says which one it is', () => {
+    for (const word of ['expired', 'declined']) expect(ROUTE).toContain(word);
+    expect(ROUTE).toContain('Nothing was charged.');
+  });
+
+  test('approval waits for the chain rather than showing an optimistic confirmation', () => {
+    // setCharge runs on the result, so `approved` can only come from what the server returned.
+    expect(ROUTE).toContain('setCharge(result.charge)');
+    expect(ROUTE).toContain("approved={charge.status === 'approved'}");
+  });
+
+  test('the reference’s exact reassurance is on the screen', () => {
+    expect(SCREEN).toContain('Expires in 24 hours. Nothing is charged until you approve.');
+    expect(SCREEN).toContain('MAKE THE NEXT ONE FREE');
+  });
+});
+
+describe('the alert', () => {
+  test('says the member has not been charged', () => {
+    // The whole message, per the reference — it is what makes the rest safe on a lock screen.
+    expect(SERVICE).toContain('You have not been charged yet.');
+  });
+
+  test('goes out in-app and by text, and never fails the charge', () => {
+    expect(SERVICE).toContain('notificationStore.emit');
+    expect(SERVICE).toContain('sendChargeAlert');
+    const notify = SERVICE.slice(SERVICE.indexOf('export async function notifyMember'));
+    expect(notify).toContain('catch');
+  });
+
+  test('respects a member who opted out', () => {
+    expect(SERVICE).toContain('if (!contact) return;');
+  });
+});
+
+describe('coming back after signing in', () => {
+  test('uses the state shape LoginPage actually reads', () => {
+    // A `?next=` would be silently ignored and drop somebody on the home screen.
+    expect(ROUTE).toContain('state: { from: location }');
+    expect(ROUTE).not.toContain("navigate('/login?");
+  });
+});
+
+/*
+ * The confirmation quotes a figure the member will budget against. It has to be the same one the
+ * split chooser showed them a moment earlier — dividing the amount by the split looks right and
+ * silently drops the carry.
+ */
+describe('the first payment matches what was quoted', () => {
+  test('comes from splitQuote, not from division', () => {
+    expect(SCREEN).toContain('splitQuote(amount, splitInto, ratePerCycle).perCycle');
+    expect(SCREEN).not.toContain('amount / splitInto');
+  });
+
+  test('and the two disagree, which is why it matters', async () => {
+    const { splitQuote } = await import('@/lib/clearModel');
+    const quoted = splitQuote(940, 4, 0.02).perCycle;
+    expect(quoted).toBeCloseTo(246.75, 2);
+    expect(quoted).not.toBeCloseTo(940 / 4, 2);
+  });
+});

--- a/app/src/pages/app/chargeApproval.test.ts
+++ b/app/src/pages/app/chargeApproval.test.ts
@@ -199,3 +199,59 @@ describe('the first payment matches what was quoted', () => {
     expect(quoted).not.toBeCloseTo(940 / 4, 2);
   });
 });
+
+/*
+ * Reconciliation — the thing that ends a stuck charge's wait.
+ *
+ * These tests are about what it must NOT do. Every wrong answer here opens a second term plan for
+ * one purchase, which is a member owing twice for one repair.
+ */
+const RECONCILER = readFileSync(join(SERVER, 'services/chargeReconciler.ts'), 'utf8');
+
+describe('a stuck charge reconciles against the chain', () => {
+  test('the tx hash is written before the wait, not after', () => {
+    // Without it there is no specific transaction to look up, and reconciliation degrades to
+    // hunting for an event that looks about right — which is not good enough to decide whether
+    // somebody owes money.
+    const approve = SERVICE.slice(SERVICE.indexOf('export async function approveCharge'));
+    expect(approve.indexOf('markSubmitted(code, tx.hash)')).toBeLessThan(approve.indexOf('await tx.wait()'));
+  });
+
+  test('a transaction still in the mempool is left alone', () => {
+    // The case a time-based rule gets wrong: an underpriced transaction can sit and then land.
+    expect(SERVICE).toContain('const tx = await rpc.getTransaction(charge.txHash);');
+    expect(SERVICE).toContain('stillPending');
+  });
+
+  test('only a reverted or dropped transaction releases the charge', () => {
+    expect(SERVICE).toContain('if (receipt.status === 0)');
+    const reconcile = SERVICE.slice(SERVICE.indexOf('export async function reconcileCharges'));
+    // A successful receipt must never reach a release.
+    const successBranch = reconcile.slice(reconcile.indexOf('if (planId === undefined)'));
+    expect(successBranch.slice(0, 400)).not.toContain('release');
+  });
+
+  test('a mined transaction with no PlanOpened is left for review, not released', () => {
+    expect(SERVICE).toContain('mined without PlanOpened');
+  });
+
+  test('an unreadable chain changes nothing', () => {
+    expect(SERVICE).toContain('[charge] reconcile failed for');
+  });
+
+  test('it only ever touches resolving rows', () => {
+    // The approve path claims `pending`. Non-overlapping sets is why there is no race here.
+    expect(STORE).toContain("WHERE status = 'resolving'");
+  });
+
+  test('and running it twice is harmless', () => {
+    // finish() guards on status = 'resolving', so a second runner behind the first does nothing.
+    expect(STORE).toContain("WHERE code = $1 AND status = 'resolving'");
+    expect(RECONCILER).toContain('if (running) return;');
+  });
+
+  test('it runs on its own rather than waiting to be remembered', () => {
+    expect(RECONCILER).toContain('setInterval');
+    expect(RECONCILER).toContain('void runChargeReconcileOnce();');
+  });
+});

--- a/app/src/pages/auth/LoginRoute.tsx
+++ b/app/src/pages/auth/LoginRoute.tsx
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useLoginWithEmail, useLoginWithOAuth, useLoginWithSms } from '@privy-io/react-auth';
+import { track } from '@/lib/analytics';
+import { useAppKitAuth } from '@/hooks/useAppKitAuth';
+import OnboardingFlow, { type OnboardingStep, type OnboardingValues } from './OnboardingFlow';
+
+/**
+ * Signing in, on the reference's own entry screen.
+ *
+ * The screens already existed — `enter` and `verify` were built to the reference during the
+ * rebuild and wired to nothing, exactly as the onboarding flows were. This is the container that
+ * makes them do something, and it is built headlessly rather than on Privy's modal because the
+ * reference is specific about what this screen says and a modal cannot say it.
+ *
+ * **One field for both.** The reference's footnote is the product decision: *"Signing in and
+ * signing up are the same. We'll figure out which."* So there is no account-exists check and no
+ * separate sign-up path — a phone gets an SMS code, an email gets an emailed one, and Privy
+ * creates the account if there is not one.
+ *
+ * Phase E was deliberately left last because it is the step most likely to lock somebody out. The
+ * shape of that risk here is specific: an unrecognised contact must not be turned away, a wrong
+ * code must not consume the whole attempt budget silently, and a member who was sent here from
+ * somewhere else must land back there rather than on the home screen.
+ */
+
+/** A contact is a phone if it is mostly digits. Anything else is treated as an email. */
+export function looksLikePhone(contact: string): boolean {
+  const trimmed = contact.trim();
+  if (!trimmed || trimmed.includes('@')) return false;
+  const digits = trimmed.replace(/\D/g, '');
+  // Ten for a US number, eleven with the country code. Fewer is a typo, not a phone — and
+  // guessing "phone" on four digits would send an SMS code nowhere and blame the member.
+  return digits.length >= 10 && /^[+\d\s().-]+$/.test(trimmed);
+}
+
+const RESEND_SECONDS = 24;
+
+export default function LoginRoute() {
+  const { isAuthenticated } = useAppKitAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const email = useLoginWithEmail();
+  const sms = useLoginWithSms();
+  const oauth = useLoginWithOAuth();
+
+  const [step, setStep] = useState<OnboardingStep>('enter');
+  const [values, setValues] = useState<OnboardingValues>({
+    contact: '',
+    code: '',
+    zip: '',
+    invite: '',
+    email: '',
+  });
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [resendIn, setResendIn] = useState(0);
+  // Which channel the code went to. Read at verify time rather than re-derived, so editing the
+  // field after the code was sent cannot send the answer to the other one.
+  const channel = useRef<'sms' | 'email' | null>(null);
+  const navigated = useRef(false);
+
+  /** Where they were going before the gate sent them here. */
+  const destination = useMemo(() => {
+    const from = (location.state as { from?: { pathname?: string; search?: string; hash?: string } } | undefined)?.from;
+    if (!from?.pathname) return '/';
+    return `${from.pathname}${from.search ?? ''}${from.hash ?? ''}`;
+  }, [location.state]);
+
+  useEffect(() => {
+    if (!isAuthenticated || navigated.current) return;
+    navigated.current = true;
+    window.dispatchEvent(new Event('wallet-connected'));
+    navigate(destination, { replace: true });
+  }, [isAuthenticated, destination, navigate]);
+
+  useEffect(() => {
+    if (resendIn <= 0) return;
+    const id = setTimeout(() => setResendIn((n) => n - 1), 1000);
+    return () => clearTimeout(id);
+  }, [resendIn]);
+
+  const onValuesChange = useCallback((patch: Partial<OnboardingValues>) => {
+    setValues((previous) => ({ ...previous, ...patch }));
+  }, []);
+
+  const send = useCallback(
+    async (contact: string) => {
+      const trimmed = contact.trim();
+      if (!trimmed) {
+        setError('Enter a phone number or an email address.');
+        return;
+      }
+      setBusy(true);
+      setError(null);
+      try {
+        if (looksLikePhone(trimmed)) {
+          channel.current = 'sms';
+          await sms.sendCode({ phoneNumber: trimmed });
+        } else {
+          channel.current = 'email';
+          await email.sendCode({ email: trimmed });
+        }
+        setResendIn(RESEND_SECONDS);
+        setStep('verify');
+        track('login_code_sent', { channel: channel.current }); // channel only, never the contact
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "We couldn't send a code to that.");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [email, sms],
+  );
+
+  const submitCode = useCallback(
+    async (code: string) => {
+      setBusy(true);
+      setError(null);
+      try {
+        if (channel.current === 'sms') await sms.loginWithCode({ code });
+        else await email.loginWithCode({ code });
+        // No navigation here. The effect above owns it, so signing in through any route — this
+        // code, OAuth, or a session that was already live — leaves from the same place.
+      } catch (e) {
+        // Cleared so the next attempt starts empty. Privy allows five tries per code, and leaving
+        // a wrong one in the boxes is how somebody spends the rest of them re-submitting it.
+        setValues((previous) => ({ ...previous, code: '' }));
+        setError(e instanceof Error ? e.message : 'That code did not work. Try again.');
+      } finally {
+        setBusy(false);
+      }
+    },
+    [email, sms],
+  );
+
+  const startOAuth = useCallback(
+    async (provider: 'google' | 'apple') => {
+      setBusy(true);
+      setError(null);
+      try {
+        await oauth.initOAuth({ provider });
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "We couldn't reach that sign-in.");
+        setBusy(false);
+      }
+      // Not cleared on success: OAuth navigates away, and re-enabling the buttons underneath a
+      // redirect that is already happening only invites a second press.
+    },
+    [oauth],
+  );
+
+  const auth = useMemo(
+    () => ({
+      busy,
+      error,
+      resendIn,
+      onContinue: () => void send(values.contact),
+      onOAuth: (provider: 'google' | 'apple') => void startOAuth(provider),
+      onSubmitCode: (code: string) => void submitCode(code),
+      onResend: () => void send(values.contact),
+    }),
+    [busy, error, resendIn, send, startOAuth, submitCode, values.contact],
+  );
+
+  return (
+    <OnboardingFlow
+      step={step}
+      onStepChange={(next) => {
+        // Back to `enter` is the only move this screen offers. Anything further belongs to
+        // onboarding, which runs after there is an account.
+        if (next === 'enter') setStep('enter');
+      }}
+      values={values}
+      onValuesChange={onValuesChange}
+      sentTo={values.contact || 'your phone'}
+      auth={auth}
+    />
+  );
+}

--- a/app/src/pages/auth/OnboardingFlow.tsx
+++ b/app/src/pages/auth/OnboardingFlow.tsx
@@ -27,7 +27,8 @@ import { money } from '@/lib/money';
  * go and what they typed, and the container decides what any of it means. An unserved ZIP going
  * to the waitlist instead of through is a decision, and it is made there rather than here.
  *
- * LoginPage still owns `enter` and `verify` — a member reaching /onboarding has already signed in.
+ * `LoginRoute` drives `enter` and `verify`; `OnboardingRoute` starts at `join`, because a member
+ * reaching /onboarding has already signed in.
  * ClaimFunds still owns the claim steps.
  */
 export type OnboardingStep =
@@ -139,6 +140,7 @@ export default function OnboardingFlow({
   waitlistRegion = 'Columbus, OH',
   waitlistPosition = 184,
   sentTo = '(909) 555-0148',
+  auth,
 }: {
   step?: OnboardingStep;
   onStepChange?: (step: OnboardingStep) => void;
@@ -155,6 +157,21 @@ export default function OnboardingFlow({
   waitlistRegion?: string;
   waitlistPosition?: number;
   sentTo?: string;
+  /**
+   * Real sign-in, when a container is driving. Omitted in the preview harness, where the buttons
+   * simply advance the step — the screens are the same either way, which is the point of keeping
+   * this optional rather than forking the component.
+   */
+  auth?: {
+    busy: boolean;
+    error?: string | null;
+    /** Seconds until a code can be resent; 0 means it can be. */
+    resendIn: number;
+    onContinue: () => void;
+    onOAuth: (provider: 'google' | 'apple') => void;
+    onSubmitCode: (code: string) => void;
+    onResend: () => void;
+  };
 }) {
   // Uncontrolled unless a container supplies values, so PreviewApp keeps working untouched: it
   // passes a step and nothing else, because looking at a screen is not collecting anything.
@@ -197,9 +214,19 @@ export default function OnboardingFlow({
             placeholder="Phone or email"
             aria-label="Phone or email"
             className="mb-2"
+            inputMode="email"
+            autoComplete="username"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && auth && !auth.busy) auth.onContinue();
+            }}
           />
-          <Button size="xs" className="mb-3.5 w-full" onClick={go('verify')}>
-            Continue
+          <Button
+            size="xs"
+            className="mb-3.5 w-full"
+            onClick={auth ? auth.onContinue : go('verify')}
+            disabled={auth?.busy}
+          >
+            {auth?.busy ? 'Sending…' : 'Continue'}
           </Button>
 
           <div className="mb-3.5 flex items-center gap-2">
@@ -208,12 +235,28 @@ export default function OnboardingFlow({
             <span className="h-px flex-1 bg-border" />
           </div>
 
-          <Button variant="clear" size="xs" className="mb-2 w-full" onClick={go('verify')}>
+          <Button
+            variant="clear"
+            size="xs"
+            className="mb-2 w-full"
+            onClick={auth ? () => auth.onOAuth('google') : go('verify')}
+            disabled={auth?.busy}
+          >
             Continue with Google
           </Button>
-          <Button variant="clear" size="xs" className="w-full" onClick={go('verify')}>
+          <Button
+            variant="clear"
+            size="xs"
+            className="w-full"
+            onClick={auth ? () => auth.onOAuth('apple') : go('verify')}
+            disabled={auth?.busy}
+          >
             Continue with Apple
           </Button>
+
+          {auth?.error && (
+            <p className="mt-2.5 text-[11px] leading-relaxed text-negative">{auth.error}</p>
+          )}
 
           <Footnote>Signing in and signing up are the same. We&rsquo;ll figure out which.</Footnote>
         </>
@@ -225,8 +268,40 @@ export default function OnboardingFlow({
           <p className="mb-5 text-[13px] leading-relaxed text-foreground-secondary">
             Sent to {sentTo}
           </p>
-          <CodeInput value={code} onChange={setCode} />
-          <p className="text-xs text-muted-foreground">Resend in 0:24</p>
+          <CodeInput
+            value={code}
+            onChange={(next) => {
+              setCode(next);
+              // Submitted on the sixth digit rather than behind a button. There is nothing else to
+              // decide on this screen, and a code that sits there waiting for a press is a step
+              // somebody has to be told to take.
+              if (auth && next.length === 6 && !auth.busy) auth.onSubmitCode(next);
+            }}
+          />
+
+          {auth?.error && (
+            <p className="mb-1.5 text-[11px] leading-relaxed text-negative">{auth.error}</p>
+          )}
+
+          {auth ? (
+            auth.resendIn > 0 ? (
+              <p className="text-xs text-muted-foreground">
+                Resend in 0:{String(auth.resendIn).padStart(2, '0')}
+              </p>
+            ) : (
+              <button
+                type="button"
+                onClick={auth.onResend}
+                disabled={auth.busy}
+                className="text-xs text-muted-foreground underline underline-offset-2 disabled:opacity-60"
+              >
+                Send a new code
+              </button>
+            )
+          ) : (
+            <p className="text-xs text-muted-foreground">Resend in 0:24</p>
+          )}
+
           <Footnote align="left">Next time, use Face ID instead.</Footnote>
         </>
       )}

--- a/app/src/pages/auth/OnboardingRoute.tsx
+++ b/app/src/pages/auth/OnboardingRoute.tsx
@@ -20,7 +20,8 @@ import OnboardingFlow, {
  * The real onboarding: the rebuilt flow, with the submit chain behind it.
  *
  * Starts at `join`, not `enter`. A member reaching /onboarding has already signed in — the gate
- * sent them here — so the contact and code steps belong to LoginPage until that is rebuilt too.
+ * sent them here — so the contact and code steps belong to `LoginRoute`, which drives the same
+ * two screens of this same component.
  * Beginning at `enter` would put a second sign-in in front of somebody already signed in.
  *
  * The flow stays presentational. It reports step changes and field edits; every decision about

--- a/app/src/pages/auth/PrivyLoginControls.tsx
+++ b/app/src/pages/auth/PrivyLoginControls.tsx
@@ -8,7 +8,7 @@ import { useLoginWithEmail, useLoginWithOAuth, useLoginWithSms } from '@privy-io
  * LINKED in-app (Privy linked accounts), and the Privy smart wallet is the user's primary wallet.
  * Email & phone are the guaranteed methods (2-step OTP: send code → verify), shown up front. Socials
  * (OAuth redirect) live behind a "More ways to sign in" slide-up sheet. On success Privy flips
- * `authenticated` → LoginPage routes onward. See [[clearpath-privy-migration]].
+ * `authenticated` → LoginRoute routes onward. See [[clearpath-privy-migration]].
  */
 
 type OAuthProvider = 'google' | 'apple' | 'twitter' | 'discord' | 'github';
@@ -72,7 +72,7 @@ export default function PrivyLoginControls() {
     try {
       if (method === 'email') await loginWithEmailCode({ code });
       else await loginWithSmsCode({ code });
-      // On success Privy authenticates; LoginPage's effect routes onward.
+      // On success Privy authenticates; LoginRoute's effect routes onward.
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Invalid or expired code.');
     } finally {

--- a/app/src/pages/auth/loginRoute.test.ts
+++ b/app/src/pages/auth/loginRoute.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { looksLikePhone } from './LoginRoute';
+
+const SOURCE = readFileSync(join(import.meta.dir, 'LoginRoute.tsx'), 'utf8');
+const FLOW = readFileSync(join(import.meta.dir, 'OnboardingFlow.tsx'), 'utf8');
+
+/*
+ * One field for both, so this function decides which channel a code goes to. Guessing wrong sends
+ * it somewhere the member cannot read and then blames them for not having it.
+ */
+describe('telling a phone from an email', () => {
+  test('reads real phone numbers', () => {
+    for (const value of ['9095550148', '(909) 555-0148', '909-555-0148', '+1 909 555 0148']) {
+      expect(looksLikePhone(value)).toBe(true);
+    }
+  });
+
+  test('reads emails', () => {
+    for (const value of ['kai@example.com', 'a.b+c@sub.example.co.uk']) {
+      expect(looksLikePhone(value)).toBe(false);
+    }
+  });
+
+  test('a short string of digits is a typo, not a phone', () => {
+    // Guessing "phone" here would send an SMS code nowhere.
+    for (const value of ['4921', '', '   ', '555']) expect(looksLikePhone(value)).toBe(false);
+  });
+
+  test('anything with an @ is an email even if it has digits', () => {
+    expect(looksLikePhone('9095550148@example.com')).toBe(false);
+  });
+});
+
+describe('signing in and signing up are the same', () => {
+  test('there is no account-exists check to turn anybody away', () => {
+    expect(SOURCE).not.toContain('disableSignup');
+    expect(FLOW).toContain('Signing in and signing up are the same');
+  });
+});
+
+/*
+ * Phase E was left last because it is the step most likely to lock somebody out. These are the
+ * specific shapes of that.
+ */
+describe('not locking anybody out', () => {
+  test('a wrong code clears the boxes', () => {
+    // Privy allows five tries per code. Leaving a wrong one in is how somebody spends the rest of
+    // them re-submitting the same digits.
+    expect(SOURCE).toContain("setValues((previous) => ({ ...previous, code: '' }))");
+  });
+
+  test('the channel is remembered rather than re-derived at verify time', () => {
+    // Editing the field after the code was sent must not send the answer to the other channel.
+    expect(SOURCE).toContain('channel.current');
+    const submit = SOURCE.slice(SOURCE.indexOf('const submitCode ='), SOURCE.indexOf('const startOAuth ='));
+    expect(submit).toContain("channel.current === 'sms'");
+    expect(submit).not.toContain('looksLikePhone');
+  });
+
+  test('somebody sent here from elsewhere lands back there', () => {
+    expect(SOURCE).toContain('const destination = useMemo');
+    expect(SOURCE).toContain('navigate(destination, { replace: true })');
+  });
+
+  test('and one place owns that navigation', () => {
+    // Code, OAuth and an already-live session all leave from the same effect, so no path can
+    // authenticate and then sit on the login screen.
+    expect(SOURCE.split('navigate(destination').length - 1).toBe(1);
+    expect(SOURCE).toContain('if (!isAuthenticated || navigated.current) return;');
+  });
+
+  test('the resend is a real countdown, not a printed string', () => {
+    expect(SOURCE).toContain('setResendIn((n) => n - 1)');
+    expect(FLOW).toContain('Send a new code');
+  });
+});
+
+describe('the code submits itself', () => {
+  test('on the sixth digit rather than behind a button', () => {
+    // Nothing else is decided on that screen, and a code waiting for a press is a step somebody
+    // has to be told to take.
+    expect(FLOW).toContain('next.length === 6');
+  });
+});
+
+describe('the preview harness still renders these screens', () => {
+  test('auth is optional, so the buttons fall back to advancing the step', () => {
+    expect(FLOW).toContain('auth?: {');
+    expect(FLOW).toContain("onClick={auth ? auth.onContinue : go('verify')}");
+  });
+});

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2294,6 +2294,16 @@ export interface CreditTermPlanRow {
   installments: number;
   installmentCents: number;
   scheduleTotalCents: number;
+  /** Unix seconds — the shelf shows the month beside the name. */
+  openedAt: number;
+  /** Carry in basis points per cycle, as the plan was written. */
+  rateBps: number;
+  /**
+   * The name a member would recognise, from the charge that opened this plan. Null when the plan
+   * did not come from a charge, or its row has since gone — the shelf shows the plan either way.
+   * The only field on this route that is not read from chain.
+   */
+  merchantName: string | null;
   closed: boolean;
 }
 

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2944,3 +2944,57 @@ export async function createRampBuySession(p: {
   const r = await apiRequest<{ url: string | null }>(`/api/ramp/buy/session`, { method: 'POST', body: JSON.stringify(p) });
   return r.error || !r.data ? { url: null } : r.data;
 }
+
+
+/**
+ * A charge a merchant has raised, as the member is allowed to see it.
+ *
+ * Payout and the merchant's address are absent because they are not the member's business — the
+ * co-op's cut of a repair is between the co-op and the shop.
+ */
+export interface ChargeView {
+  code: string;
+  merchantName: string;
+  amountCents: number;
+  status: 'pending' | 'resolving' | 'approved' | 'declined' | 'expired';
+  splitInto: number | null;
+  planId: number | null;
+  txHash: string | null;
+  expiresAt: string;
+  createdAt: string;
+}
+
+/** Null when there is no such charge, or it is not this member's to see. */
+export async function getCharge(code: string): Promise<ChargeView | null> {
+  const r = await apiRequest<ChargeView>(`/api/charges/${encodeURIComponent(code)}`);
+  return r.error || !r.data ? null : r.data;
+}
+
+export interface ChargeActionResult {
+  charge?: ChargeView;
+  error?: string;
+}
+
+/**
+ * Approve, with the split chosen here and only here.
+ *
+ * The error is surfaced rather than swallowed: approving opens a real term plan, and the failures
+ * a member can do something about — a lapsed charge, a split the contracts do not offer, a limit
+ * that will not stretch — are all things they need told rather than a spinner that stops.
+ */
+export async function approveCharge(code: string, installments: number): Promise<ChargeActionResult> {
+  const r = await apiRequest<ChargeView>(`/api/charges/${encodeURIComponent(code)}/approve`, {
+    method: 'POST',
+    body: JSON.stringify({ installments }),
+  });
+  if (r.error || !r.data) return { error: r.error || 'We could not approve this charge.' };
+  return { charge: r.data };
+}
+
+export async function declineCharge(code: string): Promise<ChargeActionResult> {
+  const r = await apiRequest<ChargeView>(`/api/charges/${encodeURIComponent(code)}/decline`, {
+    method: 'POST',
+  });
+  if (r.error || !r.data) return { error: r.error || 'We could not decline this charge.' };
+  return { charge: r.data };
+}

--- a/scripts/register_merchant.ts
+++ b/scripts/register_merchant.ts
@@ -1,0 +1,73 @@
+import hre from "hardhat";
+import { getDeployment } from "../deploy/helpers";
+
+/*
+ * Registers a merchant, which is what makes it possible to raise a charge at all.
+ *
+ * A merchant has no account and no password. It is an address in `MerchantRegistry`, and it
+ * authenticates by signing -- the server recovers the signer from an EIP-712 charge and asks this
+ * registry whether that address is a merchant in good standing. So registering one here is the
+ * whole of merchant onboarding as it exists today, and until at least one exists the charge flow
+ * cannot be exercised end to end by anybody.
+ *
+ * The three terms are all enforced server-side on every charge, so they are not documentation:
+ *
+ *   discountBps   what the co-op takes. The merchant reference quotes 2.5% at confirmation, so
+ *                 250 unless a merchant negotiated otherwise. The payout is computed from this
+ *                 and never from what the merchant device sends.
+ *   approvalCap   the ceiling on a single charge. Zero means no ceiling, which is the right
+ *                 default for a trusted partner and the wrong one for a new counter.
+ *   payoutWindow  how long the co-op has to pay the claim. Zero takes the registry default.
+ *
+ *   MERCHANT=0x… npx hardhat run scripts/register_merchant.ts --network base-sepolia
+ *   MERCHANT=0x… DISCOUNT_BPS=250 APPROVAL_CAP=2000 npx hardhat run scripts/register_merchant.ts --network base-sepolia
+ *
+ * APPROVAL_CAP is in dollars for the sake of whoever runs this; it is converted to the 6dp units
+ * the contract holds. Run by an operator.
+ */
+const { ethers } = hre as typeof hre & {
+  ethers: typeof import("hardhat").ethers;
+};
+
+async function main() {
+  const network = (await ethers.provider.getNetwork()).name;
+  const record = getDeployment(network, "MerchantRegistry");
+  if (!record) throw new Error(`No MerchantRegistry on ${network}.`);
+
+  const merchant = process.env.MERCHANT?.trim();
+  if (!merchant || !ethers.isAddress(merchant)) throw new Error("Set MERCHANT to an address.");
+
+  const discountBps = BigInt(process.env.DISCOUNT_BPS?.trim() || "250");
+  if (discountBps > 10_000n) throw new Error("DISCOUNT_BPS cannot exceed 10000.");
+
+  const capDollars = process.env.APPROVAL_CAP?.trim() || "0";
+  const approvalCap = ethers.parseUnits(capDollars, 6);
+  const payoutWindow = Number(process.env.PAYOUT_WINDOW?.trim() || "0");
+
+  const registry = await ethers.getContractAt("MerchantRegistry", record.address);
+
+  if (await registry.isRegistered(merchant)) {
+    // Registering twice reverts, so say what is already true rather than failing on a re-run.
+    const terms = await registry.termsOf(merchant);
+    console.log("already registered:", merchant);
+    console.log("  active       ", terms.active);
+    console.log("  discountBps  ", terms.discountBps.toString());
+    console.log("  approvalCap  ", ethers.formatUnits(terms.approvalCap, 6));
+    console.log("  payoutWindow ", terms.payoutWindow.toString(), "seconds");
+    console.log("\nUse updateTerms to change these; this script only registers.");
+    return;
+  }
+
+  const tx = await registry.registerMerchant(merchant, payoutWindow, approvalCap, discountBps);
+  const receipt = await tx.wait();
+  console.log("registered", merchant, "in", receipt?.hash ?? tx.hash);
+  console.log("  discountBps ", discountBps.toString(), `(${Number(discountBps) / 100}%)`);
+  console.log("  approvalCap ", approvalCap === 0n ? "none" : `$${capDollars}`);
+  console.log("  payoutWindow", payoutWindow === 0 ? "registry default" : `${payoutWindow}s`);
+  console.log("\nMerchants now registered:", (await registry.merchantCount()).toString());
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Four commits: the member side of a charge, the reconciliation that makes it safe to lose a connection mid-approval, and Phases D and E — which finish the onboarding plan.

## Phase C — a charge arrives

A merchant raises a charge, the member gets a text, and `/c/<code>` is where they pick a split and approve. That opens a real term plan on chain rather than recording an intention.

**The split is chosen on the member's phone and nowhere else.** A service writer must not be picking somebody's repayment terms, so a merchant's request carries an amount and a member and nothing about repayment. There is no field a merchant device could set.

**A merchant proves itself by signing.** No merchant account system exists, and inventing one means inventing the credential store, rotation and recovery that come with it. `MerchantRegistry` is already deployed and keyed by address, so the server recovers the signer from an EIP-712 charge and asks the registry whether it is a merchant in good standing. The cap is checked against the amount and the payout is computed from the registry's discount, never from the request — a merchant that could name its own payout could name the whole purchase. Signatures expire after five minutes.

**A code is not a credential.** It travels by text and text gets forwarded, so every member route re-checks that the charge belongs to the caller. That check needs `requireAuth` in front of it and nearly did not get it: `requireVerifiedWallet` falls through to **true** when there is no `req.auth`, a compatibility path for routes that authenticate another way. As first written, every ownership check would have passed for anyone holding a code.

## Reconciliation — the part that was missing

A charge sits in `resolving` between submitting the plan transaction and seeing its receipt. If the process dies there, nobody can say whether the plan was opened; approving again could open a second one, and so could releasing it.

The fix is mostly one line earlier: the transaction hash is now written **before** the wait. That turns an unanswerable question into an exact one — look up that transaction and get a definite answer. Mined and succeeded, record it. Mined and reverted, hand the charge back. Gone from the node, hand it back.

A transaction still in the mempool is left alone, which is the case a time-based rule gets wrong: an underpriced transaction can sit and then land, and a sweep that released the charge because ten minutes felt like enough would be the thing that opened the second plan.

It runs on a loop from boot, since the likeliest reason a charge is stuck is that this process died.

**And there is now a merchant.** The registry had zero registered, so nothing could sign a charge and none of this was exercisable. `scripts/register_merchant.ts` registers one; a test merchant is live on Base Sepolia at 2.5% with a $2,000 cap — 2.5% being what the merchant reference quotes at confirmation.

## Phase D — day one by arrival

The layout was already there: HomePage reverses its order on whether a member has an active plan. What was missing is that no member could have a plan it could see, because term plans were the last placeholder on Home.

`planAt` already returned `openedAt` and `ratePerCycle` and the reader was destructuring straight past both. The merchant name is the one thing genuinely not on chain — a plan knows an address, and an address is not what somebody recognises on their own shelf — so the credit route joins it from the charge that opened the plan, labelled as the only field there not read from chain. A plan whose name cannot be found is still shown: the member owes it either way.

The locked rows survive a real plan arriving. Partner credit and an ELPA are products nobody has unlocked yet, not fields that failed to load.

## Phase E — signing in

`enter` and `verify` were built to the reference and wired to nothing. `LoginRoute` drives them for real, on Privy's headless hooks rather than its modal — the reference is specific about what this screen says and a modal cannot say it. `LoginPage` is archived.

One field for both, because the reference makes that the product decision: *"Signing in and signing up are the same. We'll figure out which."* No account-exists check, nothing that turns somebody away at the door.

Left last because it is the step most likely to lock somebody out, so: a wrong code clears the boxes (Privy allows five tries, and leaving the wrong digits in is how you spend the other four); the channel is remembered rather than re-derived; phone detection needs ten digits, not any digits; and exactly one place owns the post-login navigation, so no path can authenticate and then sit on the login screen.

## Verification

311 app tests, 49 new across the four commits. Every screen checked against the reference at phone width — the approval figures ($246.75 / $18.80 / $47.00 / $987.00), both day-one arrivals, and both login screens.

Two things I have **not** done: run a real sign-in end to end (needs a live Privy project and an actual phone), and run a real charge end to end (needs a merchant device to sign one — the registry entry exists, the caller does not yet).

## Known gaps

- Refunds are not built, and the merchant reference's own open questions note the contracts do not unwind a plan yet.
- `openedAt` is stored on a charge but text/email delivery status is not, and the merchant reference's §05 wants all three receipts. `sendChargeAlert` already returns a status that is currently discarded.
- The server's `bun build` fails on 7 unresolved `@coinbase/cdp-sdk` imports. Pre-existing and identical before this branch.