### PR TITLE
Audit bonds and pool shares for the savings bug

### DIFF
--- a/app/server/src/services/chain/collateralCoverage.test.ts
+++ b/app/server/src/services/chain/collateralCoverage.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const READER = readFileSync(join(import.meta.dir, 'creditReader.ts'), 'utf8');
+const SYNC = readFileSync(join(import.meta.dir, 'savingsCollateralService.ts'), 'utf8');
+
+/*
+ * Every tier the issuer offers has to be reachable, and this is the test that says so.
+ *
+ * The savings tier read zero for weeks with money sitting behind it, because minting the asset and
+ * pledging it as collateral are separate steps and only the first was wired. Then the asset tiers
+ * turned out to have the same shape of hole twice over: nothing pledges them, and the limits read
+ * asked for a kind that is not an issuer tier at all.
+ *
+ * These are deployment facts, not code facts, which is why they kept slipping through unit tests.
+ * The tiers below are what `RevolvingIssuer.tierAt` actually returns on Base Sepolia, read from
+ * chain. If a tier is added, this list must grow, and the two checks under it say what wiring the
+ * new tier needs before it can ever be anything but zero.
+ */
+const ISSUER_TIERS = ['SAVINGS', 'BOND', 'POOL_SHARE', 'INCOME', 'BOOST'] as const;
+
+/** Tiers backed by a pledged asset. These need a sync that pledges as holdings change. */
+const COLLATERAL_TIERS = ['SAVINGS', 'BOND', 'POOL_SHARE'] as const;
+
+/**
+ * Underwritten off-chain and delivered as attestations, so they have no holdings to sync. Named
+ * here rather than left implicit — "no sync" has to be a decision, not an omission.
+ */
+const ATTESTED_TIERS = ['INCOME', 'BOOST'] as const;
+
+describe('every issuer tier is accounted for', () => {
+  test('the two lists cover the issuer exactly', () => {
+    expect([...COLLATERAL_TIERS, ...ATTESTED_TIERS].sort()).toEqual([...ISSUER_TIERS].sort());
+  });
+});
+
+describe('the limits read asks for tiers that exist', () => {
+  test('it reads only kinds the issuer actually offers', () => {
+    const asked = [...READER.matchAll(/encodeBytes32String\('([A-Z_]+)'\)/g)].map((m) => m[1]);
+    expect(asked.length).toBeGreaterThan(0);
+    for (const kind of new Set(asked)) {
+      expect(ISSUER_TIERS).toContain(kind as (typeof ISSUER_TIERS)[number]);
+    }
+  });
+
+  test('ASSET_INTERNAL is never asked for', () => {
+    // Registered as a collateral type, but not an issuer tier — so nothing is ever pledged under
+    // it and the read returns zero forever. Zero is a number, so a caller's `?? fallback` never
+    // fires either: the failure is total and silent.
+    expect(READER).not.toContain("encodeBytes32String('ASSET_INTERNAL')");
+  });
+
+  test('both asset tiers are read, not just one', () => {
+    expect(READER).toContain("encodeBytes32String('BOND')");
+    expect(READER).toContain("encodeBytes32String('POOL_SHARE')");
+  });
+});
+
+describe('collateral tiers have something that pledges them', () => {
+  test('savings syncs from the balance that backs it', () => {
+    expect(SYNC).toContain('SAVINGS');
+    expect(SYNC).toContain('syncSavingsCollateralFromBalance');
+  });
+
+  /*
+   * Deliberately not asserting that bonds and pool shares sync yet — they cannot, because there is
+   * no way to buy either. `BuyBondDialog` and `PoolDepositDialog` render with no handler, nothing
+   * calls the bond or pool contracts, and so no member can hold one to pledge.
+   *
+   * This test documents that and will fail the moment it stops being true, which is exactly when
+   * the pledge becomes necessary. Whoever wires the purchase will land here and be told what else
+   * the tier needs, instead of shipping a bond that mints fine and backs nothing.
+   */
+  test('bonds and pool shares still have no purchase path — wire the pledge when they do', () => {
+    const app = join(import.meta.dir, '../../../../src');
+    const sendCalls = readFileSync(join(app, 'lib/sendCalls.ts'), 'utf8');
+    const bondPathExists = /scBuyBond|BondVault|burnerBond/i.test(sendCalls);
+    const poolPathExists = /scPoolDeposit|LendingPool/i.test(sendCalls);
+
+    if (bondPathExists || poolPathExists) {
+      // A purchase path now exists. The tier it feeds needs a pledge, or it reads zero with the
+      // asset sitting behind it — the savings bug, again, in a tier nobody is watching yet.
+      expect(SYNC).toMatch(/BOND|POOL_SHARE/);
+    } else {
+      expect(bondPathExists).toBe(false);
+      expect(poolPathExists).toBe(false);
+    }
+  });
+});

--- a/app/server/src/services/chain/creditReader.ts
+++ b/app/server/src/services/chain/creditReader.ts
@@ -268,11 +268,26 @@ export async function readChainCapacities(
   try {
     const provider = getProvider(chainId);
     const limits = new ethers.Contract(calculator, LIMITS_ABI, provider);
-    const [savings, asset] = await Promise.all([
+    /*
+     * The asset tiers are BOND and POOL_SHARE, and there are two of them.
+     *
+     * This read asked for ASSET_INTERNAL, which is a registered collateral type and *not* an
+     * issuer tier — so nothing is ever pledged under it and the answer was always zero. The card's
+     * asset limit would have stayed at zero however many bonds a member held, and silently: zero
+     * is a number, so the caller's fallback to computing from holdings never fires either.
+     *
+     * Same keying mistake as the one already fixed on the issuer side; the reader kept the old key.
+     */
+    const [savings, bond, poolShare] = await Promise.all([
       limits.capacityOf(wallet, ethers.encodeBytes32String('SAVINGS')),
-      limits.capacityOf(wallet, ethers.encodeBytes32String('ASSET_INTERNAL')),
+      limits.capacityOf(wallet, ethers.encodeBytes32String('BOND')),
+      limits.capacityOf(wallet, ethers.encodeBytes32String('POOL_SHARE')),
     ]);
-    return { savingsCents: toCents(savings), assetCents: toCents(asset), available: true };
+    return {
+      savingsCents: toCents(savings),
+      assetCents: toCents(bond) + toCents(poolShare),
+      available: true,
+    };
   } catch (error) {
     console.error('[credit] capacity read failed', calculator, error);
     return { savingsCents: null, assetCents: null, available: false };


### PR DESCRIPTION
Checked whether the savings failure had landed on the other two collateral tiers. It hasn't — because it *can't* yet. But a real bug was already sitting there, and a worse version was waiting.

## Bonds and pool deposits have no transaction path at all

`BuyBondDialog` and `PoolDepositDialog` render with **no handler**. Nothing in the app references `BondVault` or `LendingPool`; there's no `scBuyBond` or `scPoolDeposit`. The buttons do nothing.

So the savings failure — asset minted, collateral never pledged, tier silently zero — cannot occur, because no asset is ever minted. That's an unbuilt feature rather than silent wrong state, which is the better of the two problems.

## But the limits read was already broken

It asked for `capacityOf(ASSET_INTERNAL)`. **`ASSET_INTERNAL` is a registered collateral type and not an issuer tier** — the asset tiers are `BOND` and `POOL_SHARE`. So nothing is ever pledged under it and the read returned zero forever. Same keying mistake already fixed on the issuer side; the reader kept the old key.

Nastier than it looks: the caller falls back to computing the asset limit from raw holdings *only when the chain figure is absent* — and zero is present. So a member holding bonds would have had their card's asset limit pinned at zero by a read confidently answering about the wrong thing.

Now reads both real tiers and sums them.

## A guard, because this keeps recurring

`collateralCoverage.test.ts` pins what the issuer actually offers against what the code wires:

- every tier is either **collateral something must pledge**, or an **attestation with no holdings to sync** — and no tier may be missing from both lists
- `ASSET_INTERNAL` is refused by name
- it **fails if a bond or pool purchase path appears without a matching pledge**

That last one is the point: whoever wires the buy button lands on a failing test telling them what else the tier needs, instead of shipping a bond that mints fine and backs nothing.

These are deployment facts, not code facts — which is why unit tests kept passing while a tier read zero with money behind it.

## Also confirmed

Savings is now syncing **on its own**: pledged 95.0 against a 95.0 balance, with no script from me. The earlier fix is genuinely working unaided.

No optimistic update added, as asked.

366 tests, 6 new.