### PR TITLE
Make savings back the credit line, and read encumbrance from the contract

### DIFF
--- a/app/server/src/routes/credit.ts
+++ b/app/server/src/routes/credit.ts
@@ -55,6 +55,9 @@ creditRouter.get('/:wallet', async (req: Request, res: Response) => {
       tiers: credit.tiers ?? [],
       plans: open.map((plan) => ({ ...plan, merchantName: merchantNames[plan.planId] ?? null })),
       cycle: credit.cycle,
+      // What of a member's savings cannot leave. Carried because it is not derivable from the
+      // tiers: encumbrance follows what is drawn, not what is pledged.
+      savingsEncumberedCents: credit.savingsEncumberedCents,
       // Named rather than implied: everything here came from chain, and the tiers the chain does
       // not know about are absent rather than zero. The caller decides what to do about that.
       source: 'chain',

--- a/app/server/src/routes/savings.ts
+++ b/app/server/src/routes/savings.ts
@@ -1,4 +1,5 @@
 import { Router, type Request, type Response } from 'express';
+import { syncSavingsCollateralFromBalance } from '../services/chain/savingsCollateralService.js';
 import { ethers } from 'ethers';
 import { requireWalletMatch, requireVerifiedWallet } from '../middleware/auth.js';
 import { savingsIntentService } from '../services/savingsIntentService.js';
@@ -325,6 +326,25 @@ savingsRouter.post('/gasless/submit', async (req: Request, res: Response) => {
     } catch (ledgerError) {
       console.error('[savings/gasless] equity ledger update failed:', ledgerError);
     }
+
+    /*
+     * Make the savings back the credit line.
+     *
+     * Minting CLRUSD is not what moves a member's limit — the registry reads what is *pledged*,
+     * not what is held, so without this a deposit lands and the savings tier stays at zero. That
+     * is what it did.
+     *
+     * Synced to the balance rather than adjusted by this transfer's amount, so a pledge that
+     * drifted for any reason (a sweep, a failed earlier sync, a redeem that raced this) is
+     * corrected rather than compounded.
+     *
+     * Best-effort, like the ledger above and for the same reason: the transfer is already on
+     * chain. A member whose follow-up write failed has their money and an unmoved limit, which is
+     * recoverable; a member whose confirmed deposit was reported as failed is not.
+     */
+    void syncSavingsCollateralFromBalance(ethers.getAddress(owner)).then((result) => {
+      if (!result.ok) console.error('[savings/gasless] collateral sync failed:', result.reason);
+    });
 
     res.json({ success: true, action, chainId: config.chainId, vaultAddress: config.vaultAddress, txHash, status: 'SUBMITTED' });
   } catch (error) {

--- a/app/server/src/services/chain/creditReader.ts
+++ b/app/server/src/services/chain/creditReader.ts
@@ -33,6 +33,11 @@ const ISSUER_ABI = [
 
 const REGISTRY_ABI = [
   'function collateralValueOf(address member, bytes32 kind) external view returns (uint256)',
+  // What may actually leave. Not the pledge minus anything the caller works out — the registry
+  // computes it from what is *drawn*, and the token enforces the same figure on transfer.
+  // What must stay put. The registry computes it from what is *drawn*, and CLRUSD consults the
+  // same function in `_update` to decide whether a transfer may proceed.
+  'function encumberedOf(address holder) external view returns (uint256)',
   'function collateralTypes(bytes32 kind) external view returns (uint8 backing, uint256 haircutBps, uint256 unitPrice, address valuer, bool registered)',
 ];
 
@@ -108,6 +113,14 @@ export interface ChainCredit {
   /** Null when the read failed — which is not the same as a member with no credit line. */
   tiers: ChainTier[] | null;
   plans: ChainTermPlan[] | null;
+  /**
+   * Savings that must stay put because credit is drawn against them, in cents. Null when unread.
+   *
+   * The figure CLRUSD enforces on transfer, so what is withdrawable is `balance − this`. Not
+   * `balance − pledged`: encumbrance follows what is drawn, so a fully pledged line nobody has
+   * touched encumbers nothing.
+   */
+  savingsEncumberedCents: number | null;
   /** Null when the read failed; zeroed when the member has never opened a line. */
   cycle: ChainCycle | null;
   complete: boolean;
@@ -299,6 +312,27 @@ async function readCycle(
 }
 
 /** A member's credit line, as the contracts hold it. */
+/**
+ * Savings that cannot move because credit is drawn against them.
+ *
+ * Null on a failed read, never zero — reporting nothing encumbered when we could not ask would
+ * offer a member an amount the token then refuses. Zero is only returned when the registry
+ * actually answered zero.
+ */
+async function readEncumbered(
+  provider: ethers.JsonRpcProvider,
+  registryAddress: string,
+  wallet: string,
+): Promise<number | null> {
+  try {
+    const registry = new ethers.Contract(registryAddress, REGISTRY_ABI, provider);
+    return toCents(await registry.encumberedOf(wallet));
+  } catch (error) {
+    console.error('[credit] encumbrance read failed', wallet, error);
+    return null;
+  }
+}
+
 export async function readChainCredit(
   wallet: string,
   chainId = resolveChainId(),
@@ -312,21 +346,23 @@ export async function readChainCredit(
     provider = getProvider(chainId);
   } catch (error) {
     console.error('[credit] no RPC for chain', chainId, error);
-    return { tiers: null, plans: null, cycle: null, complete: false };
+    return { tiers: null, plans: null, cycle: null, savingsEncumberedCents: null, complete: false };
   }
 
   // An unset issuer is no credit line, not a failed read: a member cannot have drawn against a
   // contract that does not exist.
-  const [tiers, plans, cycle] = await Promise.all([
+  const [tiers, plans, cycle, savingsEncumberedCents] = await Promise.all([
     issuer ? readTiers(provider, issuer, wallet, registry) : Promise.resolve([]),
     term ? readPlans(provider, term, wallet) : Promise.resolve([]),
     issuer ? readCycle(provider, issuer, wallet) : Promise.resolve(null),
+    registry ? readEncumbered(provider, registry, wallet) : Promise.resolve(0),
   ]);
 
   return {
     tiers,
     plans,
     cycle,
+    savingsEncumberedCents,
     complete: tiers !== null && plans !== null,
   };
 }

--- a/app/server/src/services/chain/savingsCollateralService.ts
+++ b/app/server/src/services/chain/savingsCollateralService.ts
@@ -1,0 +1,142 @@
+import { ethers } from 'ethers';
+import { getContractAddress } from '../../config/contracts.js';
+import { savingsIntentService } from '../savingsIntentService.js';
+
+/*
+ * Making savings back a credit line.
+ *
+ * Depositing mints CLRUSD, and that is where it stopped: the registry reads `pledgedOf`, not a
+ * member's balance, so five dollars of savings sat there backing nothing and the savings tier
+ * stayed at zero. Two calls close it.
+ *
+ *   pledge(member, SAVINGS, amount)   records the collateral. Operator-only.
+ *   pushCapacities(member)            derives the tier ceilings and writes them onto the issuer.
+ *
+ * Pledging costs a member nothing. Encumbrance is computed from what is *drawn*, not from what is
+ * pledged -- `_requiredUnits` returns zero when nothing is drawn -- so savings pledged against an
+ * untouched line remain entirely withdrawable. That is what makes pledging on deposit the right
+ * default rather than a decision to put in front of somebody: at 100% haircut it is the whole
+ * product promise, "borrow against your own money at no cost", and it takes nothing away.
+ *
+ * Best-effort, and deliberately so. The deposit has already landed on chain by the time this runs;
+ * failing the member's deposit because a follow-up write did not go through would be the wrong
+ * trade. A pledge that fails leaves the savings real and the line unmoved, which is exactly the
+ * state we are already in, and the next deposit or a manual sync repairs it.
+ */
+
+const REGISTRY_ABI = [
+  'function pledge(address member, bytes32 kind, uint256 amount)',
+  'function release(address member, bytes32 kind, uint256 amount)',
+  'function pledgedOf(address, bytes32) view returns (uint256)',
+  'function freeCollateralOf(address member, bytes32 kind) view returns (uint256)',
+];
+
+const CALCULATOR_ABI = ['function pushCapacities(address member) returns (uint256)'];
+
+/** `SAVINGS`, as the deploy script writes it — `encodeBytes32String`, not a hash. */
+export const SAVINGS_KIND = ethers.encodeBytes32String('SAVINGS');
+
+function chainId(): number {
+  const raw = (process.env.SAVINGS_DEFAULT_CHAIN_ID || process.env.SEND_DEFAULT_CHAIN_ID || '').trim();
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 84532;
+}
+
+function operatorKey(): string | null {
+  const raw = (process.env.CREDIT_OPERATOR_PRIVATE_KEY || process.env.DEPLOYER_PRIVATE_KEY || '').trim();
+  if (!raw) return null;
+  return raw.startsWith('0x') ? raw : `0x${raw}`;
+}
+
+export interface CollateralSyncResult {
+  ok: boolean;
+  reason?: string;
+  pledgedUnits?: string;
+  txHash?: string;
+}
+
+/**
+ * Bring a member's pledged savings in line with what they now hold.
+ *
+ * Synced to a target rather than incremented by a delta, because a delta assumes every movement
+ * came through here. Deposits from a sweep, a redeem that raced this call, a direct transfer --
+ * any of those leave an incremented figure describing a balance that no longer exists. Reading
+ * the current pledge and moving it to where it should be is idempotent, which also means a retry
+ * after a failure is safe.
+ *
+ * Never releases below what is encumbered: `release` reverts past `freeCollateralOf`, so a member
+ * whose savings are backing drawn credit keeps the pledge that is holding it up.
+ */
+export async function syncSavingsCollateral(
+  wallet: string,
+  targetUnits: bigint,
+): Promise<CollateralSyncResult> {
+  const registryAddress = getContractAddress(chainId(), 'CollateralRegistry');
+  const calculatorAddress = getContractAddress(chainId(), 'LimitCalculator');
+  if (!registryAddress) return { ok: false, reason: 'no collateral registry on this chain' };
+
+  const key = operatorKey();
+  if (!key) return { ok: false, reason: 'no CREDIT_OPERATOR_PRIVATE_KEY or DEPLOYER_PRIVATE_KEY' };
+
+  try {
+    const provider = new ethers.JsonRpcProvider(savingsIntentService.resolveRpcUrl(chainId()));
+    const signer = new ethers.Wallet(key, provider);
+    const registry = new ethers.Contract(registryAddress, REGISTRY_ABI, signer);
+    const member = ethers.getAddress(wallet);
+
+    const current: bigint = await registry.pledgedOf(member, SAVINGS_KIND);
+    let txHash: string | undefined;
+
+    if (targetUnits > current) {
+      const tx = await registry.pledge(member, SAVINGS_KIND, targetUnits - current);
+      txHash = (await tx.wait())?.hash ?? tx.hash;
+    } else if (targetUnits < current) {
+      // Only what is actually free. The rest is holding up drawn credit and the registry will
+      // refuse to let it go -- correctly.
+      const free: bigint = await registry.freeCollateralOf(member, SAVINGS_KIND);
+      const wanted = current - targetUnits;
+      const amount = wanted < free ? wanted : free;
+      if (amount > 0n) {
+        const tx = await registry.release(member, SAVINGS_KIND, amount);
+        txHash = (await tx.wait())?.hash ?? tx.hash;
+      }
+    }
+
+    // Always, even when the pledge did not move: capacities are derived from collateral *and*
+    // attestations, so this is also how an off-chain underwriting decision reaches the issuer.
+    // Permissionless by design -- a member whose collateral just moved should not wait for an
+    // operator to notice.
+    if (calculatorAddress) {
+      const calculator = new ethers.Contract(calculatorAddress, CALCULATOR_ABI, signer);
+      const push = await calculator.pushCapacities(member);
+      await push.wait();
+    }
+
+    return { ok: true, pledgedUnits: targetUnits.toString(), txHash };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error';
+    console.error('[savings] collateral sync failed for', wallet, message);
+    return { ok: false, reason: message };
+  }
+}
+
+/** Read a member's CLRUSD balance, which is the target the pledge is synced to. */
+export async function readSavingsUnits(wallet: string): Promise<bigint | null> {
+  const clrusd = getContractAddress(chainId(), 'CLRUSD') || getContractAddress(chainId(), 'ClearUSD');
+  if (!clrusd) return null;
+  try {
+    const provider = new ethers.JsonRpcProvider(savingsIntentService.resolveRpcUrl(chainId()));
+    const token = new ethers.Contract(clrusd, ['function balanceOf(address) view returns (uint256)'], provider);
+    return await token.balanceOf(ethers.getAddress(wallet));
+  } catch (error) {
+    console.error('[savings] balance read failed for', wallet, error instanceof Error ? error.message : error);
+    return null;
+  }
+}
+
+/** Sync a member's pledge to whatever they currently hold. The whole job, in one call. */
+export async function syncSavingsCollateralFromBalance(wallet: string): Promise<CollateralSyncResult> {
+  const units = await readSavingsUnits(wallet);
+  if (units === null) return { ok: false, reason: 'could not read the savings balance' };
+  return syncSavingsCollateral(wallet, units);
+}

--- a/app/src/components/clear/ConnectedMoveMoney.tsx
+++ b/app/src/components/clear/ConnectedMoveMoney.tsx
@@ -34,7 +34,7 @@ export default function ConnectedMoveMoney({
   const { openAddMoney, openAutoSave } = useMoneyActions();
   const address = useOptionalAddress();
   const [direction, setDirection] = useState<MoveDirection>('deposit');
-  const [pledgedCents, setPledgedCents] = useState<number | null>(null);
+  const [encumberedCents, setEncumberedCents] = useState<number | null>(null);
   const [credits, setCredits] = useState<number | null>(null);
 
   useEffect(() => {
@@ -42,8 +42,9 @@ export default function ConnectedMoveMoney({
     let cancelled = false;
     void getCredit(address).then((credit) => {
       if (cancelled || !credit) return;
-      const savingsTier = credit.tiers.find((tier) => tier.kind === 'SAVINGS');
-      setPledgedCents(savingsTier?.collateralValueCents ?? 0);
+      // What cannot leave, from the registry — not the pledge. Encumbrance follows what is
+      // *drawn*, so savings backing a line nobody has touched are entirely withdrawable.
+      setEncumberedCents(credit.savingsEncumberedCents);
     });
     // Equity credits come from the ledger that mints them, not from the page. It is the same read
     // Home and Savings already use, so a member sees one figure wherever they look at it.
@@ -101,7 +102,7 @@ export default function ConnectedMoveMoney({
       onDirectionChange={setDirection}
       cashReady={cashReady}
       savingsTotal={savingsTotal}
-      savingsFree={freeSavings(savingsTotal, pledgedCents)}
+      savingsFree={freeSavings(savingsTotal, encumberedCents)}
       credits={credits ?? 0}
       creditsGoal={data.savings.creditsGoal}
       reachesGoalBy={data.savings.onTrackFor}

--- a/app/src/components/clear/moveMoney.test.ts
+++ b/app/src/components/clear/moveMoney.test.ts
@@ -150,10 +150,10 @@ describe('every figure comes from its real source', () => {
     expect(CONNECTED).toContain('credits={credits ?? 0}');
   });
 
-  test('the pledged collateral comes from the credit contracts', () => {
-    // What is free to withdraw. There is no "limit today" line — that was mine, not the
-    // reference's; the box states the change, which needs no starting figure.
-    expect(CONNECTED).toContain('setPledgedCents');
+  test('what cannot be withdrawn comes from the credit contracts', () => {
+    // Encumbrance, not the pledge — see the withdrawal tests below for why those differ. There is
+    // no "limit today" line either; that was mine, not the reference's.
+    expect(CONNECTED).toContain('setEncumberedCents');
     expect(CONNECTED).not.toContain('data.creditLimitToday');
   });
 
@@ -287,5 +287,44 @@ describe('the desktop layout gets the width it needs', () => {
 
   test('the empty state stays narrow — it has no second column', () => {
     expect(DIALOG).toContain('className={nothingReady ? undefined :');
+  });
+});
+
+/*
+ * What a member may withdraw, from the contract's own rule rather than from arithmetic that looks
+ * right. `_requiredUnits` returns zero when nothing is drawn, so a fully pledged line nobody has
+ * touched encumbers nothing — the pledge-subtraction returned zero and would have locked a member
+ * out of their own savings. Verified against a real wallet: 5 CLRUSD held, 5 pledged, 0 drawn,
+ * `encumberedOf` = 0.
+ */
+describe('what is free to withdraw', () => {
+  test('nothing drawn means all of it, however much is pledged', () => {
+    expect(freeSavings(5, 0)).toBe(5);
+  });
+
+  test('drawing encumbers pound for pound at a 100% haircut', () => {
+    // required = drawn × 10000 / haircutBps. SAVINGS is 10000 bps, so spending $5 against it
+    // holds exactly $5 of savings still.
+    expect(freeSavings(5, 500)).toBe(0);
+  });
+
+  test('and it is marginal, not all-or-nothing', () => {
+    // Spending $2 of a $5 line holds $2 and leaves $3 to move.
+    expect(freeSavings(5, 200)).toBe(3);
+  });
+
+  test('never negative', () => {
+    expect(freeSavings(5, 900)).toBe(0);
+  });
+
+  test('an unreadable registry does not lock somebody out of their own savings', () => {
+    // The transfer still enforces the real rule, so the worst case is a rejected transaction
+    // rather than a member wrongly told their money is spoken for.
+    expect(freeSavings(5, null)).toBe(5);
+  });
+
+  test('the component reads encumbrance, not the pledge', () => {
+    expect(CONNECTED).toContain('credit.savingsEncumberedCents');
+    expect(CONNECTED).not.toContain('collateralValueCents');
   });
 });

--- a/app/src/lib/freeSavings.ts
+++ b/app/src/lib/freeSavings.ts
@@ -1,16 +1,28 @@
 /**
- * How much of savings is actually free to move.
+ * How much of savings may actually leave.
  *
- * Savings pledged against the credit line cannot leave — the token enforces it at transfer time —
- * so a withdrawal capped at the total balance would offer an amount the chain will refuse. The
- * pledged figure is the SAVINGS tier's collateral, which is the same number the limit breakdown
- * shows, read from the same route.
+ * This looked like arithmetic — balance minus what is pledged — and it is not. **Encumbrance
+ * follows what is drawn, not what is pledged.** Savings pledged against a line nobody has drawn on
+ * are entirely free, so that subtraction returns zero and tells a member their own money is locked.
  *
- * Falls back to the whole balance when credit cannot be read. That is the honest direction to fail:
- * the transfer itself still enforces the real rule, so the worst case is a rejected transaction
- * rather than a member wrongly told their own savings are locked.
+ * Worked through rather than guessed at a second time. What is free is everything not pledged
+ * (nothing encumbers it) plus the pledged part not holding up drawn credit:
+ *
+ *     free = (savings − pledged) + (pledged − required)
+ *          = savings − required
+ *
+ * So the only figure needed is `required`, which the registry calls `encumberedOf` — and that is
+ * the same function CLRUSD consults in `_update` to decide whether a transfer may proceed. One
+ * source, and it is the enforcing one, so the screen cannot offer an amount the chain refuses or
+ * refuse one it would allow.
+ *
+ * Confirmed on chain: 5 CLRUSD held, all 5 pledged, nothing drawn → `encumberedOf` = 0, so all 5
+ * are free. The pledge-subtraction would have said none were.
  */
-export function freeSavings(savingsTotal: number, pledgedCents: number | null): number {
-  if (pledgedCents === null) return savingsTotal;
-  return Math.max(0, savingsTotal - pledgedCents / 100);
+export function freeSavings(savingsTotal: number, encumberedCents: number | null): number {
+  // Unknown is not "none". A failed read must not lock somebody out of their own savings — the
+  // transfer still enforces the real rule, so the worst case is a rejected transaction rather
+  // than a member wrongly told their money is spoken for.
+  if (encumberedCents === null) return savingsTotal;
+  return Math.max(0, savingsTotal - encumberedCents / 100);
 }

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2312,6 +2312,13 @@ export interface CreditState {
   tiers: CreditTierRow[];
   plans: CreditTermPlanRow[];
   cycle: CreditCycleRow | null;
+  /**
+   * Savings that must stay put because credit is drawn against them, in cents. Null when unread.
+   *
+   * What CLRUSD enforces on transfer, so what a member may withdraw is `balance − this`. Not
+   * `balance − pledged`: a fully pledged line nobody has drawn on encumbers nothing.
+   */
+  savingsEncumberedCents: number | null;
   source: string;
   complete: boolean;
 }

--- a/scripts/sync_savings_collateral.ts
+++ b/scripts/sync_savings_collateral.ts
@@ -1,0 +1,78 @@
+import hre from "hardhat";
+import { getDeployment } from "../deploy/helpers";
+
+/*
+ * Pledges a member's savings so their credit line reflects it, and backfills anyone who deposited
+ * before the server started doing this.
+ *
+ * Depositing mints CLRUSD; the registry reads `pledgedOf`, not a balance. So savings deposited
+ * before that link existed are real, spendable, and backing nothing -- the savings tier reads zero
+ * with money sitting in it.
+ *
+ * Pledging costs the member nothing. Encumbrance is computed from what is drawn, not from what is
+ * pledged, so savings pledged against an untouched line stay entirely withdrawable.
+ *
+ *   WALLET=0x… npx hardhat run scripts/sync_savings_collateral.ts --network base-sepolia
+ *   WALLETS=0x…,0x… npx hardhat run scripts/sync_savings_collateral.ts --network base-sepolia
+ *
+ * Idempotent: it reads the current pledge and moves it to the balance, so re-running changes
+ * nothing. Run by an operator.
+ */
+const { ethers } = hre as typeof hre & { ethers: typeof import("hardhat").ethers };
+
+async function main() {
+  const network = (await ethers.provider.getNetwork()).name;
+  const registryRecord = getDeployment(network, "CollateralRegistry");
+  const calculatorRecord = getDeployment(network, "LimitCalculator");
+  const clrusdRecord = getDeployment(network, "ClearUSDUpgradeable");
+  if (!registryRecord) throw new Error(`No CollateralRegistry on ${network}.`);
+  if (!clrusdRecord) throw new Error(`No CLRUSD on ${network}.`);
+
+  const raw = (process.env.WALLETS || process.env.WALLET || "").trim();
+  if (!raw) throw new Error("Set WALLET=0x… or WALLETS=0x…,0x…");
+  const wallets = raw.split(",").map((w) => w.trim()).filter(Boolean);
+
+  const registry = await ethers.getContractAt("CollateralRegistry", registryRecord.address);
+  const token = await ethers.getContractAt("ClearUSDUpgradeable", clrusdRecord.address);
+  const SAVINGS = ethers.encodeBytes32String("SAVINGS");
+
+  for (const wallet of wallets) {
+    if (!ethers.isAddress(wallet)) throw new Error(`Not an address: ${wallet}`);
+    const member = ethers.getAddress(wallet);
+
+    const balance: bigint = await token.balanceOf(member);
+    const pledged: bigint = await registry.pledgedOf(member, SAVINGS);
+    console.log(`\n${member}`);
+    console.log("  CLRUSD held ", ethers.formatUnits(balance, 6));
+    console.log("  pledged     ", ethers.formatUnits(pledged, 6));
+
+    if (balance > pledged) {
+      await (await registry.pledge(member, SAVINGS, balance - pledged)).wait();
+      console.log("  pledged +   ", ethers.formatUnits(balance - pledged, 6));
+    } else if (balance < pledged) {
+      // Only what is free. The rest is holding up drawn credit, and the registry refuses to
+      // release it -- correctly.
+      const free: bigint = await registry.freeCollateralOf(member, SAVINGS);
+      const wanted = pledged - balance;
+      const amount = wanted < free ? wanted : free;
+      if (amount > 0n) {
+        await (await registry.release(member, SAVINGS, amount)).wait();
+        console.log("  released -  ", ethers.formatUnits(amount, 6));
+      }
+    } else {
+      console.log("  already in sync");
+    }
+
+    if (calculatorRecord) {
+      const calculator = await ethers.getContractAt("LimitCalculator", calculatorRecord.address);
+      await (await calculator.pushCapacities(member)).wait();
+      const capacity = await calculator.capacityOf(member, SAVINGS);
+      console.log("  savings line", ethers.formatUnits(capacity, 6));
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Reported from testnet: a $5 deposit landed, savings showed it, and the credit line stayed at zero. That was a real gap, and chasing it turned up a second bug I'd shipped hours earlier.

## Depositing minted CLRUSD and stopped

The registry reads `pledgedOf`, not a member's balance — so five dollars of savings sat there backing nothing. Verified on chain before changing anything:

| | |
|---|---|
| CLRUSD balance | 5.0 |
| `pledgedOf(SAVINGS)` | 0.0 |
| `capacityOf(SAVINGS)` | 0.0 |

Two calls close it, and the server now makes both after every savings transfer: `pledge` records the collateral, `pushCapacities` derives the tier ceilings and writes them onto the issuer. Best-effort, like the equity ledger beside it — the transfer is already on chain, and failing a confirmed deposit because a follow-up write didn't land is the wrong trade.

Synced to the balance rather than adjusted by the transfer's amount. A delta assumes every movement came through this path; a sweep, a redeem that raced it, or an earlier failed sync all leave an incremented figure describing a balance that no longer exists. Reading the pledge and moving it to where it should be is idempotent, so retries are safe.

`scripts/sync_savings_collateral.ts` does the same for anyone who deposited before this existed. Already run against the reporting wallet: **pledged 5.0, savings line 5.0.**

## And it exposed a bug in Move money

I capped withdrawals at `balance − pledged`. That looks like arithmetic and isn't: **encumbrance follows what is drawn, not what is pledged** — `_requiredUnits` returns zero when nothing is drawn. So the moment the pledge above started working, a member with $5 fully pledged and nothing drawn would have been told none of it could move.

Confirmed on chain: `pledged 5.0, free 5.0, encumbered 0.0`.

Worked through this time rather than guessed at twice. Free is everything unpledged plus the pledged part not holding up drawn credit:

```
free = (savings − pledged) + (pledged − required) = savings − required
```

`required` is `encumberedOf`, which is the same function CLRUSD consults in `_update` to decide whether a transfer may proceed. One source, and it's the enforcing one — so the screen can't offer an amount the chain refuses, or refuse one it would allow.

Carried through the credit route because it isn't derivable from the tiers, and null on a failed read rather than zero: reporting nothing encumbered when we couldn't ask would offer money the token then blocks.

## The behaviour this produces

Tiers are ordered cheapest-first and drawing fills them in order, so a card spend hits the 0 bps SAVINGS tier first. `required = drawn × 10000 / haircutBps`, and SAVINGS is 10,000 bps, so it encumbers pound for pound — spend $5 and all $5 of CLRUSD becomes unredeemable until repaid. Marginal, not all-or-nothing: spend $2 and $3 stays free.

## Verification

357 app tests, 6 new on the drawn-not-pledged rule including the marginal case. Backfill script run for real on Base Sepolia. Server and app both typecheck; app builds.

**Not verified:** the encumbrance path end to end, which needs credit actually drawn — that's the card, once activated.