### PR TITLE
Wire the general ESA deposit

### DIFF
--- a/app/src/components/clear/AddToSavingsDialog.tsx
+++ b/app/src/components/clear/AddToSavingsDialog.tsx
@@ -4,6 +4,7 @@ import Modal from './Modal';
 import AmountPicker from './AmountPicker';
 import DetailRows from './DetailRows';
 import InfoBlock from './InfoBlock';
+import { Check, Loader2 } from 'lucide-react';
 import { money, count } from '@/lib/money';
 import type { SavingsData } from '@/lib/clearModel';
 
@@ -14,19 +15,34 @@ import type { SavingsData } from '@/lib/clearModel';
  * The matched credits are the reason anyone does this, so they lead, above the
  * mechanics. The footnote is the counterweight: this money locks up, and that
  * shouldn't be discovered later.
+ *
+ * Presentational. `ConnectedAddToSavings` supplies the deposit; the preview harness supplies
+ * nothing and gets the same screen, which is what keeps the two honest about each other.
  */
 export default function AddToSavingsDialog({
   data,
   open,
   onOpenChange,
   onAdd,
+  busy = false,
+  error = null,
+  txHash = null,
 }: {
   data: SavingsData;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onAdd?: (amount: number) => void;
+  busy?: boolean;
+  error?: string | null;
+  /** Set once the deposit has landed — the dialog becomes a receipt rather than vanishing. */
+  txHash?: string | null;
 }) {
   const [amount, setAmount] = useState(500);
+  // Capped against the balance this dialog actually displays, not a second number passed in beside
+  // it. Those disagreed the first time round, and the disagreement was on screen: a From row
+  // reading $6,200.00 above a warning that the account holds $0.00.
+  const available = data.payFrom.balance;
+  const overBalance = amount > available;
 
   return (
     <Modal
@@ -35,6 +51,29 @@ export default function AddToSavingsDialog({
       title="Add to savings"
       description="Choose how much to add to savings and review the credits it earns."
     >
+      {txHash ? (
+        <div className="py-2 text-center">
+          <div className="mx-auto mb-3 flex h-11 w-11 items-center justify-center rounded-full bg-positive/15">
+            <Check className="h-[22px] w-[22px] text-positive" strokeWidth={2.4} />
+          </div>
+          <p className="text-2xl font-medium">{money(amount, { cents: true })}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Added to savings · {count(amount)} in equity credits
+          </p>
+          <p className="mt-3 text-[11px] leading-relaxed text-muted-foreground">
+            Credits vest after 30 days in the system.
+          </p>
+          <Button
+            size="xs"
+            variant="clear"
+            className="mt-4 w-full"
+            onClick={() => onOpenChange(false)}
+          >
+            Done
+          </Button>
+        </div>
+      ) : (
+        <>
       <AmountPicker amount={amount} presets={[100, 500, 1000]} onChange={setAmount} />
 
       <InfoBlock tone="success" className="mb-3">
@@ -53,12 +92,33 @@ export default function AddToSavingsDialog({
         ]}
       />
 
-      <Button size="xs" className="w-full" onClick={() => onAdd?.(amount)}>
-        Add {money(amount)}
+      {overBalance && (
+        <p className="mb-2 text-[11px] leading-relaxed text-negative">
+          That&rsquo;s more than your cash account holds ({money(available, { cents: true })}).
+        </p>
+      )}
+      {error && <p className="mb-2 text-[11px] leading-relaxed text-negative">{error}</p>}
+
+      <Button
+        size="xs"
+        className="w-full"
+        onClick={() => onAdd?.(amount)}
+        disabled={busy || overBalance}
+      >
+        {busy ? (
+          <>
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            Adding…
+          </>
+        ) : (
+          `Add ${money(amount)}`
+        )}
       </Button>
       <p className="mt-2.5 text-center text-[11px] text-muted-foreground">
         Locked until you reserve a home or leave.
       </p>
+        </>
+      )}
     </Modal>
   );
 }

--- a/app/src/components/clear/ConnectedAddToSavings.tsx
+++ b/app/src/components/clear/ConnectedAddToSavings.tsx
@@ -1,0 +1,67 @@
+import { useCallback } from 'react';
+import AddToSavingsDialog from './AddToSavingsDialog';
+import { useSavingsDeposit } from '@/hooks/useSavingsDeposit';
+import { useClearBalances } from '@/hooks/useClearBalances';
+import { track } from '@/lib/analytics';
+import type { SavingsData } from '@/lib/clearModel';
+
+/**
+ * Add to savings, wired up.
+ *
+ * The general deposit, as distinct from auto-save. Auto-save is a standing instruction — sign once
+ * and it runs on a schedule — and it had been carrying both jobs, which meant the ordinary case of
+ * "put $500 in right now" was routed through a setup flow for something recurring.
+ *
+ * The dialog itself stays presentational so the preview harness renders the same screen with no
+ * wallet, no balances and no deposit behind it.
+ */
+export default function ConnectedAddToSavings({
+  data,
+  open,
+  onOpenChange,
+}: {
+  data: SavingsData;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const balances = useClearBalances();
+
+  const onDeposited = useCallback(
+    (amount: number) => {
+      // Optimistic, and reconciled by the poll: cash down, savings up. Without it the member
+      // watches a receipt for money that is still sitting in the old balance for half a minute.
+      balances.applyOptimistic(-amount, amount);
+      track('savings_deposit', {}); // that it happened, not how much
+    },
+    [balances],
+  );
+
+  const { busy, error, txHash, deposit, reset } = useSavingsDeposit(onDeposited);
+
+  // The live cash balance replaces whatever the page was carrying, so the figure the member reads
+  // in the From row is the same one the button is checked against. Only once it has actually been
+  // read: before that the page's own number stands, because refusing a deposit on a balance we
+  // have not seen would be blaming a member for our latency — and in the design preview, where
+  // there is no wallet at all, the fixture's figure is the honest one to show.
+  const live = !balances.loading && balances.total > 0;
+  const withLiveBalance = live
+    ? { ...data, payFrom: { ...data.payFrom, balance: balances.cash } }
+    : data;
+
+  return (
+    <AddToSavingsDialog
+      data={withLiveBalance}
+      open={open}
+      onOpenChange={(next) => {
+        // Cleared on close, not on open. A member who closes a receipt and immediately reopens
+        // should get a fresh form; clearing on open would blank the receipt they just landed on.
+        if (!next) reset();
+        onOpenChange(next);
+      }}
+      onAdd={(amount) => void deposit(amount)}
+      busy={busy}
+      error={error}
+      txHash={txHash}
+    />
+  );
+}

--- a/app/src/components/clear/addToSavings.test.ts
+++ b/app/src/components/clear/addToSavings.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DIALOG = readFileSync(join(import.meta.dir, 'AddToSavingsDialog.tsx'), 'utf8');
+const CONNECTED = readFileSync(join(import.meta.dir, 'ConnectedAddToSavings.tsx'), 'utf8');
+const HOOK = readFileSync(join(import.meta.dir, '../../hooks/useSavingsDeposit.ts'), 'utf8');
+
+/*
+ * The general deposit, as distinct from auto-save. Auto-save is a standing instruction; this is
+ * "put $500 in now", and it had been routed through the recurring setup flow for want of a wired
+ * component.
+ */
+describe('the deposit actually deposits', () => {
+  test('every call site gets the connected version', () => {
+    for (const page of ['../../pages/app/HomePage.tsx', '../../pages/app/SavingsPage.tsx']) {
+      const source = readFileSync(join(import.meta.dir, page), 'utf8');
+      expect(source).toContain('ConnectedAddToSavings');
+      // The bare dialog does nothing on press — that was the bug.
+      expect(source).not.toContain('<AddToSavingsDialog');
+    }
+  });
+
+  test('and onAdd is wired rather than left undefined', () => {
+    expect(CONNECTED).toContain('onAdd={(amount) => void deposit(amount)}');
+  });
+});
+
+/*
+ * One number, shown and enforced. These disagreed the first time round and the disagreement was
+ * visible on screen: a From row reading $6,200.00 above a warning that the account held $0.00.
+ */
+describe('the balance shown is the balance enforced', () => {
+  test('the cap reads the same field the From row displays', () => {
+    expect(DIALOG).toContain('const available = data.payFrom.balance;');
+    expect(DIALOG).toContain('const overBalance = amount > available;');
+  });
+
+  test('no second balance is passed in beside it', () => {
+    expect(DIALOG).not.toContain('maxAmount');
+    expect(CONNECTED).not.toContain('maxAmount');
+  });
+
+  test('the live balance replaces the displayed one rather than sitting next to it', () => {
+    expect(CONNECTED).toContain('payFrom: { ...data.payFrom, balance: balances.cash }');
+  });
+
+  test('and only once it has been read', () => {
+    // Refusing a deposit on a balance we have not seen would blame a member for our latency.
+    expect(CONNECTED).toContain('const live = !balances.loading && balances.total > 0;');
+  });
+});
+
+/*
+ * Which rail a deposit takes is a property of the member's wallet, not of the screen. Neither
+ * reaches the UI, because neither changes anything a member decides.
+ */
+describe('how the money moves', () => {
+  test('smart accounts send a sponsored op, EOAs fall back to the relayer', () => {
+    expect(HOOK).toContain('scDeposit(');
+    expect(HOOK).toContain('gaslessDeposit(');
+    expect(HOOK.indexOf('scDeposit(')).toBeLessThan(HOOK.indexOf('gaslessDeposit('));
+  });
+
+  test('the amount is a fixed-precision string, never a float', () => {
+    // It becomes token micros. 0.1 + 0.2 has no business near somebody's savings balance.
+    expect(HOOK).toContain('amount.toFixed(2)');
+  });
+
+  test('it is extracted rather than copied out of TransferModal', () => {
+    const transfer = readFileSync(join(import.meta.dir, '../app-ui/TransferModal.tsx'), 'utf8');
+    // Two implementations of "how money reaches savings" is how they end up disagreeing about
+    // which paths a member has.
+    expect(transfer).toContain('gaslessDeposit');
+    expect(HOOK).toContain('Extracted from TransferModal');
+  });
+});
+
+/*
+ * The design preview renders these same pages with no wallet providers at all. A component
+ * reaching for a wallet hook two levels below a page is what blanked the harness.
+ */
+describe('the preview harness still renders', () => {
+  test('both wallet hooks are provider-optional', () => {
+    expect(HOOK).toContain('function useOptionalSmartWalletClient');
+    expect(HOOK).toContain('function useOptionalAddress');
+  });
+
+  test('and the dialog itself stays presentational', () => {
+    expect(DIALOG).not.toContain('useSavingsDeposit');
+    expect(DIALOG).not.toContain('useClearBalances');
+  });
+});
+
+describe('the receipt', () => {
+  test('replaces the form rather than closing on it', () => {
+    // A deposit that just vanishes leaves somebody unsure whether it happened.
+    expect(DIALOG).toContain('txHash ? (');
+    expect(DIALOG).toContain('Added to savings');
+  });
+
+  test('is cleared on close, not on open', () => {
+    // Clearing on open would blank the receipt the member just landed on.
+    expect(CONNECTED).toContain('if (!next) reset();');
+  });
+});

--- a/app/src/hooks/useSavingsDeposit.ts
+++ b/app/src/hooks/useSavingsDeposit.ts
@@ -1,0 +1,120 @@
+import { useCallback, useState } from 'react';
+import { useSmartWallets } from '@privy-io/react-auth/smart-wallets';
+import { useAppKitAccount } from '@/lib/walletCompat';
+import { ACTIVE_CHAIN_ID } from '@/lib/clearNetwork';
+import { scDeposit } from '@/lib/sendCalls';
+import { gaslessDeposit } from '@/lib/gaslessMoney';
+
+/**
+ * Adding to savings — Cash (USDC) into the ESA vault, which mints CLRUSD and matches equity credits.
+ *
+ * There are two ways this lands and which one applies is a property of the member's wallet, not of
+ * the screen they started from. A smart account sends a sponsored UserOp; an EOA signs an EIP-3009
+ * authorization the relayer submits. Either way the member pays no gas and signs once, which is
+ * why the distinction never reaches the UI — it has no bearing on anything they decide.
+ *
+ * The fallback is not belt-and-braces. A smart account whose client has not finished setting up
+ * looks exactly like an EOA from here, and that state is common on a first session — so a failed
+ * sponsored send drops to the relayer rather than telling somebody their deposit failed when the
+ * money could have moved perfectly well.
+ *
+ * Extracted from TransferModal rather than copied out of it. This is the second surface that
+ * deposits and there will be more, and two implementations of "how money reaches savings" is how
+ * they end up disagreeing about which paths a member has.
+ */
+export interface SavingsDepositState {
+  busy: boolean;
+  error: string | null;
+  /** Set once the deposit has landed — the dialog becomes a receipt rather than closing. */
+  txHash: string | null;
+  deposit: (amount: number) => Promise<void>;
+  reset: () => void;
+}
+
+/*
+ * Both wallet hooks below are provider-optional, because the design preview harness renders these
+ * same pages with no wallet providers at all — no Privy, no wagmi. That is the harness's whole
+ * point: it shows the screens without an account behind them.
+ *
+ * This follows what `useClearBalances` already does, which resolves its context to a zeroed
+ * fallback rather than requiring a provider. Reached differently here only because these two throw
+ * instead of returning null. The call still happens unconditionally, so hook order stays stable,
+ * and the failure mode is honest: no wallet means the deposit cannot run, which is exactly what
+ * `deposit` already reports when there is no address.
+ *
+ * The alternative was to keep every wallet hook out of anything a page renders, which is how this
+ * file broke the harness in the first place — a component reached for one two levels below a page
+ * that the harness mounts.
+ */
+function useOptionalSmartWalletClient(): ((opts: { id: number }) => Promise<unknown>) | null {
+  try {
+    return useSmartWallets().getClientForChain as (opts: { id: number }) => Promise<unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function useOptionalAddress(): string | undefined {
+  try {
+    return useAppKitAccount().address;
+  } catch {
+    return undefined;
+  }
+}
+
+export function useSavingsDeposit(onDeposited?: (amount: number) => void): SavingsDepositState {
+  const address = useOptionalAddress();
+  const getClientForChain = useOptionalSmartWalletClient();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [txHash, setTxHash] = useState<string | null>(null);
+
+  const deposit = useCallback(
+    async (amount: number) => {
+      if (!address) {
+        setError('Connect a wallet first.');
+        return;
+      }
+      if (!Number.isFinite(amount) || amount <= 0) {
+        setError('Enter an amount to add.');
+        return;
+      }
+
+      setBusy(true);
+      setError(null);
+      try {
+        const chainId = ACTIVE_CHAIN_ID;
+        // Six decimals, and a string rather than a float: the amount becomes token micros, and
+        // 0.1 + 0.2 has no business anywhere near somebody's savings balance.
+        const amountStr = amount.toFixed(2);
+
+        let hash: string;
+        try {
+          // Bind the client to this chain — the default one sits on Privy's defaultChain, which is
+          // not necessarily the chain we transact on.
+          const chainClient = getClientForChain
+            ? await getClientForChain({ id: chainId }).catch(() => undefined)
+            : undefined;
+          hash = await scDeposit({ smartWalletClient: chainClient, ownerWallet: address, amount: amountStr, chainId });
+        } catch {
+          hash = await gaslessDeposit({ ownerWallet: address, amount: amountStr, chainId });
+        }
+
+        setTxHash(hash);
+        onDeposited?.(amount);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "That didn't go through.");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [address, getClientForChain, onDeposited],
+  );
+
+  const reset = useCallback(() => {
+    setError(null);
+    setTxHash(null);
+  }, []);
+
+  return { busy, error, txHash, deposit, reset };
+}

--- a/app/src/pages/app/HomePage.tsx
+++ b/app/src/pages/app/HomePage.tsx
@@ -18,7 +18,7 @@ import SplitPlanDialog from '@/components/clear/SplitPlanDialog';
 import PaymentAccountDialog from '@/components/clear/PaymentAccountDialog';
 import TermLimitDialog from '@/components/clear/TermLimitDialog';
 import AddBoostDialog from '@/components/clear/AddBoostDialog';
-import AddToSavingsDialog from '@/components/clear/AddToSavingsDialog';
+import ConnectedAddToSavings from '@/components/clear/ConnectedAddToSavings';
 import AutoSaveDialog from '@/components/clear/AutoSaveDialog';
 import LinkAccountDialog from '@/components/clear/LinkAccountDialog';
 import TransactionDetailDialog from '@/components/clear/TransactionDetailDialog';
@@ -197,7 +197,7 @@ export default function HomePage({ data = HOME_DAY_ONE }: { data?: HomeData }) {
           )}
         </div>
         {termPlanModals}
-        <AddToSavingsDialog
+        <ConnectedAddToSavings
           data={{ ...SAVINGS_DAY_ONE, savings: data.savings, creditLimitToday: 0 }}
           open={addSavingsOpen}
           onOpenChange={setAddSavingsOpen}
@@ -334,7 +334,7 @@ export default function HomePage({ data = HOME_DAY_ONE }: { data?: HomeData }) {
       {termPlanModals}
       {/* Savings deposit is the same surface Savings uses; the credit limit it
           quotes comes from this page's own tiers so the two can't disagree. */}
-      <AddToSavingsDialog
+      <ConnectedAddToSavings
         data={{ ...SAVINGS_DAY_ONE, savings: data.savings, creditLimitToday: creditLimit(data.credit) }}
         open={addSavingsOpen}
         onOpenChange={setAddSavingsOpen}

--- a/app/src/pages/app/SavingsPage.tsx
+++ b/app/src/pages/app/SavingsPage.tsx
@@ -9,7 +9,7 @@ import MilestonePath from '@/components/clear/MilestonePath';
 import ProjectionCard from '@/components/clear/ProjectionCard';
 import AssuranceList from '@/components/clear/AssuranceList';
 import VestingList from '@/components/clear/VestingList';
-import AddToSavingsDialog from '@/components/clear/AddToSavingsDialog';
+import ConnectedAddToSavings from '@/components/clear/ConnectedAddToSavings';
 import AutoSaveDialog from '@/components/clear/AutoSaveDialog';
 import { SAVINGS_DAY_ONE } from '@/data/clearPlaceholder';
 import { money } from '@/lib/money';
@@ -131,7 +131,7 @@ export default function SavingsPage({ data = SAVINGS_DAY_ONE }: { data?: Savings
         </div>
       </div>
 
-      <AddToSavingsDialog data={data} open={addOpen} onOpenChange={setAddOpen} />
+      <ConnectedAddToSavings data={data} open={addOpen} onOpenChange={setAddOpen} />
       <AutoSaveDialog data={data} open={autoSaveOpen} onOpenChange={setAutoSaveOpen} />
     </>
   );


### PR DESCRIPTION
`AddToSavingsDialog` matched the reference and was **inert** — three call sites rendered it and none passed `onAdd`, so the button did nothing. Auto-save had been carrying both jobs, which meant "put $500 in right now" went through a setup flow for a standing instruction.

## What it does now

Deposits through the path that already existed. A smart account sends a sponsored UserOp; an EOA signs an EIP-3009 authorization the relayer submits. Which rail applies is a property of the member's wallet, not of the screen, so neither reaches the UI — the member signs once and pays no gas either way. The fallback isn't belt-and-braces: a smart account whose client hasn't finished setting up is indistinguishable from an EOA from here, and that's common on a first session.

Extracted into `useSavingsDeposit` rather than copied out of `TransferModal`. This is the second surface that deposits and there will be more; two implementations of "how money reaches savings" is how they end up disagreeing about which paths a member actually has.

## Two things found by opening it, not reading it

**The preview harness went blank.** It renders these pages with no wallet providers at all, and a component two levels below a page reached for one — so Home and Savings rendered nothing. Both wallet hooks are provider-optional now, matching what `useClearBalances` already does with its context. The general point is worth stating: the harness is a real consumer of these pages, and anything a page renders has to survive having no wallet.

**A contradiction on screen.** The dialog took the balance to *display* and the balance to *enforce* as two separate inputs, and they disagreed — a From row reading "Cash account · $6,200.00" directly above "that's more than your cash account holds ($0.00)". The cap now reads the same field the row displays, and the live balance replaces that field rather than arriving beside it. One number, shown and checked. Only once actually read, since refusing a deposit on a balance we haven't seen would blame a member for our latency.

The dialog also stays open on success and becomes a receipt — a deposit that just vanishes leaves somebody unsure whether it happened.

## Housekeeping

Removed 359 untracked `<name> 2.<ext>` iCloud duplicates that had reappeared across `contracts/`, `scripts/`, `deploy/` and `docs/`. They were breaking the app typecheck. Each deleted only where the real file existed beside it; none were tracked by git.

## Verification

324 app tests, 13 new. Checked against the reference in the harness: amount and presets, the matched-credits block, From / Repeat / New credit limit, and the locked-until footnote.

**Not verified:** an actual on-chain deposit. That needs a real wallet session, which is what this unblocks on the demo.