### PR TITLE
Wire the yield pool, moving funds from Ready to allocate

### DIFF
--- a/app/server/src/routes/savings.ts
+++ b/app/server/src/routes/savings.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import { syncSavingsCollateralFromBalance } from '../services/chain/savingsCollateralService.js';
+import { syncSavingsCollateralFromBalance, syncPoolCollateral } from '../services/chain/savingsCollateralService.js';
 import { ethers } from 'ethers';
 import { requireWalletMatch, requireVerifiedWallet } from '../middleware/auth.js';
 import { savingsIntentService } from '../services/savingsIntentService.js';
@@ -460,6 +460,37 @@ savingsRouter.post('/gasless/wallet-transfer/submit', async (req: Request, res: 
  * accrues credits. Idempotent per txHash. NOTE: trusts the authenticated wallet + amount for now;
  * mainnet should verify the tx receipt's Deposited/Redeemed event before crediting.
  */
+/**
+ * A yield-pool movement landed on chain; pledge the position behind it.
+ *
+ * Its own route rather than a third action on `/gasless/record`, because that route's body is
+ * about a vault deposit -- it verifies the ESA's own event and writes the equity-credit match, and
+ * neither applies to the pool. A pool deposit earns yield, not credits.
+ *
+ * Nothing is trusted from the body but the fact that something happened: the position is read back
+ * from the pool and the pledge is synced to it, so a wrong or replayed amount changes nothing.
+ */
+savingsRouter.post('/pool/record', async (req: Request, res: Response) => {
+  try {
+    const wallet = req.auth?.walletAddress;
+    if (!wallet || !ethers.isAddress(wallet)) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const result = await syncPoolCollateral(ethers.getAddress(wallet));
+    if (!result.ok) console.error('[pool/record] collateral sync failed:', result.reason);
+
+    // Answered as accepted either way. The movement is already on chain; a failed pledge leaves a
+    // position that backs nothing yet, which the next movement or a manual sync repairs -- and
+    // reporting failure here would tell a member their deposit did not work when it did.
+    res.json({ success: true, pledged: result.ok });
+  } catch (error) {
+    console.error('[pool/record] failed:', error);
+    res.status(500).json({ error: 'Failed to record pool movement' });
+  }
+});
+
 savingsRouter.post('/gasless/record', async (req: Request, res: Response) => {
   try {
     const wallet = req.auth?.walletAddress;

--- a/app/server/src/services/chain/savingsCollateralService.ts
+++ b/app/server/src/services/chain/savingsCollateralService.ts
@@ -47,8 +47,9 @@ const REGISTRY_ABI = [
 
 const CALCULATOR_ABI = ['function pushCapacities(address member) returns (uint256)'];
 
-/** `SAVINGS`, as the deploy script writes it — `encodeBytes32String`, not a hash. */
+/** Kinds as the deploy script writes them — `encodeBytes32String`, not a hash. */
 export const SAVINGS_KIND = ethers.encodeBytes32String('SAVINGS');
+export const POOL_SHARE_KIND = ethers.encodeBytes32String('POOL_SHARE');
 
 function chainId(): number {
   const raw = (process.env.SAVINGS_DEFAULT_CHAIN_ID || process.env.SEND_DEFAULT_CHAIN_ID || '').trim();
@@ -91,16 +92,35 @@ export async function syncSavingsCollateral(
   wallet: string,
   targetUnits: bigint,
 ): Promise<CollateralSyncResult> {
-  const key = wallet.trim().toLowerCase();
+  return syncCollateralKind(wallet, SAVINGS_KIND, targetUnits);
+}
+
+/**
+ * The same sync, for any pledged kind.
+ *
+ * Savings and pool shares differ in where the target comes from and in nothing else — both are an
+ * amount the registry values at a flat price, both are pledged by the operator, and both need the
+ * capacities pushed afterwards. One implementation so the second tier cannot drift from the first,
+ * which is the failure this whole area keeps producing.
+ *
+ * The in-flight guard is per wallet *and* kind: two kinds syncing at once are different rows and
+ * must not deduplicate each other, while two syncs of the same kind are the same work twice.
+ */
+export async function syncCollateralKind(
+  wallet: string,
+  kind: string,
+  targetUnits: bigint,
+): Promise<CollateralSyncResult> {
+  const key = `${wallet.trim().toLowerCase()}:${kind}`;
   const running = inFlight.get(key);
   if (running) return running;
 
-  const attempt = runSync(wallet, targetUnits).finally(() => inFlight.delete(key));
+  const attempt = runSync(wallet, kind, targetUnits).finally(() => inFlight.delete(key));
   inFlight.set(key, attempt);
   return attempt;
 }
 
-async function runSync(wallet: string, targetUnits: bigint): Promise<CollateralSyncResult> {
+async function runSync(wallet: string, kind: string, targetUnits: bigint): Promise<CollateralSyncResult> {
   const registryAddress = getContractAddress(chainId(), 'CollateralRegistry');
   const calculatorAddress = getContractAddress(chainId(), 'LimitCalculator');
   if (!registryAddress) return { ok: false, reason: 'no collateral registry on this chain' };
@@ -114,20 +134,20 @@ async function runSync(wallet: string, targetUnits: bigint): Promise<CollateralS
     const registry = new ethers.Contract(registryAddress, REGISTRY_ABI, signer);
     const member = ethers.getAddress(wallet);
 
-    const current: bigint = await registry.pledgedOf(member, SAVINGS_KIND);
+    const current: bigint = await registry.pledgedOf(member, kind);
     let txHash: string | undefined;
 
     if (targetUnits > current) {
-      const tx = await registry.pledge(member, SAVINGS_KIND, targetUnits - current);
+      const tx = await registry.pledge(member, kind, targetUnits - current);
       txHash = (await tx.wait())?.hash ?? tx.hash;
     } else if (targetUnits < current) {
       // Only what is actually free. The rest is holding up drawn credit and the registry will
       // refuse to let it go -- correctly.
-      const free: bigint = await registry.freeCollateralOf(member, SAVINGS_KIND);
+      const free: bigint = await registry.freeCollateralOf(member, kind);
       const wanted = current - targetUnits;
       const amount = wanted < free ? wanted : free;
       if (amount > 0n) {
-        const tx = await registry.release(member, SAVINGS_KIND, amount);
+        const tx = await registry.release(member, kind, amount);
         txHash = (await tx.wait())?.hash ?? tx.hash;
       }
     }
@@ -182,4 +202,42 @@ export async function syncSavingsCollateralFromBalance(wallet: string): Promise<
   const units = await readSavingsUnits(wallet);
   if (units === null) return { ok: false, reason: 'could not read the savings balance' };
   return syncSavingsCollateral(wallet, units);
+}
+
+
+const POOL_ABI = [
+  'function balanceOf(address) view returns (uint256)',
+  'function convertToAssets(uint256 shares) view returns (uint256)',
+];
+
+/**
+ * Pledge a member's yield-pool position so it backs their credit line.
+ *
+ * The pool tier had exactly the hole savings had: a member could hold a position worth real money
+ * and the POOL_SHARE tier would read zero, because holding is not pledging. Wired from the start
+ * here rather than discovered later.
+ *
+ * Pledged in **assets, not shares**. The registry values an amount-based pledge at a flat unit
+ * price, and a pool share is not worth a dollar — it drifts up as the pool earns. Pledging shares
+ * would value the position at its share count, which is a different number that happens to start
+ * out close and diverges. `convertToAssets` is what makes them comparable.
+ *
+ * Synced to the current position, so a withdrawal shrinks the pledge on the same path a deposit
+ * grows it, and a retry after a failure is safe.
+ */
+export async function syncPoolCollateral(wallet: string): Promise<CollateralSyncResult> {
+  const pool = getContractAddress(chainId(), 'LendingPool');
+  if (!pool) return { ok: false, reason: 'no lending pool on this chain' };
+
+  try {
+    const rpc = new ethers.JsonRpcProvider(savingsIntentService.resolveRpcUrl(chainId()));
+    const contract = new ethers.Contract(pool, POOL_ABI, rpc);
+    const shares: bigint = await contract.balanceOf(ethers.getAddress(wallet));
+    const assets: bigint = shares === 0n ? 0n : await contract.convertToAssets(shares);
+    return syncCollateralKind(wallet, POOL_SHARE_KIND, assets);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error';
+    console.error('[pool] position read failed for', wallet, message);
+    return { ok: false, reason: message };
+  }
 }

--- a/app/src/PreviewApp.tsx
+++ b/app/src/PreviewApp.tsx
@@ -248,6 +248,62 @@ function MoveMoneyPreview() {
   );
 }
 
+/**
+ * The yield pool — the same component, pointed elsewhere.
+ *
+ * Figures passed in explicitly, as with the savings preview: the live component reads them and
+ * shows a member with nothing exactly that, so fixtures belong in the harness rather than behind
+ * it. The states are the three the reference draws, including the pool being fully lent.
+ */
+function PoolMovePreview() {
+  const [direction, setDirection] = useState<MoveDirection>('deposit');
+  const [lent, setLent] = useState(false);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <MoveMoneyDialog
+        open
+        onOpenChange={() => {}}
+        destination="pool"
+        direction={direction}
+        onDirectionChange={setDirection}
+        cashReady={2109}
+        savingsTotal={2500}
+        savingsFree={2541}
+        credits={0}
+        creditsGoal={0}
+        pool={{
+          apyPercent: 6.8,
+          haircutBps: 7_000,
+          freeNow: lent ? 600 : 2541,
+          utilizationBps: lent ? 7_600 : 7_400,
+          limitAfter: 7600,
+          owed: 2400,
+        }}
+        onMove={() => {}}
+      />
+
+      <div className="fixed inset-x-0 bottom-0 z-[60] flex justify-center gap-1 border-t-[0.5px] border-border bg-background/90 p-2 backdrop-blur-sm">
+        {([['add', 'deposit', false], ['take', 'withdraw', false], ['fully lent', 'withdraw', true]] as const).map(
+          ([label, dir, isLent]) => (
+            <button
+              key={label}
+              type="button"
+              onClick={() => {
+                setDirection(dir as MoveDirection);
+                setLent(isLent);
+              }}
+              className="rounded-md border-[0.5px] border-border px-2 py-1 text-[11px] text-muted-foreground"
+            >
+              {label}
+            </button>
+          ),
+        )}
+      </div>
+    </div>
+  );
+}
+
 /** A charge arriving — the approval screen and the state after it. */
 function ChargeApprovalPreview() {
   const [splitInto, setSplitInto] = useState(4);
@@ -386,6 +442,7 @@ export default function PreviewApp() {
           <Route path="/onboarding-counter" element={<CounterOnboardingPreview />} />
           <Route path="/charge" element={<ChargeApprovalPreview />} />
           <Route path="/move-money" element={<MoveMoneyPreview />} />
+          <Route path="/pool" element={<PoolMovePreview />} />
 
           <Route
             path="*"

--- a/app/src/components/clear/ConnectedPoolMove.tsx
+++ b/app/src/components/clear/ConnectedPoolMove.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useState } from 'react';
+import MoveMoneyDialog, { type MoveDirection } from './MoveMoneyDialog';
+import { usePoolMove } from '@/hooks/usePoolMove';
+import { useClearBalances } from '@/hooks/useClearBalances';
+import { useOptionalAddress } from '@/hooks/useOptionalWallet';
+import { useMoneyActions } from '@/context/MoneyActionsContext';
+import { getCredit, getEarn, type EarnPoolRow } from '@/utils/apiClient';
+import { track } from '@/lib/analytics';
+
+/**
+ * The haircut `CollateralRegistry` applies to a pool share, read from the deployment.
+ *
+ * Stated here rather than fetched because it is a co-op parameter that changes by governance, not
+ * by the minute — but it is a real on-chain value, so if it moves this constant is the one place
+ * that is wrong, and the limit it quotes is the thing a member would notice.
+ */
+const POOL_SHARE_HAIRCUT_BPS = 7_000;
+
+/**
+ * Add to / take from the yield pool, wired.
+ *
+ * The same component as savings, pointed at a different destination — which is how the reference
+ * describes it, so it is a prop rather than a second modal. Both directions draw on, or return to,
+ * **Ready to allocate**: the USDC already in the member's smart account that the card cannot spend.
+ *
+ * Every figure is read, none come from the page. That is the rule the savings tier was fixed to
+ * follow after showing a member the reference's money as their own, and it applies here from the
+ * start rather than after the same bug.
+ */
+export default function ConnectedPoolMove({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const balances = useClearBalances();
+  const address = useOptionalAddress();
+  const { openAddMoney, openAutoSave } = useMoneyActions();
+  const [direction, setDirection] = useState<MoveDirection>('deposit');
+  const [limitCents, setLimitCents] = useState<number | null>(null);
+  const [owedCents, setOwedCents] = useState<number | null>(null);
+  // Read here rather than passed in. A page holding a mapped model would have to hand over
+  // fixtures on the way, and fixtures reaching a screen that moves money is the exact mistake the
+  // savings dialog was fixed for.
+  const [pool, setPool] = useState<EarnPoolRow | null>(null);
+
+  useEffect(() => {
+    if (!address || !open) return;
+    let cancelled = false;
+    void getEarn(address).then((earn) => {
+      if (!cancelled && earn) setPool(earn.pool);
+    });
+    void getCredit(address).then((credit) => {
+      if (cancelled || !credit) return;
+      const active = credit.tiers.filter((tier) => tier.active);
+      setLimitCents(active.reduce((sum, tier) => sum + tier.limitCents, 0));
+      setOwedCents(active.reduce((sum, tier) => sum + tier.usedCents, 0));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [address, open]);
+
+  const onMoved = useCallback(
+    (moved: MoveDirection, amount: number) => {
+      // Cash is Ready to allocate, and the pool position is not a Clear balance the hook tracks —
+      // so only the cash leg moves optimistically. The position reconciles on the next Earn read.
+      balances.applyOptimistic(moved === 'deposit' ? -amount : amount, 0);
+      track('pool_move', { direction: moved }); // direction only, never the amount
+    },
+    [balances],
+  );
+
+  const { busy, error, txHash, move, reset } = usePoolMove(onMoved);
+
+  const position = (pool?.positionCents ?? 0) / 100;
+  // What the pool can pay right now. Capacity less what is lent out is the cash on hand, and it is
+  // the reason a withdrawal can be partly queued rather than refused.
+  const freeNow = Math.max(0, ((pool?.capacityCents ?? 0) - (pool?.lentCents ?? 0)) / 100);
+  const utilizationBps =
+    pool && pool.capacityCents > 0 ? Math.round((pool.lentCents / pool.capacityCents) * 10_000) : 0;
+
+  return (
+    <MoveMoneyDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          reset();
+          setDirection('deposit');
+        }
+        onOpenChange(next);
+      }}
+      destination="pool"
+      direction={direction}
+      onDirectionChange={setDirection}
+      cashReady={balances.cash}
+      savingsTotal={position}
+      // The member's whole position is theirs; what caps a withdrawal is the pool's cash, which
+      // MoveMoneyDialog applies on top.
+      savingsFree={position}
+      credits={0}
+      creditsGoal={0}
+      pool={{
+        apyPercent: pool?.apyPercent ?? 0,
+        // POOL_SHARE is registered at a 70% haircut, so a dollar lent backs seventy cents of
+        // limit. The dialog applies it to whatever is typed rather than to a fixed figure.
+        haircutBps: POOL_SHARE_HAIRCUT_BPS,
+        freeNow,
+        utilizationBps,
+        ...(limitCents !== null ? { limitAfter: limitCents / 100 } : {}),
+        ...(owedCents !== null ? { owed: owedCents / 100 } : {}),
+      }}
+      busy={busy}
+      error={error}
+      txHash={txHash}
+      onMove={(amount) => void move(direction, amount, freeNow)}
+      onAddMoney={() => {
+        onOpenChange(false);
+        openAddMoney();
+      }}
+      onAutoSave={() => {
+        onOpenChange(false);
+        openAutoSave();
+      }}
+    />
+  );
+}

--- a/app/src/components/clear/MoveMoneyDialog.tsx
+++ b/app/src/components/clear/MoveMoneyDialog.tsx
@@ -32,6 +32,31 @@ import { cn } from '@/lib/utils';
 
 export type MoveDirection = 'deposit' | 'withdraw';
 
+/**
+ * Where the money is going. The reference is explicit that the pool is "the same component as
+ * savings, pointed at a different destination" — so it is a prop rather than a second modal.
+ */
+export type MoveDestination = 'savings' | 'pool';
+
+/** What the pool needs that savings does not. Absent for a savings move. */
+export interface PoolTerms {
+  /** e.g. 6.8 — variable, which is why the yield figure it produces is stated as approximate. */
+  apyPercent: number;
+  /**
+   * The haircut the registry applies to a pool share, in basis points — 7000 on chain today.
+   *
+   * Carried rather than a precomputed delta, because the figure it produces moves as the member
+   * types. A dollar lent backs seventy cents of limit, and the screen says so live.
+   */
+  haircutBps: number;
+  /** Cash the pool can pay right now. Below the request, the rest queues. */
+  freeNow: number;
+  utilizationBps: number;
+  /** The limit this withdrawal lands on, and what is owed against it. */
+  limitAfter?: number;
+  owed?: number;
+}
+
 function Leg({
   label,
   name,
@@ -87,6 +112,8 @@ export interface MoveMoneyProps {
   savingsFree: number;
   credits: number;
   creditsGoal: number;
+  destination?: MoveDestination;
+  pool?: PoolTerms;
   /** e.g. "Jan 2028" — the only number on the screen about the thing they actually want. */
   reachesGoalBy?: string;
   /** e.g. "2 months later" — what a withdrawal costs in time. */
@@ -109,6 +136,8 @@ export default function MoveMoneyDialog({
   savingsFree,
   credits,
   creditsGoal,
+  destination = 'savings',
+  pool,
   reachesGoalBy,
   goalShift,
   busy = false,
@@ -121,11 +150,17 @@ export default function MoveMoneyDialog({
   const [typed, setTyped] = useState('250');
 
   const isDeposit = direction === 'deposit';
+  const isPool = destination === 'pool';
+  // The pool can be fully lent — a state savings does not have. What is free to take is capped by
+  // the pool's cash, not by the member's position.
+  const poolFree = isPool && pool ? Math.min(savingsFree, pool.freeNow) : savingsFree;
   const amount = Number(typed) || 0;
   // Each leg carries its balance, so the constraint is visible before anything is typed and the
   // "All" chip has a stated meaning.
-  const available = isDeposit ? cashReady : savingsFree;
-  const presets = isDeposit ? [100, 250, 500] : [100, 500, 1000];
+  const available = isDeposit ? cashReady : isPool ? poolFree : savingsFree;
+  // "An amount and a keypad, not three preset buttons" — someone lending $3,400 because that is
+  // what is spare should not have to pick $1,000. The chips are shortcuts; the pad is the input.
+  const presets = isPool ? [500, 1000, 2500] : isDeposit ? [100, 250, 500] : [100, 500, 1000];
   const over = amount > available;
   const shortBy = amount - available;
 
@@ -147,6 +182,13 @@ export default function MoveMoneyDialog({
 
   const amountBlock = (dim = false) => (
     <>
+      {/* The pool can be fully lent; savings cannot. Named at the top so the constrained figures
+          below have a reason before they are read. */}
+      {isPool && !isDeposit && over && (
+        <p className="mb-2 text-[10px] uppercase tracking-[0.5px] text-muted-foreground">
+          Pool is fully lent
+        </p>
+      )}
       <p className="mb-0.5 text-[11px] text-muted-foreground">Amount</p>
       <p
         className={cn(
@@ -165,7 +207,8 @@ export default function MoveMoneyDialog({
       {over && (
         // Stated as the difference, because that is the number they can act on — not as a refusal.
         <p className="mb-3 text-[11.5px] text-tier-boost-fg">
-          {money(shortBy, { cents: true })} more than is {isDeposit ? 'ready to allocate' : 'free to move'}
+          {money(shortBy, { cents: true })} more than is{' '}
+          {isDeposit ? 'ready to allocate' : isPool ? 'free right now' : 'free to move'}
         </p>
       )}
     </>
@@ -176,14 +219,14 @@ export default function MoveMoneyDialog({
       <Leg
         side="left"
         label="From"
-        name={isDeposit ? 'Cash account' : 'Savings'}
-        balance={isDeposit ? cashReady : savingsFree}
-        note={isDeposit ? 'ready' : 'free'}
+        name={isDeposit ? 'Cash account' : isPool ? 'Yield pool' : 'Savings'}
+        balance={isDeposit ? cashReady : isPool ? poolFree : savingsFree}
+        note={isDeposit ? 'ready' : isPool && pool && pool.freeNow < savingsFree ? 'free now' : 'free'}
       />
       <Leg
         side="right"
         label="To"
-        name={isDeposit ? 'Savings' : 'Cash account'}
+        name={isDeposit ? (isPool ? 'Yield pool' : 'Savings') : 'Cash account'}
         balance={isDeposit ? savingsTotal : cashReady}
       />
       <button
@@ -229,6 +272,51 @@ export default function MoveMoneyDialog({
 
   const pad = <Keypad onKey={(key) => setTyped((current) => applyKey(current, key))} disabled={busy} />;
 
+  const poolConsequences = pool && (
+    <>
+      {isDeposit ? (
+        <div className="mb-3 rounded-[10px] border-[0.5px] border-tier-boost/40 bg-tier-boost/[0.08] px-3.5 py-3">
+          <Row label="Earning" value={`${pool.apyPercent}% APY`} accent />
+          <Row
+            label="Backs your limit"
+            value={`+${money((amount * pool.haircutBps) / 10_000, { cents: true })}`}
+            accent
+          />
+        </div>
+      ) : (
+        <div className="mb-3 rounded-[10px] border-[0.5px] border-border bg-secondary/50 px-3.5 py-3">
+          <Row label="Limit" value={`−${money((amount * pool.haircutBps) / 10_000, { cents: true })}`} />
+          {/* Approximate on purpose: the rate moves with utilisation, so a precise figure would be
+              a promise the pool cannot keep. */}
+          <Row label="Yield lost" value={`~${money((amount * pool.apyPercent) / 100, { cents: true })} a year`} />
+          {pool.limitAfter !== undefined && (
+            <p className="mt-[7px] text-[11px] leading-[1.55] text-muted-foreground">
+              Limit falls to {money(pool.limitAfter, { cents: true })}
+              {pool.owed !== undefined
+                ? `, still above the ${money(pool.owed, { cents: true })} you owe.`
+                : '.'}
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="mb-3.5 border-t-[0.5px] border-border pt-2.5">
+        <Row label="Position after" value={money(after.savings, { cents: true })} />
+        {isDeposit ? (
+          <>
+            <Row label="Yield a year" value={`~${money((after.savings * pool.apyPercent) / 100, { cents: true })}`} />
+            <Row label="Withdraw" value="Any time" />
+          </>
+        ) : (
+          <>
+            <Row label="Arrives" value={over ? 'Some queued' : 'Within 24 hours'} />
+            <Row label="Pool utilization" value={`${Math.round(pool.utilizationBps / 100)}%`} />
+          </>
+        )}
+      </div>
+    </>
+  );
+
   const consequences = (
     <>
       {isDeposit ? (
@@ -269,7 +357,30 @@ export default function MoveMoneyDialog({
     </>
   );
 
-  const action = over ? (
+  // The pool has a state savings does not: it can be fully lent. Asking for more than is free is
+  // not a mistake to refuse — pay what is there and queue the rest, which is what the contract's
+  // requestWithdrawal exists for.
+  const canQueue = isPool && !isDeposit && over;
+
+  const action = canQueue ? (
+    <>
+      <div className="mb-3 rounded-[10px] border-[0.5px] border-border bg-secondary/50 px-3.5 py-[11px]">
+        <p className="text-[12px] leading-[1.6] text-foreground-secondary">
+          The rest is lent out. <strong className="font-medium text-foreground">Queue it</strong> and
+          it is sent as members repay.
+        </p>
+      </div>
+      <Button size="xs" className="mb-2 w-full py-[11px]" disabled={busy} onClick={() => onMove(available)}>
+        Take {money(available, { cents: true })} now
+      </Button>
+      <Button size="xs" variant="clear" className="w-full text-xs" disabled={busy} onClick={() => onMove(amount)}>
+        Queue the remaining {money(amount - available, { cents: true })}
+      </Button>
+      <p className="mt-2.5 text-center text-[11px] leading-[1.55] text-muted-foreground">
+        Sent automatically. Nothing to come back and do.
+      </p>
+    </>
+  ) : over ? (
     <>
       <div className="mb-3 rounded-[10px] bg-secondary/50 px-3.5 py-[11px]">
         <p className="text-[12px] leading-[1.6] text-foreground-secondary">
@@ -295,12 +406,20 @@ export default function MoveMoneyDialog({
             <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
             Moving…
           </>
+        ) : isPool ? (
+          `${isDeposit ? 'Add' : 'Take'} ${money(amount, { cents: true })}`
         ) : (
           `Move ${money(amount, { cents: true })} to ${isDeposit ? 'savings' : 'cash'}`
         )}
       </Button>
-      <p className="mt-2.5 text-center text-[11px] text-muted-foreground">
-        {isDeposit ? 'Instant. You can move it back any time.' : 'Instant. Move it back whenever you like.'}
+      <p className="mt-2.5 text-center text-[11px] leading-[1.55] text-muted-foreground">
+        {isPool
+          ? isDeposit
+            ? 'Rate moves with how much of the pool is lent.'
+            : 'Sent to your cash account.'
+          : isDeposit
+            ? 'Instant. You can move it back any time.'
+            : 'Instant. Move it back whenever you like.'}
       </p>
     </>
   );
@@ -309,8 +428,12 @@ export default function MoveMoneyDialog({
     <Modal
       open={open}
       onOpenChange={onOpenChange}
-      title="Move money"
-      description="Move money between your cash account and savings."
+      title={isPool ? (isDeposit ? 'Add to the pool' : 'Take from the pool') : 'Move money'}
+      description={
+        isPool
+          ? 'Move money between your cash account and the yield pool.'
+          : 'Move money between your cash account and savings.'
+      }
       // The desktop dialog is 360px by default, and the two-column layout below needs the width
       // the reference gives it — a 216px keypad beside a column that still has to fit "Credits
       // earned" on one line. Forced into 360px it wraps to one word per line, which is what it
@@ -360,7 +483,7 @@ export default function MoveMoneyDialog({
             {chips}
             {route}
             <div className="mb-3 sm:hidden">{pad}</div>
-            {consequences}
+            {isPool ? poolConsequences : consequences}
           </div>
           <div className="hidden sm:block">{pad}</div>
           <div className="sm:col-span-2">{action}</div>

--- a/app/src/components/clear/moveMoney.test.ts
+++ b/app/src/components/clear/moveMoney.test.ts
@@ -68,7 +68,10 @@ describe('what is free to withdraw', () => {
 describe('one component, two directions', () => {
   test('each leg carries its own balance, which is what gives the presets stated meanings', () => {
     expect(DIALOG).toContain("isDeposit ? 'All' : 'All free'");
-    expect(DIALOG).toContain('const available = isDeposit ? cashReady : savingsFree;');
+    // Each direction takes its cap from its own leg, and the pool's leg is capped again by what
+    // the pool can actually pay.
+    expect(DIALOG).toContain('const available = isDeposit ? cashReady : isPool ? poolFree : savingsFree;');
+    expect(DIALOG).toContain('Math.min(savingsFree, pool.freeNow)');
   });
 
   test('the consequence flips with the direction', () => {
@@ -206,7 +209,8 @@ describe('never block the keypad', () => {
   test('the overage is stated as a difference', () => {
     // The number they can act on, not a refusal.
     expect(DIALOG).toContain('const shortBy = amount - available;');
-    expect(DIALOG).toContain('more than is {isDeposit ?');
+    expect(DIALOG).toContain('more than is');
+    expect(DIALOG).toContain("'ready to allocate'");
   });
 
   test('and the affordable amount is offered', () => {
@@ -352,5 +356,109 @@ describe('what may be shown before the chain agrees', () => {
     const home = readFileSync(join(import.meta.dir, '../../pages/app/HomeRoute.tsx'), 'utf8');
     expect(home).toContain("addEventListener('clear:credit-stale'");
     expect(home).toContain('[3000, 8000, 15000]');
+  });
+});
+
+/*
+ * The yield pool — "the same component as savings, pointed at a different destination", which is
+ * why it is a prop rather than a second modal.
+ */
+const POOL = readFileSync(join(import.meta.dir, 'ConnectedPoolMove.tsx'), 'utf8');
+const POOL_HOOK = readFileSync(join(import.meta.dir, '../../hooks/usePoolMove.ts'), 'utf8');
+
+describe('the pool is the same component, redirected', () => {
+  test('destination is a prop, not a fork', () => {
+    expect(DIALOG).toContain("export type MoveDestination = 'savings' | 'pool'");
+    expect(DIALOG).toContain("const isPool = destination === 'pool';");
+  });
+
+  test('it names itself for what it does', () => {
+    expect(DIALOG).toContain("'Add to the pool'");
+    expect(DIALOG).toContain("'Take from the pool'");
+  });
+
+  test('the limit it quotes moves with the amount', () => {
+    // A fixed delta would be right once and wrong on every keystroke after. 70% haircut, applied
+    // to whatever is typed.
+    expect(DIALOG).toContain('(amount * pool.haircutBps) / 10_000');
+    expect(DIALOG).not.toContain('limitDeltaCents');
+  });
+
+  test('the yield figure is approximate on purpose', () => {
+    // The rate moves with utilisation, so a precise number would be a promise the pool cannot keep.
+    expect(DIALOG).toContain('~${money((after.savings * pool.apyPercent) / 100');
+    expect(DIALOG).toContain('Rate moves with how much of the pool is lent.');
+  });
+
+  test('the withdraw panel names the limit it lands on, not only the drop', () => {
+    // The question a member is actually asking is whether they stay above what they owe.
+    expect(DIALOG).toContain('Limit falls to');
+    expect(DIALOG).toContain('you owe');
+  });
+});
+
+/*
+ * The pool has a state savings does not: it can be fully lent. A member whose money is out on loan
+ * has not made a mistake, so the honest handling is to pay what is free and queue the rest.
+ */
+describe('fully lent is queued, not refused', () => {
+  test('what can be taken now is capped by the pool’s cash, not the position', () => {
+    expect(DIALOG).toContain('Math.min(savingsFree, pool.freeNow)');
+  });
+
+  test('the state is named before the constrained figures are read', () => {
+    expect(DIALOG).toContain('Pool is fully lent');
+  });
+
+  test('both actions are offered — take what is free, queue the rest', () => {
+    expect(DIALOG).toContain('Take {money(available, { cents: true })} now');
+    expect(DIALOG).toContain('Queue the remaining');
+    expect(DIALOG).toContain('Sent automatically. Nothing to come back and do.');
+  });
+
+  test('the split is computed in shares from the contract’s own cap', () => {
+    // maxRedeem already accounts for available cash, so what it will not pay is exactly what must
+    // queue. Deriving it from dollars would be the app guessing at a number the pool decides.
+    expect(POOL_HOOK).toContain("functionName: 'maxRedeem'");
+    expect(POOL_HOOK).toContain('const sharesQueued = wanted - sharesNow;');
+  });
+
+  test('both legs of the split go in one batch', () => {
+    const send = readFileSync(join(import.meta.dir, '../../lib/sendCalls.ts'), 'utf8');
+    expect(send).toContain("functionName: 'requestWithdrawal'");
+    expect(send).toContain('scPoolWithdraw');
+  });
+});
+
+describe('the pool pledges what it holds', () => {
+  test('a movement tells the server, which pledges the position', () => {
+    const send = readFileSync(join(import.meta.dir, '../../lib/sendCalls.ts'), 'utf8');
+    expect(send).toContain('recordGaslessPool');
+  });
+
+  test('the position is read back rather than taken from the request', () => {
+    // Nothing in the body is trusted but the fact that something happened, so a wrong or replayed
+    // amount changes nothing.
+    const service = readFileSync(
+      join(import.meta.dir, '../../../server/src/services/chain/savingsCollateralService.ts'),
+      'utf8',
+    );
+    expect(service).toContain('syncPoolCollateral');
+    expect(service).toContain('convertToAssets');
+  });
+
+  test('it pledges assets, not shares', () => {
+    // The registry values an amount pledge at a flat unit price, and a share is not worth a dollar
+    // — it drifts up as the pool earns.
+    const service = readFileSync(
+      join(import.meta.dir, '../../../server/src/services/chain/savingsCollateralService.ts'),
+      'utf8',
+    );
+    expect(service).toContain('POOL_SHARE_KIND, assets');
+  });
+
+  test('every figure is read, none passed in', () => {
+    expect(POOL).toContain('getEarn(address)');
+    expect(POOL).toContain('getCredit(address)');
   });
 });

--- a/app/src/hooks/usePoolMove.ts
+++ b/app/src/hooks/usePoolMove.ts
@@ -1,0 +1,109 @@
+import { useCallback, useState } from 'react';
+import { ACTIVE_CHAIN_ID, clearContracts } from '@/lib/clearNetwork';
+import { scPoolDeposit, scPoolWithdraw } from '@/lib/sendCalls';
+import { useOptionalAddress, useOptionalSmartWalletClient } from './useOptionalWallet';
+import { readContract } from '@wagmi/core';
+import { wagmiAdapter } from '@/AppKitProvider';
+import { parseUnits } from 'viem';
+
+/**
+ * Moving money in and out of the yield pool.
+ *
+ * The deposit half mirrors savings exactly: approve and deposit in one sponsored batch. The
+ * withdraw half does not, because the pool can be fully lent — so the amount is split into what
+ * the pool can pay now and what has to queue, and both go in the same batch.
+ *
+ * The split is computed here rather than in the component, because it is arithmetic about shares
+ * and the screen deals in dollars. `maxRedeem` is the contract's own answer to "how much can
+ * actually leave right now", and using it means the app never asks for a redemption the pool will
+ * refuse.
+ */
+const POOL_READ_ABI = [
+  { type: 'function', name: 'maxRedeem', stateMutability: 'view', inputs: [{ name: 'owner', type: 'address' }], outputs: [{ name: '', type: 'uint256' }] },
+  { type: 'function', name: 'convertToShares', stateMutability: 'view', inputs: [{ name: 'assets', type: 'uint256' }], outputs: [{ name: '', type: 'uint256' }] },
+] as const;
+
+export type MoveDirection = 'deposit' | 'withdraw';
+
+export interface PoolMoveState {
+  busy: boolean;
+  error: string | null;
+  txHash: string | null;
+  /** `freeNow` is what the pool can pay; anything above it is queued rather than refused. */
+  move: (direction: MoveDirection, amount: number, freeNow: number) => Promise<void>;
+  reset: () => void;
+}
+
+export function usePoolMove(onMoved?: (direction: MoveDirection, amount: number) => void): PoolMoveState {
+  const address = useOptionalAddress();
+  const getClientForChain = useOptionalSmartWalletClient();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [txHash, setTxHash] = useState<string | null>(null);
+
+  const move = useCallback(
+    async (direction: MoveDirection, amount: number, freeNow: number) => {
+      if (!address) {
+        setError('Connect a wallet first.');
+        return;
+      }
+      if (!Number.isFinite(amount) || amount <= 0) {
+        setError('Enter an amount to move.');
+        return;
+      }
+
+      const chainId = ACTIVE_CHAIN_ID;
+      const pool = clearContracts(chainId)?.lendingPool;
+      if (!pool) {
+        setError('The yield pool is not available on this network.');
+        return;
+      }
+
+      setBusy(true);
+      setError(null);
+      try {
+        const chainClient = getClientForChain
+          ? await getClientForChain({ id: chainId }).catch(() => undefined)
+          : undefined;
+        // Six decimals, as a string: the amount becomes token micros, and float arithmetic has no
+        // business near somebody's position.
+        const amountStr = amount.toFixed(2);
+
+        let hash: string;
+        if (direction === 'deposit') {
+          hash = await scPoolDeposit({ smartWalletClient: chainClient, ownerWallet: address, amount: amountStr, chainId });
+        } else {
+          // Split in shares, using the contract's own cap. `maxRedeem` already accounts for the
+          // pool's available cash, so what it will not pay now is exactly what must queue.
+          const wanted = await readContract(wagmiAdapter.wagmiConfig, {
+            address: pool, abi: POOL_READ_ABI, functionName: 'convertToShares',
+            args: [parseUnits(amountStr, 6)], chainId,
+          }) as bigint;
+          const payable = await readContract(wagmiAdapter.wagmiConfig, {
+            address: pool, abi: POOL_READ_ABI, functionName: 'maxRedeem',
+            args: [address as `0x${string}`], chainId,
+          }) as bigint;
+
+          const sharesNow = wanted < payable ? wanted : payable;
+          const sharesQueued = wanted - sharesNow;
+          hash = await scPoolWithdraw({ smartWalletClient: chainClient, ownerWallet: address, sharesNow, sharesQueued, chainId });
+        }
+
+        setTxHash(hash);
+        onMoved?.(direction, Math.min(amount, direction === 'withdraw' ? freeNow || amount : amount));
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "That didn't go through.");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [address, getClientForChain, onMoved],
+  );
+
+  const reset = useCallback(() => {
+    setError(null);
+    setTxHash(null);
+  }, []);
+
+  return { busy, error, txHash, move, reset };
+}

--- a/app/src/lib/clearNetwork.ts
+++ b/app/src/lib/clearNetwork.ts
@@ -24,6 +24,12 @@ export interface ClearContracts {
   clrusd: `0x${string}`;
   usdc: `0x${string}`;
   claimEscrow: `0x${string}`;
+  /**
+   * The yield pool. Optional because it is only deployed on testnet so far — a chain without one
+   * has no pool to move money into, and the UI reads that as "not available here" rather than
+   * calling a zero address.
+   */
+  lendingPool?: `0x${string}`;
 }
 const CONTRACTS: Record<number, ClearContracts> = {
   8453: {
@@ -33,6 +39,7 @@ const CONTRACTS: Record<number, ClearContracts> = {
     claimEscrow: '0xb30E97FEd437bf89B122693D26338C8D64515096',
   },
   84532: {
+    lendingPool: '0x58405326b66888d8a9f2Dc4646cAc2F5EaC7ce23',
     // Replacement pair. The vault and token these succeed are still deployed and still
     // mutually redeemable -- ESADepositVaultLegacy holds the USDC behind the CLRUSD that was
     // outstanding when the swap happened, so nobody who held the old token is stranded.

--- a/app/src/lib/sendCalls.ts
+++ b/app/src/lib/sendCalls.ts
@@ -2,7 +2,7 @@ import { encodeFunctionData, parseUnits } from 'viem';
 import { sendCalls, waitForCallsStatus } from '@wagmi/core';
 import { wagmiAdapter } from '@/AppKitProvider';
 import { clearContracts } from '@/lib/clearNetwork';
-import { recordGaslessSavings } from '@/utils/apiClient';
+import { recordGaslessSavings, recordGaslessPool } from '@/utils/apiClient';
 
 /*
  * 3-TIER gasless money router (see [[clearpath-privy-migration]]).
@@ -133,6 +133,75 @@ export async function scRedeem(args: { smartWalletClient?: unknown; ownerWallet:
     { to: c.esaVault, data: encodeFunctionData({ abi: VAULT_ABI, functionName: 'redeem', args: [c.usdc, amt, receiver] }) },
   ]);
   await recordGaslessSavings({ action: 'redeem', amount: amt.toString(), txHash: hash, chainId: args.chainId }).catch(() => {});
+  return hash;
+}
+
+const POOL_ABI = [
+  { type: 'function', name: 'deposit', stateMutability: 'nonpayable',
+    inputs: [{ name: 'assets', type: 'uint256' }, { name: 'receiver', type: 'address' }],
+    outputs: [{ name: 'shares', type: 'uint256' }] },
+  { type: 'function', name: 'redeem', stateMutability: 'nonpayable',
+    inputs: [{ name: 'shares', type: 'uint256' }, { name: 'receiver', type: 'address' }, { name: 'owner', type: 'address' }],
+    outputs: [{ name: 'assets', type: 'uint256' }] },
+  { type: 'function', name: 'requestWithdrawal', stateMutability: 'nonpayable',
+    inputs: [{ name: 'shares', type: 'uint256' }, { name: 'receiver', type: 'address' }],
+    outputs: [{ name: 'requestId', type: 'uint256' }] },
+] as const;
+
+/**
+ * Ready to allocate (USDC) → the yield pool: [approve, deposit] in ONE sponsored batch.
+ *
+ * The same shape as a savings deposit, pointed at a different destination — which is also how the
+ * reference describes the screen in front of it.
+ */
+export async function scPoolDeposit(args: { smartWalletClient?: unknown; ownerWallet: string; amount: string; chainId: number }): Promise<string> {
+  const c = clearContracts(args.chainId);
+  if (!c?.lendingPool) throw new Error('The yield pool is not available on this network.');
+  const amt = parseUnits(args.amount, 6);
+  const receiver = args.ownerWallet as `0x${string}`;
+  const hash = await runBatch(args.smartWalletClient, args.ownerWallet, args.chainId, [
+    { to: c.usdc, data: encodeFunctionData({ abi: ERC20_ABI, functionName: 'approve', args: [c.lendingPool, amt] }) },
+    { to: c.lendingPool, data: encodeFunctionData({ abi: POOL_ABI, functionName: 'deposit', args: [amt, receiver] }) },
+  ]);
+  await recordGaslessPool({ action: 'deposit', amount: amt.toString(), txHash: hash, chainId: args.chainId }).catch(() => {});
+  return hash;
+}
+
+/**
+ * The yield pool → Ready to allocate.
+ *
+ * Two paths, because the pool has a state savings does not: it can be fully lent. `redeem` pays
+ * immediately and is capped at `maxRedeem`, which the contract caps at available cash;
+ * `requestWithdrawal` burns the shares now and queues the claim, paid as members repay.
+ *
+ * A member asking for more than is free gets both in one batch — paid what is there, queued for
+ * the rest — because refusing the whole amount would be the pool telling somebody their own money
+ * is unavailable when most of it is not.
+ */
+export async function scPoolWithdraw(args: {
+  smartWalletClient?: unknown;
+  ownerWallet: string;
+  /** Shares to redeem now, already capped at what the pool can pay. */
+  sharesNow: bigint;
+  /** Shares to queue. Zero when the pool can cover the whole request. */
+  sharesQueued: bigint;
+  chainId: number;
+}): Promise<string> {
+  const c = clearContracts(args.chainId);
+  if (!c?.lendingPool) throw new Error('The yield pool is not available on this network.');
+  if (args.sharesNow === 0n && args.sharesQueued === 0n) throw new Error('Nothing to withdraw.');
+  const owner = args.ownerWallet as `0x${string}`;
+
+  const calls: { to: `0x${string}`; data: `0x${string}` }[] = [];
+  if (args.sharesNow > 0n) {
+    calls.push({ to: c.lendingPool, data: encodeFunctionData({ abi: POOL_ABI, functionName: 'redeem', args: [args.sharesNow, owner, owner] }) });
+  }
+  if (args.sharesQueued > 0n) {
+    calls.push({ to: c.lendingPool, data: encodeFunctionData({ abi: POOL_ABI, functionName: 'requestWithdrawal', args: [args.sharesQueued, owner] }) });
+  }
+
+  const hash = await runBatch(args.smartWalletClient, args.ownerWallet, args.chainId, calls);
+  await recordGaslessPool({ action: 'withdraw', amount: (args.sharesNow + args.sharesQueued).toString(), txHash: hash, chainId: args.chainId }).catch(() => {});
   return hash;
 }
 

--- a/app/src/pages/app/EarnPage.tsx
+++ b/app/src/pages/app/EarnPage.tsx
@@ -9,7 +9,7 @@ import YieldPoolCard from '@/components/clear/YieldPoolCard';
 import HeldBondsCard from '@/components/clear/HeldBondsCard';
 import BondLadder from '@/components/clear/BondLadder';
 import BuyBondDialog from '@/components/clear/BuyBondDialog';
-import PoolDepositDialog from '@/components/clear/PoolDepositDialog';
+import ConnectedPoolMove from '@/components/clear/ConnectedPoolMove';
 import PoolWithdrawDialog from '@/components/clear/PoolWithdrawDialog';
 import { EARN_DAY_ONE, HOME_DAY_ONE } from '@/data/clearPlaceholder';
 import { money, signedMoney } from '@/lib/money';
@@ -133,7 +133,7 @@ export default function EarnPage({ data = EARN_DAY_ONE }: { data?: EarnData }) {
       </div>
 
       <BuyBondDialog data={data} open={buyOpen} onOpenChange={setBuyOpen} />
-      <PoolDepositDialog data={data} open={depositOpen} onOpenChange={setDepositOpen} />
+      <ConnectedPoolMove open={depositOpen} onOpenChange={setDepositOpen} />
       {/* The limit it quotes comes from Home's own tiers, so the drop it shows is
           the drop that would actually happen. */}
       <PoolWithdrawDialog

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -3015,3 +3015,20 @@ export async function declineCharge(code: string): Promise<ChargeActionResult> {
   if (r.error || !r.data) return { error: r.error || 'We could not decline this charge.' };
   return { charge: r.data };
 }
+
+
+/**
+ * Tell the server a pool movement landed, so it can pledge the position as collateral.
+ *
+ * The same shape as `recordGaslessSavings` and for the same reason: depositing mints a position
+ * and pledging it is a separate step. Skipping this is what left savings backing nothing for
+ * weeks, so the pool gets the call from the start rather than as a later fix.
+ */
+export async function recordGaslessPool(p: {
+  action: 'deposit' | 'withdraw';
+  amount: string;
+  txHash: string;
+  chainId: number;
+}): Promise<void> {
+  await apiRequest('/api/savings/pool/record', { method: 'POST', body: JSON.stringify(p) });
+}


### PR DESCRIPTION
The reference calls this *"the same component as savings, pointed at a different destination"* — so it's a `destination` prop on `MoveMoneyDialog`, not a second modal. Both directions move USDC already in the smart account: **Ready to allocate**, the balance the card can't spend.

## What the pool needs that savings doesn't

- **An amount and a keypad, not three preset buttons.** Someone lending $3,400 because that's what's spare shouldn't have to pick $1,000.
- **The limit it quotes moves as they type.** A pool share is haircut at 70%, so a dollar lent backs seventy cents. A precomputed delta would be right once and wrong on every keystroke after — the haircut is carried and applied live.
- **The yield figure is deliberately approximate.** The rate moves with utilisation, so a precise number would be a promise the pool can't keep, and the screen says so underneath.
- **The withdraw panel names the limit it lands on**, not only the drop — the question a member is actually asking is whether they stay above what they owe.

## Fully lent is queued, not refused

The pool has a state savings doesn't: a member's money can be out on loan. Asking for more than is free **pays what's there and queues the rest**, in one batch — `redeem` plus `requestWithdrawal`, which is exactly what that contract path exists for.

The split is computed in **shares** from `maxRedeem` — the contract's own answer to what can leave right now — rather than from dollars the app guessed at.

## The pledge is wired from the start

A pool position backs the `POOL_SHARE` tier, and holding is not pledging — the exact hole that left savings backing nothing for weeks. A movement reports to `/api/savings/pool/record`, which reads the position back from the pool and syncs the pledge to it. Nothing in the request body is trusted but the fact that something happened, so a wrong or replayed amount changes nothing.

Pledged in **assets, not shares**: the registry values an amount pledge at a flat unit price, and a share isn't worth a dollar — it drifts up as the pool earns.

## The guard worked

The coverage test from the last change detected the new pool path and **demanded the pledge**. It passes now because both exist — but it would have failed had I shipped the path alone. That's the first time one of these has been caught by a test rather than by a member noticing a tier reading zero.

## Verification

380 tests, 14 new. All three states checked against the reference in the harness — add, take, and fully lent with the queue. Deposit shows `+$175.00` backing on $250, which is the 70% haircut computing live.

**Not verified:** an on-chain pool deposit. That needs a real session on the demo — and it's the thing to watch, since the whole point is that the pledge should now happen unaided.