### PR TITLE
Wire buying a bond, and pledge it by identity

### DIFF
--- a/app/server/src/routes/savings.ts
+++ b/app/server/src/routes/savings.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import { syncSavingsCollateralFromBalance, syncPoolCollateral } from '../services/chain/savingsCollateralService.js';
+import { syncSavingsCollateralFromBalance, syncPoolCollateral, syncBondCollateral } from '../services/chain/savingsCollateralService.js';
 import { ethers } from 'ethers';
 import { requireWalletMatch, requireVerifiedWallet } from '../middleware/auth.js';
 import { savingsIntentService } from '../services/savingsIntentService.js';
@@ -488,6 +488,33 @@ savingsRouter.post('/pool/record', async (req: Request, res: Response) => {
   } catch (error) {
     console.error('[pool/record] failed:', error);
     res.status(500).json({ error: 'Failed to record pool movement' });
+  }
+});
+
+/**
+ * A bond was bought; pledge it.
+ *
+ * Takes no amount, which is the point: bonds pledge by identity, so the server reads which ones
+ * the member holds and reconciles the pledged set against it. There is nothing in the body worth
+ * lying about.
+ */
+savingsRouter.post('/bond/record', async (req: Request, res: Response) => {
+  try {
+    const wallet = req.auth?.walletAddress;
+    if (!wallet || !ethers.isAddress(wallet)) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const result = await syncBondCollateral(ethers.getAddress(wallet));
+    if (!result.ok) console.error('[bond/record] collateral sync failed:', result.reason);
+
+    // Accepted either way: the purchase is already on chain, and reporting failure here would tell
+    // a member their bond did not mint when it did.
+    res.json({ success: true, pledged: result.ok });
+  } catch (error) {
+    console.error('[bond/record] failed:', error);
+    res.status(500).json({ error: 'Failed to record bond purchase' });
   }
 });
 

--- a/app/server/src/services/chain/collateralCoverage.test.ts
+++ b/app/server/src/services/chain/collateralCoverage.test.ts
@@ -4,6 +4,15 @@ import { join } from 'node:path';
 
 const READER = readFileSync(join(import.meta.dir, 'creditReader.ts'), 'utf8');
 const SYNC = readFileSync(join(import.meta.dir, 'savingsCollateralService.ts'), 'utf8');
+/*
+ * The routes, because a sync that exists and is never called pledges nothing.
+ *
+ * An earlier version of this file asserted the function's *name* appeared in the service. Renaming
+ * it to `syncBondCollateralDISABLED` still satisfied that — a substring match cannot tell a
+ * definition from a corpse. What matters is that a request path invokes it, so that is what is
+ * checked.
+ */
+const ROUTES = readFileSync(join(import.meta.dir, '../../routes/savings.ts'), 'utf8');
 
 /*
  * Every tier the issuer offers has to be reachable, and this is the test that says so.
@@ -60,31 +69,42 @@ describe('the limits read asks for tiers that exist', () => {
 describe('collateral tiers have something that pledges them', () => {
   test('savings syncs from the balance that backs it', () => {
     expect(SYNC).toContain('SAVINGS');
-    expect(SYNC).toContain('syncSavingsCollateralFromBalance');
+    expect(ROUTES).toMatch(/syncSavingsCollateralFromBalance\(/);
   });
 
   /*
-   * Deliberately not asserting that bonds and pool shares sync yet — they cannot, because there is
-   * no way to buy either. `BuyBondDialog` and `PoolDepositDialog` render with no handler, nothing
-   * calls the bond or pool contracts, and so no member can hold one to pledge.
+   * Each collateral tier is checked against its *own* sync, not against any sync.
    *
-   * This test documents that and will fail the moment it stops being true, which is exactly when
-   * the pledge becomes necessary. Whoever wires the purchase will land here and be told what else
-   * the tier needs, instead of shipping a bond that mints fine and backs nothing.
+   * An earlier version asserted /BOND|POOL_SHARE/ — which passes if either exists, so a bond
+   * purchase shipped alongside a pool sync would have satisfied it while pledging nothing. A guard
+   * that can be satisfied by the wrong tier is not a guard.
    */
-  test('bonds and pool shares still have no purchase path — wire the pledge when they do', () => {
-    const app = join(import.meta.dir, '../../../../src');
-    const sendCalls = readFileSync(join(app, 'lib/sendCalls.ts'), 'utf8');
-    const bondPathExists = /scBuyBond|BondVault|burnerBond/i.test(sendCalls);
-    const poolPathExists = /scPoolDeposit|LendingPool/i.test(sendCalls);
+  const APP = join(import.meta.dir, '../../../../src');
+  const SEND_CALLS = readFileSync(join(APP, 'lib/sendCalls.ts'), 'utf8');
 
-    if (bondPathExists || poolPathExists) {
-      // A purchase path now exists. The tier it feeds needs a pledge, or it reads zero with the
-      // asset sitting behind it — the savings bug, again, in a tier nobody is watching yet.
-      expect(SYNC).toMatch(/BOND|POOL_SHARE/);
-    } else {
-      expect(bondPathExists).toBe(false);
-      expect(poolPathExists).toBe(false);
-    }
+  test('a pool path exists, so the pool pledge must too', () => {
+    expect(/scPoolDeposit|LendingPool|lendingPool/i.test(SEND_CALLS)).toBe(true);
+    expect(ROUTES).toMatch(/await syncPoolCollateral\(/);
+    expect(SYNC).toContain('POOL_SHARE_KIND');
+  });
+
+  test('a bond path exists, so the bond pledge must too', () => {
+    expect(/scBuyBond|burnerBondDeposit/i.test(SEND_CALLS)).toBe(true);
+    expect(ROUTES).toMatch(/await syncBondCollateral\(/);
+    expect(SYNC).toContain('BOND_KIND');
+  });
+
+  test('bonds pledge by identity, not by amount', () => {
+    // A bond has identity — the registry records which one, because refusing to let it move and
+    // valuing it both need to know that. Half a bond is not a thing, so `pledge` would be wrong.
+    expect(SYNC).toContain('pledgeItem');
+    expect(SYNC).toContain('releaseItem');
+  });
+
+  test('and the bond set is reconciled both ways', () => {
+    // A bond can leave by transfer, redemption or seizure. A pledge left behind would value a
+    // member's line against something they no longer own.
+    expect(SYNC).toContain('getBondIdsByCreator');
+    expect(SYNC).toContain('pledgedItemsOf');
   });
 });

--- a/app/server/src/services/chain/savingsCollateralService.ts
+++ b/app/server/src/services/chain/savingsCollateralService.ts
@@ -50,6 +50,7 @@ const CALCULATOR_ABI = ['function pushCapacities(address member) returns (uint25
 /** Kinds as the deploy script writes them — `encodeBytes32String`, not a hash. */
 export const SAVINGS_KIND = ethers.encodeBytes32String('SAVINGS');
 export const POOL_SHARE_KIND = ethers.encodeBytes32String('POOL_SHARE');
+export const BOND_KIND = ethers.encodeBytes32String('BOND');
 
 function chainId(): number {
   const raw = (process.env.SAVINGS_DEFAULT_CHAIN_ID || process.env.SEND_DEFAULT_CHAIN_ID || '').trim();
@@ -238,6 +239,100 @@ export async function syncPoolCollateral(wallet: string): Promise<CollateralSync
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown error';
     console.error('[pool] position read failed for', wallet, message);
+    return { ok: false, reason: message };
+  }
+}
+
+
+const BOND_COLLECTION_ABI = [
+  'function getBondIdsByCreator(address creator) view returns (uint256[])',
+  'function balanceOf(address account, uint256 id) view returns (uint256)',
+];
+
+const REGISTRY_ITEM_ABI = [
+  'function pledgeItem(address member, bytes32 kind, uint256 itemId)',
+  'function releaseItem(address member, bytes32 kind, uint256 itemId)',
+  'function pledgedItemsOf(address member, bytes32 kind) view returns (uint256[])',
+];
+
+/**
+ * Pledge a member's bonds so they back the BOND tier.
+ *
+ * Bonds pledge differently from savings and pool shares, and the difference is not cosmetic. They
+ * have identity — the registry records *which* bond, because refusing to let it move and valuing
+ * it both need to know that — so this is `pledgeItem` per bond rather than one amount. Half a bond
+ * is not a thing.
+ *
+ * It follows that there is no figure to sync toward. The reconciliation is set-shaped: pledge what
+ * is held and not yet pledged, release what is pledged and no longer held. Both directions matter,
+ * because a bond can leave by transfer, redemption or seizure, and a pledge left behind would
+ * value a member's line against something they no longer own.
+ *
+ * The value comes from `BondValuer`, which the registry calls itself — a bond is worth something
+ * different every day, so nothing here computes a price. Registering the valuer is what makes that
+ * work, and it is already registered against BOND at a 95% haircut.
+ */
+export async function syncBondCollateral(wallet: string): Promise<CollateralSyncResult> {
+  const registryAddress = getContractAddress(chainId(), 'CollateralRegistry');
+  const collectionAddress = getContractAddress(chainId(), 'BurnerBond');
+  const calculatorAddress = getContractAddress(chainId(), 'LimitCalculator');
+  if (!registryAddress) return { ok: false, reason: 'no collateral registry on this chain' };
+  if (!collectionAddress) return { ok: false, reason: 'no bond collection on this chain' };
+
+  const key = operatorKey();
+  if (!key) return { ok: false, reason: 'no CREDIT_OPERATOR_PRIVATE_KEY or DEPLOYER_PRIVATE_KEY' };
+
+  try {
+    const rpc = new ethers.JsonRpcProvider(savingsIntentService.resolveRpcUrl(chainId()));
+    const signer = new ethers.Wallet(key, rpc);
+    const member = ethers.getAddress(wallet);
+
+    const collection = new ethers.Contract(collectionAddress, BOND_COLLECTION_ABI, rpc);
+    const registry = new ethers.Contract(registryAddress, REGISTRY_ITEM_ABI, signer);
+
+    // Created is not held: a bond can be transferred, redeemed or seized, and one the member no
+    // longer holds backs nothing of theirs.
+    const created: bigint[] = await collection.getBondIdsByCreator(member);
+    const held = new Set<string>();
+    for (const id of created) {
+      const balance: bigint = await collection.balanceOf(member, id);
+      if (balance > 0n) held.add(id.toString());
+    }
+
+    const pledgedIds: bigint[] = await registry.pledgedItemsOf(member, BOND_KIND);
+    const pledged = new Set(pledgedIds.map((id) => id.toString()));
+
+    let changed = 0;
+    for (const id of held) {
+      if (pledged.has(id)) continue;
+      const tx = await registry.pledgeItem(member, BOND_KIND, id);
+      await tx.wait();
+      changed += 1;
+    }
+    for (const id of pledged) {
+      if (held.has(id)) continue;
+      // `releaseItem` refuses while the bond is holding up drawn credit, which is correct — the
+      // member cannot have moved it either.
+      try {
+        const tx = await registry.releaseItem(member, BOND_KIND, id);
+        await tx.wait();
+        changed += 1;
+      } catch {
+        // Encumbered, or already gone. Left as it is rather than treated as a failure of the sync.
+      }
+    }
+
+    if (calculatorAddress) {
+      const calculator = new ethers.Contract(calculatorAddress, CALCULATOR_ABI, signer);
+      const estimate = await calculator.pushCapacities.estimateGas(member);
+      const push = await calculator.pushCapacities(member, { gasLimit: (estimate * 15n) / 10n });
+      await push.wait();
+    }
+
+    return { ok: true, pledgedUnits: String(held.size) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error';
+    console.error('[bond] collateral sync failed for', wallet, message);
     return { ok: false, reason: message };
   }
 }

--- a/app/src/components/clear/BuyBondDialog.tsx
+++ b/app/src/components/clear/BuyBondDialog.tsx
@@ -33,11 +33,20 @@ export default function BuyBondDialog({
   open,
   onOpenChange,
   onBuy,
+  busy = false,
+  error = null,
 }: {
   data: EarnData;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onBuy?: (term: BondTerm) => void;
+  /**
+   * A purchase needs more than the term. The face value is chosen on this screen and the price is
+   * derived from both, so passing the term alone would make the caller re-derive figures the
+   * screen already has — and re-derived money is money that can disagree.
+   */
+  onBuy?: (purchase: { term: BondTerm; face: number; price: number; maturity: { label: string; date: Date } }) => void;
+  busy?: boolean;
+  error?: string | null;
 }) {
   const [months, setMonths] = useState(24);
   const [face, setFace] = useState(5000);
@@ -126,8 +135,15 @@ export default function BuyBondDialog({
         </InfoBlock>
       )}
 
-      <Button size="xs" className="w-full" onClick={() => onBuy?.(term)}>
-        Buy this bond
+      {error && <p className="mb-2 text-[11px] leading-relaxed text-negative">{error}</p>}
+
+      <Button
+        size="xs"
+        className="w-full"
+        disabled={busy}
+        onClick={() => onBuy?.({ term, face, price, maturity })}
+      >
+        {busy ? 'One moment…' : 'Buy this bond'}
       </Button>
     </Modal>
   );

--- a/app/src/components/clear/ConnectedBuyBond.tsx
+++ b/app/src/components/clear/ConnectedBuyBond.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useState } from 'react';
+import { readContract } from '@wagmi/core';
+import { parseUnits } from 'viem';
+import BuyBondDialog from './BuyBondDialog';
+import { useClearBalances } from '@/hooks/useClearBalances';
+import { useOptionalAddress, useOptionalSmartWalletClient } from '@/hooks/useOptionalWallet';
+import { ACTIVE_CHAIN_ID, clearContracts } from '@/lib/clearNetwork';
+import { wagmiAdapter } from '@/AppKitProvider';
+import { scBuyBond } from '@/lib/sendCalls';
+import { getEarn } from '@/utils/apiClient';
+import { toEarnData } from '@/lib/earnMapping';
+import { EARN_DAY_ONE } from '@/data/clearPlaceholder';
+import { track } from '@/lib/analytics';
+import type { EarnData } from '@/lib/clearModel';
+
+/**
+ * Buying a bond, wired.
+ *
+ * Paid from **Ready to allocate** — the USDC already in the member's smart account — the same
+ * balance savings and the pool draw on. Approve and mint go in one sponsored batch.
+ *
+ * **The price is quoted by the chain, not by the screen.** `calculateRequiredDeposit` is what the
+ * deposit contract will actually charge, and it is what the approval is for. The ladder on the
+ * screen is a model of the same curve; letting it set the approval would mean two figures that
+ * agree until the curve moves and then quietly do not, with the approval being the one that fails.
+ */
+const DEPOSIT_ABI = [
+  { type: 'function', name: 'calculateRequiredDeposit', stateMutability: 'view',
+    inputs: [
+      { name: 'tokenAddress', type: 'address' },
+      { name: 'faceValue', type: 'uint256' },
+      { name: 'maturityDate', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'uint256' }] },
+] as const;
+
+const BOND_ABI = [
+  { type: 'function', name: 'getDiscountForMaturity', stateMutability: 'view',
+    inputs: [{ name: 'timeToMaturity', type: 'uint256' }],
+    outputs: [{ name: '', type: 'uint256' }] },
+] as const;
+
+export default function ConnectedBuyBond({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const balances = useClearBalances();
+  const address = useOptionalAddress();
+  const getClientForChain = useOptionalSmartWalletClient();
+  const [data, setData] = useState<EarnData>(EARN_DAY_ONE);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Read, not passed. A page holding a mapped model would hand fixtures to a screen that spends
+  // money, which is the mistake the savings dialog was fixed for.
+  useEffect(() => {
+    if (!address || !open) return;
+    let cancelled = false;
+    void getEarn(address).then((earn) => {
+      if (cancelled || !earn) return;
+      setData(toEarnData(earn.pool, earn.bonds, earn.terms, earn.earnedToDateCents, null, EARN_DAY_ONE));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [address, open]);
+
+  const onBuy = useCallback(
+    async (purchase: { face: number; maturity: { date: Date } }) => {
+      if (!address) {
+        setError('Connect a wallet first.');
+        return;
+      }
+      const chainId = ACTIVE_CHAIN_ID;
+      const c = clearContracts(chainId);
+      if (!c?.burnerBondDeposit || !c.burnerBond) {
+        setError('Bonds are not available on this network.');
+        return;
+      }
+
+      setBusy(true);
+      setError(null);
+      try {
+        const faceValue = purchase.face.toFixed(2);
+        const maturityDate = Math.floor(purchase.maturity.date.getTime() / 1000);
+        const face = parseUnits(faceValue, 6);
+
+        // Both from the chain: what it costs, and the discount the collection prices it at. The
+        // deposit contract validates the discount it is handed, so a number the screen invented
+        // would be rejected at the last possible moment.
+        const priceUnits = (await readContract(wagmiAdapter.wagmiConfig, {
+          address: c.burnerBondDeposit, abi: DEPOSIT_ABI, functionName: 'calculateRequiredDeposit',
+          args: [c.usdc, face, BigInt(maturityDate)], chainId,
+        })) as bigint;
+
+        const secondsToMaturity = BigInt(Math.max(0, maturityDate - Math.floor(Date.now() / 1000)));
+        const discountBps = (await readContract(wagmiAdapter.wagmiConfig, {
+          address: c.burnerBond, abi: BOND_ABI, functionName: 'getDiscountForMaturity',
+          args: [secondsToMaturity], chainId,
+        })) as bigint;
+
+        const chainClient = getClientForChain
+          ? await getClientForChain({ id: chainId }).catch(() => undefined)
+          : undefined;
+
+        await scBuyBond({
+          smartWalletClient: chainClient,
+          ownerWallet: address,
+          faceValue,
+          maturityDate,
+          discountBps: Number(discountBps),
+          priceUnits,
+          chainId,
+        });
+
+        // Ready to allocate falls by what the bond actually cost, not by its face.
+        balances.applyOptimistic(-Number(priceUnits) / 1e6, 0);
+        track('bond_bought', {}); // that it happened, never the amount or the term
+        onOpenChange(false);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "That didn't go through.");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [address, getClientForChain, balances, onOpenChange],
+  );
+
+  return (
+    <BuyBondDialog
+      data={data}
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setError(null);
+        onOpenChange(next);
+      }}
+      onBuy={(p) => void onBuy(p)}
+      busy={busy}
+      error={error}
+    />
+  );
+}

--- a/app/src/lib/clearNetwork.ts
+++ b/app/src/lib/clearNetwork.ts
@@ -30,6 +30,10 @@ export interface ClearContracts {
    * calling a zero address.
    */
   lendingPool?: `0x${string}`;
+  /** Where a bond is bought. Optional for the same reason as the pool — testnet only so far. */
+  burnerBondDeposit?: `0x${string}`;
+  /** The collection a bought bond is minted into, and what the app reads holdings from. */
+  burnerBond?: `0x${string}`;
 }
 const CONTRACTS: Record<number, ClearContracts> = {
   8453: {
@@ -40,6 +44,8 @@ const CONTRACTS: Record<number, ClearContracts> = {
   },
   84532: {
     lendingPool: '0x58405326b66888d8a9f2Dc4646cAc2F5EaC7ce23',
+    burnerBondDeposit: '0x1933aC0BDd58C1a6D48c19f8A7fD96c5Ec27c6C3',
+    burnerBond: '0x4d96904EA80aae8cAC34826f8Fd0aF52Ae85c148',
     // Replacement pair. The vault and token these succeed are still deployed and still
     // mutually redeemable -- ESADepositVaultLegacy holds the USDC behind the CLRUSD that was
     // outstanding when the swap happened, so nobody who held the old token is stranded.

--- a/app/src/lib/sendCalls.ts
+++ b/app/src/lib/sendCalls.ts
@@ -2,7 +2,7 @@ import { encodeFunctionData, parseUnits } from 'viem';
 import { sendCalls, waitForCallsStatus } from '@wagmi/core';
 import { wagmiAdapter } from '@/AppKitProvider';
 import { clearContracts } from '@/lib/clearNetwork';
-import { recordGaslessSavings, recordGaslessPool } from '@/utils/apiClient';
+import { recordGaslessSavings, recordGaslessPool, recordGaslessBond } from '@/utils/apiClient';
 
 /*
  * 3-TIER gasless money router (see [[clearpath-privy-migration]]).
@@ -202,6 +202,55 @@ export async function scPoolWithdraw(args: {
 
   const hash = await runBatch(args.smartWalletClient, args.ownerWallet, args.chainId, calls);
   await recordGaslessPool({ action: 'withdraw', amount: (args.sharesNow + args.sharesQueued).toString(), txHash: hash, chainId: args.chainId }).catch(() => {});
+  return hash;
+}
+
+const BOND_DEPOSIT_ABI = [
+  { type: 'function', name: 'makeDeposit', stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'tokenAddress', type: 'address' },
+      { name: 'faceValue', type: 'uint256' },
+      { name: 'maturityDate', type: 'uint256' },
+      { name: 'discountPercentage', type: 'uint256' },
+    ],
+    outputs: [{ name: 'bondId', type: 'uint256' }] },
+] as const;
+
+/**
+ * Ready to allocate (USDC) → a bond: [approve, makeDeposit] in ONE sponsored batch.
+ *
+ * A bond is bought at a discount and matures at face, so what a member pays is derived from the
+ * face value and the term rather than typed. `approve` is for the price, not the face — approving
+ * the face would let the deposit contract take more than the bond costs.
+ *
+ * The price is quoted by the chain (`calculateRequiredDeposit`) and passed in, so the approval and
+ * the purchase agree on one figure that neither this file nor the screen invented.
+ */
+export async function scBuyBond(args: {
+  smartWalletClient?: unknown;
+  ownerWallet: string;
+  /** Face value in whole units — what the bond pays at maturity. */
+  faceValue: string;
+  /** Unix seconds. */
+  maturityDate: number;
+  /** Basis points, as the collection prices it. */
+  discountBps: number;
+  /** What it costs today, quoted by the chain. */
+  priceUnits: bigint;
+  chainId: number;
+}): Promise<string> {
+  const c = clearContracts(args.chainId);
+  if (!c?.burnerBondDeposit) throw new Error('Bonds are not available on this network.');
+  const face = parseUnits(args.faceValue, 6);
+
+  const hash = await runBatch(args.smartWalletClient, args.ownerWallet, args.chainId, [
+    { to: c.usdc, data: encodeFunctionData({ abi: ERC20_ABI, functionName: 'approve', args: [c.burnerBondDeposit, args.priceUnits] }) },
+    { to: c.burnerBondDeposit, data: encodeFunctionData({
+        abi: BOND_DEPOSIT_ABI, functionName: 'makeDeposit',
+        args: [c.usdc, face, BigInt(args.maturityDate), BigInt(args.discountBps)],
+      }) },
+  ]);
+  await recordGaslessBond({ txHash: hash, chainId: args.chainId }).catch(() => {});
   return hash;
 }
 

--- a/app/src/pages/app/EarnPage.tsx
+++ b/app/src/pages/app/EarnPage.tsx
@@ -8,7 +8,7 @@ import InfoBlock from '@/components/clear/InfoBlock';
 import YieldPoolCard from '@/components/clear/YieldPoolCard';
 import HeldBondsCard from '@/components/clear/HeldBondsCard';
 import BondLadder from '@/components/clear/BondLadder';
-import BuyBondDialog from '@/components/clear/BuyBondDialog';
+import ConnectedBuyBond from '@/components/clear/ConnectedBuyBond';
 import ConnectedPoolMove from '@/components/clear/ConnectedPoolMove';
 import PoolWithdrawDialog from '@/components/clear/PoolWithdrawDialog';
 import { EARN_DAY_ONE, HOME_DAY_ONE } from '@/data/clearPlaceholder';
@@ -132,7 +132,7 @@ export default function EarnPage({ data = EARN_DAY_ONE }: { data?: EarnData }) {
         </Card>
       </div>
 
-      <BuyBondDialog data={data} open={buyOpen} onOpenChange={setBuyOpen} />
+      <ConnectedBuyBond open={buyOpen} onOpenChange={setBuyOpen} />
       <ConnectedPoolMove open={depositOpen} onOpenChange={setDepositOpen} />
       {/* The limit it quotes comes from Home's own tiers, so the drop it shows is
           the drop that would actually happen. */}

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -3032,3 +3032,14 @@ export async function recordGaslessPool(p: {
 }): Promise<void> {
   await apiRequest('/api/savings/pool/record', { method: 'POST', body: JSON.stringify(p) });
 }
+
+
+/**
+ * Tell the server a bond was bought, so it pledges it as collateral.
+ *
+ * No amount is sent. Bonds pledge by identity, and the server reads which ones a member holds
+ * rather than believing a number — so there is nothing here worth lying about.
+ */
+export async function recordGaslessBond(p: { txHash: string; chainId: number }): Promise<void> {
+  await apiRequest('/api/savings/bond/record', { method: 'POST', body: JSON.stringify(p) });
+}


### PR DESCRIPTION
The last of the three collateral tiers. `BuyBondDialog` matched the reference and did nothing — no handler, no contract call — so the `BOND` tier could only ever read zero.

## The purchase

Paid from **Ready to allocate**, like savings and the pool: approve and mint in one sponsored batch through `BurnerBondDeposit.makeDeposit`, which is the only caller `mintBond` accepts.

**The price is quoted by the chain, not by the screen.** `calculateRequiredDeposit` is what the deposit contract will actually charge, and it's what the approval is for. The ladder on screen models the same curve; letting it set the approval would be two figures that agree until the curve moves and then quietly don't — with the approval being the one that fails. The discount is read the same way, since the contract validates the one it's handed.

Approving the **price, not the face** — different numbers, since a bond is bought at a discount. Approving the face would let the deposit contract take more than the bond costs.

## Bonds pledge by identity

The registry records *which* bond, because refusing to let it move and valuing it both need to know that — half a bond is not a thing. So this is `pledgeItem` per bond rather than one amount, and the reconciliation is set-shaped: pledge what's held and not pledged, release what's pledged and not held.

Both directions, because a bond can leave by transfer, redemption or seizure — and a pledge left behind would value a member's line against something they no longer own.

Nothing here prices anything. `BondValuer` is registered against `BOND` and the registry asks it.

## The guard was weaker than I claimed

Two real holes, both found by trying to break it:

**It asserted `/BOND|POOL_SHARE/`** — which passes if *either* exists. A bond purchase shipped beside a pool sync would have satisfied it while pledging nothing. Each tier is now checked against its own sync.

**It checked that a function *name* appeared in the service.** I renamed `syncBondCollateral` to `syncBondCollateralDISABLED` expecting a failure, and it passed — a substring match can't tell a definition from a corpse. It now asserts the **route actually calls** the sync, which is what matters: a sync nothing invokes pledges nothing. Verified by removing the call and watching it fail.

## State

All three collateral tiers now have a purchase path and a pledge, and a test that fails if either goes missing.

383 tests. **Not verified:** an on-chain bond purchase — that needs a real session on the demo.