### PR TITLE
Stop two syncs racing, and refetch the limit rather than guessing it

### DIFF
--- a/app/server/src/services/chain/savingsCollateralService.ts
+++ b/app/server/src/services/chain/savingsCollateralService.ts
@@ -22,6 +22,20 @@ import { savingsIntentService } from '../savingsIntentService.js';
  * failing the member's deposit because a follow-up write did not go through would be the wrong
  * trade. A pledge that fails leaves the savings real and the line unmoved, which is exactly the
  * state we are already in, and the next deposit or a manual sync repairs it.
+ *
+ * ## One sync per wallet at a time
+ *
+ * Both `/gasless/submit` and `/gasless/record` call this, because a deposit takes one route or the
+ * other depending on the member's wallet. When one deposit reached both, two syncs ran
+ * concurrently on the same operator key: they read the same state, built identical transactions,
+ * and collided on the same nonce -- so the two became one transaction, which then ran out of gas
+ * because the pledge landed between its gas estimate and its execution. The pledge stuck and the
+ * capacity push did not, which is the worst of the three possible outcomes: a member whose
+ * collateral is recorded and whose limit does not know about it.
+ *
+ * Coalesced rather than queued. A second caller for the same wallet joins the first call's promise
+ * instead of starting another, which is correct rather than merely safe: both were asking the same
+ * question -- "make the pledge match the balance" -- and one answer serves both.
  */
 
 const REGISTRY_ABI = [
@@ -48,6 +62,12 @@ function operatorKey(): string | null {
   return raw.startsWith('0x') ? raw : `0x${raw}`;
 }
 
+/**
+ * Syncs in flight, by wallet. Module-level because two concurrent HTTP handlers in this process are
+ * exactly the case being guarded, and a per-request value cannot see the other request.
+ */
+const inFlight = new Map<string, Promise<CollateralSyncResult>>();
+
 export interface CollateralSyncResult {
   ok: boolean;
   reason?: string;
@@ -71,6 +91,16 @@ export async function syncSavingsCollateral(
   wallet: string,
   targetUnits: bigint,
 ): Promise<CollateralSyncResult> {
+  const key = wallet.trim().toLowerCase();
+  const running = inFlight.get(key);
+  if (running) return running;
+
+  const attempt = runSync(wallet, targetUnits).finally(() => inFlight.delete(key));
+  inFlight.set(key, attempt);
+  return attempt;
+}
+
+async function runSync(wallet: string, targetUnits: bigint): Promise<CollateralSyncResult> {
   const registryAddress = getContractAddress(chainId(), 'CollateralRegistry');
   const calculatorAddress = getContractAddress(chainId(), 'LimitCalculator');
   if (!registryAddress) return { ok: false, reason: 'no collateral registry on this chain' };
@@ -108,8 +138,21 @@ export async function syncSavingsCollateral(
     // operator to notice.
     if (calculatorAddress) {
       const calculator = new ethers.Contract(calculatorAddress, CALCULATOR_ABI, signer);
-      const push = await calculator.pushCapacities(member);
-      await push.wait();
+      /*
+       * Estimated with headroom, not taken at face value.
+       *
+       * The pledge immediately above changes the very state this call reads, so an estimate is a
+       * measurement of the world before the write it follows. Executed after it, the same call
+       * writes a *changed* capacity rather than an identical one and costs more -- and a limit set
+       * exactly to the estimate runs out of gas and reverts with no reason data, which is what
+       * happened. The buffer is on the gas limit only; unused gas is not charged.
+       */
+      const estimate = await calculator.pushCapacities.estimateGas(member);
+      const push = await calculator.pushCapacities(member, { gasLimit: (estimate * 15n) / 10n });
+      const receipt = await push.wait();
+      if (receipt?.status === 0) {
+        return { ok: false, reason: 'pushCapacities reverted', pledgedUnits: targetUnits.toString() };
+      }
     }
 
     return { ok: true, pledgedUnits: targetUnits.toString(), txHash };

--- a/app/src/components/clear/ConnectedMoveMoney.tsx
+++ b/app/src/components/clear/ConnectedMoveMoney.tsx
@@ -63,6 +63,13 @@ export default function ConnectedMoveMoney({
       // that could have settled a card authorization.
       const delta = moved === 'deposit' ? amount : -amount;
       balances.applyOptimistic(-delta, delta);
+
+      // The balances above are safe to show optimistically -- the transfer confirmed, so they are
+      // already true. The credit limit is not: it moves only once the server has pledged the
+      // collateral and pushed the capacities, two writes later. So this asks for a re-read rather
+      // than predicting a figure the contracts have not agreed to yet.
+      window.dispatchEvent(new Event('clear:credit-stale'));
+
       track('savings_move', { direction: moved }); // direction only, never the amount
     },
     [balances],

--- a/app/src/components/clear/moveMoney.test.ts
+++ b/app/src/components/clear/moveMoney.test.ts
@@ -328,3 +328,29 @@ describe('what is free to withdraw', () => {
     expect(CONNECTED).not.toContain('collateralValueCents');
   });
 });
+
+/*
+ * The limit is not ours to predict.
+ *
+ * Balances are safe to show optimistically — the transfer confirmed, so they are already true. The
+ * limit is not: it moves only after the server pledges the collateral and pushes the capacities,
+ * two writes later. Faking it would have hidden a real bug where the pledge landed and the push
+ * did not, leaving collateral recorded and the line unaware of it.
+ */
+describe('what may be shown before the chain agrees', () => {
+  test('balances are optimistic, the limit is not', () => {
+    expect(CONNECTED).toContain('balances.applyOptimistic');
+    // No arithmetic on a limit anywhere in the connected component.
+    expect(CONNECTED).not.toContain('creditLimit');
+  });
+
+  test('a move asks for a re-read instead', () => {
+    expect(CONNECTED).toContain("new Event('clear:credit-stale')");
+  });
+
+  test('and the reader refetches on it, with backoff for the two writes', () => {
+    const home = readFileSync(join(import.meta.dir, '../../pages/app/HomeRoute.tsx'), 'utf8');
+    expect(home).toContain("addEventListener('clear:credit-stale'");
+    expect(home).toContain('[3000, 8000, 15000]');
+  });
+});

--- a/app/src/pages/app/HomeRoute.tsx
+++ b/app/src/pages/app/HomeRoute.tsx
@@ -83,11 +83,35 @@ export default function HomeRoute() {
     // Null covers both "no credit line" and "could not read the chain", and the route distinguishes
     // them with a 503 for the second. Either way the placeholder stands rather than a zeroed line:
     // telling a member their credit is gone because an RPC timed out is the worse mistake.
-    void getCredit(address).then((result) => {
-      if (!cancelled) setCredit(result);
-    });
+    const read = () => {
+      void getCredit(address).then((result) => {
+        if (!cancelled) setCredit(result);
+      });
+    };
+    read();
+
+    /*
+     * Re-read after something that changes the line, rather than showing a guess.
+     *
+     * A savings deposit moves the limit, but not instantly: the server pledges the collateral and
+     * pushes the capacities, which is two on-chain writes after the deposit itself confirms. Until
+     * they land the old limit is the true one, so this refetches on a signal instead of predicting
+     * the new figure -- an optimistic limit would be inventing a number that only the contracts get
+     * to decide, and it would have hidden the bug where the pledge landed and the push did not.
+     *
+     * Backs off across a short window because the writes take a few seconds and the app has no way
+     * to be told when they finish.
+     */
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const onStale = () => {
+      for (const delay of [3000, 8000, 15000]) timers.push(setTimeout(read, delay));
+    };
+    window.addEventListener('clear:credit-stale', onStale);
+
     return () => {
       cancelled = true;
+      window.removeEventListener('clear:credit-stale', onStale);
+      for (const timer of timers) clearTimeout(timer);
     };
   }, [address]);
 


### PR DESCRIPTION
**Your instinct was right — don't hide it.** The backend was *not* fully working, and optimistic display would have painted $30 on screen tonight while the issuer said $25. That's exactly the bug it would have concealed.

## What was actually broken

The pledge worked automatically this time: **30 held, 30 pledged.** The capacity push didn't — issuer stuck at 25. Collateral recorded and the line unaware of it, which is the worst of the three possible outcomes.

Caused by wiring the sync onto both routes in #398. One deposit reached `/gasless/submit` *and* `/gasless/record`; both ran a sync on the same operator key and built identical transactions on the same nonce — the tell was **both handlers logging the same tx hash**. Merged into one transaction, it then ran out of gas: its limit came from an estimate taken *before* the pledge landed, and executing after the pledge means writing a *changed* capacity rather than an identical one.

It needed **412,607** gas and had **406,124**. Short by six thousand — and it reverts with `reason: null`, so it reads as a mystery rather than as out-of-gas. Confirmed by replaying the same call one block earlier, where it succeeds.

## Two fixes

**Syncs are coalesced per wallet.** A second caller joins the first call's promise rather than starting another — right rather than merely safe, since both are asking the same question and one answer serves both.

**The push is sent with headroom over its estimate.** An estimate taken before the write it follows is a measurement of the wrong world. Gas limit only; unused gas isn't charged.

Issuer is caught up: **SAVINGS 30.0**, matching balance and pledge.

## On showing it sooner

Balances stay optimistic; the limit does not. Balances are already true the moment the transfer confirms — the limit isn't, because it moves two writes later and only the contracts decide it. So a deposit now dispatches a credit re-read on a short backoff (3s/8s/15s) instead of predicting a figure.

That gets you the real number in seconds rather than on next page load, without inventing one.

360 tests, 3 new pinning that distinction.