### PR TITLE
Grant the credit operator the role it needs to pledge collateral

### DIFF
--- a/scripts/grant_collateral_operator.ts
+++ b/scripts/grant_collateral_operator.ts
@@ -1,0 +1,60 @@
+import hre from "hardhat";
+import { getDeployment } from "../deploy/helpers";
+
+/*
+ * Grants the credit operator the roles it needs to pledge collateral.
+ *
+ * `RevolvingIssuer` checks operators through `AccessManager`; `CollateralRegistry` and
+ * `LimitCalculator` are plain AccessControl and check their own `OPERATOR_ROLE`. Those are three
+ * separate grants, and the operator only ever got the first -- so `openLine` worked and `pledge`
+ * reverted on the access check, which surfaces as "missing revert data" during gas estimation
+ * because AccessControl's custom error carries no string the provider returns.
+ *
+ * The symptom was a savings deposit that never moved the credit line: the server's sync ran on
+ * every deposit, tried to pledge, and was refused. Manual backfills succeeded because they run as
+ * the deployer, which holds the admin role -- so the fix looked like it worked and then never
+ * worked again.
+ *
+ *   OPERATOR=0x… npx hardhat run scripts/grant_collateral_operator.ts --network base-sepolia
+ *
+ * Run by an admin. Idempotent.
+ */
+const { ethers } = hre as typeof hre & { ethers: typeof import("hardhat").ethers };
+
+const TARGETS = ["CollateralRegistry", "LimitCalculator"] as const;
+
+async function main() {
+  const network = (await ethers.provider.getNetwork()).name;
+  const operator = process.env.OPERATOR?.trim();
+  if (!operator || !ethers.isAddress(operator)) throw new Error("Set OPERATOR to an address.");
+  const member = ethers.getAddress(operator);
+
+  for (const name of TARGETS) {
+    const record = getDeployment(network, name);
+    if (!record) {
+      console.log(`${name}: not deployed on ${network}, skipping`);
+      continue;
+    }
+    const contract = await ethers.getContractAt(name, record.address);
+    const role = await contract.OPERATOR_ROLE();
+
+    if (await contract.hasRole(role, member)) {
+      console.log(`${name}: already an operator`);
+      continue;
+    }
+    await (await contract.grantRole(role, member)).wait();
+    console.log(`${name}: granted OPERATOR_ROLE to ${member}`);
+  }
+
+  console.log("\nCheck the operator has gas — a role without ETH is still an operator that cannot act.");
+  const balance = await ethers.provider.getBalance(member);
+  console.log("operator balance:", ethers.formatEther(balance), "ETH");
+  if (balance < ethers.parseEther("0.002")) {
+    console.log("  ^ low. Two writes per deposit (pledge + pushCapacities) will exhaust this.");
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/rotate_credit_operator.ts
+++ b/scripts/rotate_credit_operator.ts
@@ -53,6 +53,41 @@ async function main() {
     console.log("No OLD_OPERATOR given — nothing revoked. Pass it to complete the rotation.");
   }
 
+  /*
+   * Three role systems, not one.
+   *
+   * The issuer checks operators through AccessManager; CollateralRegistry and LimitCalculator are
+   * plain AccessControl and check their own OPERATOR_ROLE. Granting only the first is what left an
+   * operator that could open a credit line and not pledge collateral against it -- so deposits
+   * landed and the savings tier stayed at zero, silently, because AccessControl's revert carries
+   * no string and surfaces as "missing revert data" during gas estimation.
+   *
+   * Rotating the key has to move all three or it reintroduces exactly that.
+   */
+  for (const name of ["CollateralRegistry", "LimitCalculator"] as const) {
+    const record = getDeployment(network, name);
+    if (!record) {
+      console.log(`${name}: not deployed on ${network}, skipping`);
+      continue;
+    }
+    const contract = await ethers.getContractAt(name, record.address);
+    const role = await contract.OPERATOR_ROLE();
+
+    if (!(await contract.hasRole(role, next))) {
+      await (await contract.grantRole(role, next)).wait();
+      console.log(`${name}: granted OPERATOR_ROLE to`, next);
+    } else {
+      console.log(`${name}: already an operator`);
+    }
+
+    if (previous && ethers.isAddress(previous) && previous.toLowerCase() !== next.toLowerCase()) {
+      if (await contract.hasRole(role, previous)) {
+        await (await contract.revokeRole(role, previous)).wait();
+        console.log(`${name}: revoked OPERATOR_ROLE from`, previous);
+      }
+    }
+  }
+
   console.log("new is operator  :", await access.isOperator(next));
   console.log("new is admin     :", await access.isAdmin(next), "(should be false)");
 }


### PR DESCRIPTION
Three deposits, line stuck at exactly what the last manual backfill set. I'd assumed the server wasn't deployed. **It was** — the logs show the sync running on every deposit, on both paths, trying to pledge 5 then 10 then 15 as the balance grew, and being refused each time.

## Root cause

The credit operator has **no `OPERATOR_ROLE` on `CollateralRegistry`**.

Three role systems, not one:
- `RevolvingIssuer` checks operators through `AccessManager` ← the only one granted
- `CollateralRegistry` is plain AccessControl with its own `OPERATOR_ROLE`
- `LimitCalculator` likewise

So the operator could open a credit line and could not pledge collateral against it.

## Why it took three rounds to find

**It fails as `missing revert data` during gas estimation.** AccessControl's revert carries no string the provider returns, so a permission error looks identical to a flaky RPC. I read it as the latter twice.

**And every manual backfill ran as the deployer**, which holds the admin role. So each fix appeared to work — the line moved, I verified it on chain, and then it never moved again on its own. The backfill was masking the actual bug each time I "fixed" it.

## The fix

`scripts/grant_collateral_operator.ts`, run on Base Sepolia. The previously-failing call now estimates cleanly at 83,818 gas.

`rotate_credit_operator.ts` only ever moved the AccessManager role, so rotating the key would have reintroduced this. It now grants **and revokes** all three.

## Flagging

The operator holds **0.00029 ETH**. Each deposit costs it two writes (`pledge` + `pushCapacities`), so it needs topping up or this stops again for a duller reason. The grant script now warns below 0.002.

## What to watch

Next deposit should move the line on its own, no backfill. That's the first time that will have been true.