### PR TITLE
Price the operator's gas instead of guessing

### DIFF
--- a/scripts/grant_collateral_operator.ts
+++ b/scripts/grant_collateral_operator.ts
@@ -46,11 +46,26 @@ async function main() {
     console.log(`${name}: granted OPERATOR_ROLE to ${member}`);
   }
 
-  console.log("\nCheck the operator has gas — a role without ETH is still an operator that cannot act.");
+  /*
+   * Gas, measured rather than guessed at.
+   *
+   * An earlier version of this warned below a flat 0.002 ETH, which is a mainnet-shaped number and
+   * badly wrong on an L2 -- it reported a healthy operator as nearly empty and sent a real
+   * investigation chasing a non-problem. A pledge is ~85k gas, and two writes per deposit, so the
+   * only honest way to state a runway is to price it at the chain's current fee.
+   */
   const balance = await ethers.provider.getBalance(member);
-  console.log("operator balance:", ethers.formatEther(balance), "ETH");
-  if (balance < ethers.parseEther("0.002")) {
-    console.log("  ^ low. Two writes per deposit (pledge + pushCapacities) will exhaust this.");
+  const fee = await ethers.provider.getFeeData();
+  const gasPrice = fee.gasPrice ?? fee.maxFeePerGas ?? 0n;
+  const perDeposit = gasPrice * 85_000n * 2n;
+
+  console.log("\noperator balance:", ethers.formatEther(balance), "ETH");
+  if (perDeposit > 0n) {
+    console.log("cost per deposit:", ethers.formatEther(perDeposit), "ETH  (pledge + pushCapacities)");
+    console.log("runway          :", (balance / perDeposit).toString(), "deposits");
+    if (balance / perDeposit < 50n) {
+      console.log("  ^ low — top up. A role without gas is still an operator that cannot act.");
+    }
   }
 }
 


### PR DESCRIPTION
**No funds needed — my alarm was wrong.**

The warning I added fired below a flat `0.002 ETH`, which is a mainnet-shaped number and meaningless on an L2. Base Sepolia gas is 0.006 gwei, so a deposit costs **0.0000010 ETH** and the operator's existing balance covers **283 of them**. I reported a healthy operator as nearly empty and sent a real investigation chasing a non-problem.

The check now measures — current fee data × ~85k gas × two writes — and reports a **runway in deposits** rather than a verdict on a balance. It warns under 50 deposits, which says how many more times this can work, instead of naming an ETH figure that means different things on different chains.

## And the role fix is now verified properly

Signing as the **operator key the server uses**, not the deployer. That distinction is the entire reason three previous attempts looked fixed and weren't:

| | |
|---|---|
| `pledgedOf(SAVINGS)` | **25.0** |
| `LimitCalculator.capacityOf` | **25.0** |
| `RevolvingIssuer` SAVINGS tier | **25.0** ← what the app reads |

Written by the operator itself, with no admin role involved.