### PR TITLE
Fix the Move money desktop layout

### DIFF
--- a/app/src/components/clear/MoveMoneyDialog.tsx
+++ b/app/src/components/clear/MoveMoneyDialog.tsx
@@ -311,6 +311,12 @@ export default function MoveMoneyDialog({
       onOpenChange={onOpenChange}
       title="Move money"
       description="Move money between your cash account and savings."
+      // The desktop dialog is 360px by default, and the two-column layout below needs the width
+      // the reference gives it — a 216px keypad beside a column that still has to fit "Credits
+      // earned" on one line. Forced into 360px it wraps to one word per line, which is what it
+      // did. Only widened where the two-column layout applies: Modal switches to a bottom sheet
+      // below 640px, the same breakpoint the grid uses, so the two never disagree.
+      className={nothingReady ? undefined : 'sm:max-w-[640px] sm:p-[21px]'}
     >
       {txHash ? (
         <div className="py-2 text-center">

--- a/app/src/components/clear/moveMoney.test.ts
+++ b/app/src/components/clear/moveMoney.test.ts
@@ -263,3 +263,29 @@ describe('the classes are this app’s tokens, not the reference’s variable na
     }
   });
 });
+
+/*
+ * The two-column layout and the dialog's width are one decision, not two.
+ *
+ * Gated on a breakpoint but rendered inside a fixed-width dialog, the grid forced a 216px keypad
+ * and a full consequence column into 360px — every row wrapped to one word per line and the legs
+ * truncated to a single character. A breakpoint says how wide the *window* is, which is not the
+ * same question as how wide the container is.
+ */
+describe('the desktop layout gets the width it needs', () => {
+  test('the dialog widens exactly where the two-column layout applies', () => {
+    expect(DIALOG).toContain('sm:max-w-[640px]');
+    expect(DIALOG).toContain('sm:grid-cols-[minmax(0,1fr)_216px]');
+  });
+
+  test('and both use the breakpoint Modal itself switches at', () => {
+    // Modal renders a bottom sheet below 640px and a dialog above it. A grid on a different
+    // breakpoint would put two columns inside a sheet, or one inside a wide dialog.
+    const modal = readFileSync(join(import.meta.dir, 'Modal.tsx'), 'utf8');
+    expect(modal).toContain('(max-width: 639px)');
+  });
+
+  test('the empty state stays narrow — it has no second column', () => {
+    expect(DIALOG).toContain('className={nothingReady ? undefined :');
+  });
+});


### PR DESCRIPTION
On the demo the desktop layout was broken: keypad crushed against a column too narrow to hold it, "Credits earned" wrapping to one word per line, and the from/to legs truncated to a single character each.

The two-column layout and the dialog's width are **one decision** and I'd made them separately. The grid was gated on a breakpoint, but it renders inside a dialog fixed at 360px — so above 640px it dutifully forced a 216px keypad plus a full consequence column into 360px.

A breakpoint says how wide the *window* is. That isn't the same question as how wide the *container* is, and only the second one matters to a grid.

The dialog now widens to the reference's 640px exactly where the two-column layout applies. Both use 640px, which is also where `Modal` switches from a bottom sheet to a dialog — so the three can't disagree. The empty state stays narrow, having no second column to make room for.

Measured after the fix: every consequence row is a single 24px line, the dialog is 617px with no horizontal overflow, and the legs read "Cash account" and "Savings".

351 tests, 3 new — pinning the width to the layout that needs it.