### PR TITLE
Sync collateral on the sponsored deposit path

### DIFF
--- a/app/server/src/routes/savings.ts
+++ b/app/server/src/routes/savings.ts
@@ -501,6 +501,16 @@ savingsRouter.post('/gasless/record', async (req: Request, res: Response) => {
     } else {
       await payLedgerStore.clawbackDepositMatch({ wallet: ledgerWallet, amountMicros, network });
     }
+
+    // Make the savings back the credit line. This is the path a smart-account deposit takes -- the
+    // sponsored UserOp goes straight to the vault and reports here, never through /gasless/submit,
+    // so the sync living only there fired for the relayer fallback and not for the common case.
+    // That is why a first deposit needed a manual backfill and a second did not move the line.
+    // Synced to the balance, so it does not matter that this and /submit both run it.
+    void syncSavingsCollateralFromBalance(ethers.getAddress(wallet)).then((result) => {
+      if (!result.ok) console.error('[savings/record] collateral sync failed:', result.reason);
+    });
+
     res.json({ success: true });
   } catch (error) {
     res.status(500).json({ error: 'Failed to record credits', message: error instanceof Error ? error.message : 'Unknown error' });


### PR DESCRIPTION
Follow-up to #397. On the demo the line moved once (my manual backfill) and then a second deposit didn't move it at all. On chain: **10 CLRUSD held, 5 pledged** — the automatic sync never fired on a real deposit.

## The hole

The sync was on the wrong path. A smart-account deposit is a sponsored UserOp that goes straight to the vault and reports to `/api/savings/gasless/record`; the EOA relayer fallback is what hits `/gasless/submit`. **Every Privy embedded member takes the first path**, and I'd put the sync only on the second.

The tell was in the earlier screenshots and I misread it: equity credits updated on every deposit (recorded in `/record`) while the line didn't (pledge recorded in `/submit`). Two follow-ups to one deposit, wired to two different routes — and only one of them is the route deposits actually take.

## The fix

The sync is on both routes now. `/record` reads the balance and moves the pledge to match, same as `/submit`. Both are idempotent — sync-to-balance, not adjust-by-delta — so it doesn't matter that a deposit might touch one or the other, and a relayer deposit that somehow hit both would still be correct.

Timing is safe: `/record` already verifies the deposit on chain (parses the vault's `Deposited` event) before it runs, so the balance the sync reads is the mined one.

## State

Reporting wallet backfilled to **pledged 10.0, savings line 10.0** — matching the $10 in savings. From here it tracks deposits on its own.

**Still unverified end to end:** that a *fresh* deposit now moves the line without intervention. That's the next thing to watch on the demo once this deploys — deposit $5 and the line should go to $15 on its own.