### PR TITLE
Stop rounding what a position backs to whole dollars

### DIFF
--- a/app/server/src/services/chain/collateralCoverage.test.ts
+++ b/app/server/src/services/chain/collateralCoverage.test.ts
@@ -108,3 +108,31 @@ describe('collateral tiers have something that pledges them', () => {
     expect(SYNC).toContain('pledgedItemsOf');
   });
 });
+
+
+/*
+ * The haircuts exist in three places that cannot import from each other: the contracts, the app,
+ * and this server. Two of them are copies, and a copy that drifts quotes a member a limit the
+ * contracts will not give them.
+ *
+ * Pinned here against the registry as deployed on Base Sepolia — POOL_SHARE 7000 bps, BOND 9500 —
+ * and against the app's own constants, which have their own matching test. If governance moves a
+ * haircut, three tests fail and each names the file to change.
+ */
+describe('the server’s haircuts match the contracts and the app', () => {
+  test('a pool share is 70%', async () => {
+    const { POOL_LTV } = await import('../lithic/tierLimits.js');
+    expect(POOL_LTV).toBeCloseTo(7_000 / 10_000, 6);
+  });
+
+  test('a bond is 95%', async () => {
+    const { BOND_LTV } = await import('../lithic/tierLimits.js');
+    expect(BOND_LTV).toBeCloseTo(9_500 / 10_000, 6);
+  });
+
+  test('and the app agrees', () => {
+    const model = readFileSync(join(import.meta.dir, '../../../../src/lib/clearModel.ts'), 'utf8');
+    expect(model).toContain('POOL_SHARE_HAIRCUT_BPS = 7_000');
+    expect(model).toContain('BOND_HAIRCUT_BPS = 9_500');
+  });
+});

--- a/app/src/components/clear/ConnectedPoolMove.tsx
+++ b/app/src/components/clear/ConnectedPoolMove.tsx
@@ -6,15 +6,9 @@ import { useOptionalAddress } from '@/hooks/useOptionalWallet';
 import { useMoneyActions } from '@/context/MoneyActionsContext';
 import { getCredit, getEarn, type EarnPoolRow } from '@/utils/apiClient';
 import { track } from '@/lib/analytics';
+import { POOL_SHARE_HAIRCUT_BPS } from '@/lib/clearModel';
 
-/**
- * The haircut `CollateralRegistry` applies to a pool share, read from the deployment.
- *
- * Stated here rather than fetched because it is a co-op parameter that changes by governance, not
- * by the minute — but it is a real on-chain value, so if it moves this constant is the one place
- * that is wrong, and the limit it quotes is the thing a member would notice.
- */
-const POOL_SHARE_HAIRCUT_BPS = 7_000;
+
 
 /**
  * Add to / take from the yield pool, wired.

--- a/app/src/data/clearPlaceholder.ts
+++ b/app/src/data/clearPlaceholder.ts
@@ -21,6 +21,7 @@ import type {
   TermPlan,
   LinkedAccount,
 } from '@/lib/clearModel';
+import { POOL_SHARE_HAIRCUT_BPS } from '@/lib/clearModel';
 import { assetBackedLimit } from '@/lib/clearModel';
 import { CLEAR_GRANTS } from '@/lib/clearGrants';
 
@@ -34,7 +35,9 @@ const PAY_FROM = { label: 'Cash account', balance: 6200 };
 
 /** Loan-to-value each product is lent against — spec §6. */
 const BOND_LTV = 0.95;
-const POOL_LTV = 0.7;
+// Derived, not restated. This is the registry's haircut expressed as a fraction, and it decides
+// how much credit a member gets — a second copy is a second thing to forget.
+const POOL_LTV = POOL_SHARE_HAIRCUT_BPS / 10_000;
 
 const POOL: YieldPool = { apy: 6.8, lent: 740000, capacity: 1000000, position: 2500, earned: 41.2 };
 

--- a/app/src/lib/backing.test.ts
+++ b/app/src/lib/backing.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+import { poolBacking, bondsBacking, POOL_SHARE_HAIRCUT_BPS, BOND_HAIRCUT_BPS } from '@/lib/clearModel';
+import { EARN_DAY_ONE } from '@/data/clearPlaceholder';
+import type { EarnData } from '@/lib/clearModel';
+
+const withPosition = (position: number): EarnData => ({
+  ...EARN_DAY_ONE,
+  pool: { ...EARN_DAY_ONE.pool, position },
+});
+
+/*
+ * Reported from the demo: $5 into the pool, Earn said $4.00 backs the limit and Home said $3.50.
+ * Home was right — it reads the credit contracts. Earn rounded 3.5 to a whole dollar, and upward,
+ * which overstates what backs a member's limit. That is the worse direction to be wrong in.
+ */
+describe('what a position backs', () => {
+  test('keeps cents rather than rounding to dollars', () => {
+    expect(poolBacking(withPosition(5))).toBe(3.5);
+  });
+
+  test('the case that was reported, exactly', () => {
+    // 5 × 0.70 = 3.50. Math.round took this to 4.
+    expect(poolBacking(withPosition(5))).not.toBe(4);
+  });
+
+  test('rounds half-cents rather than truncating them', () => {
+    // 3.333… of position is a real figure after a partial withdrawal.
+    expect(poolBacking(withPosition(3.333))).toBe(2.33);
+  });
+
+  test('nothing backs nothing', () => {
+    expect(poolBacking(withPosition(0))).toBe(0);
+  });
+
+  test('bonds are rounded the same way', () => {
+    expect(bondsBacking(EARN_DAY_ONE)).toBe(Math.round(bondsBacking(EARN_DAY_ONE) * 100) / 100);
+  });
+});
+
+/*
+ * The haircuts are stated in the app and enforced on chain, so they can disagree. These pin the
+ * app's copy to what `CollateralRegistry` actually registers on Base Sepolia — read from chain,
+ * not assumed:
+ *
+ *   SAVINGS         100%
+ *   ASSET_INTERNAL   95%
+ *   POOL_SHARE       70%
+ *   BOND             95%
+ *
+ * If governance moves one, this fails and names the number to change. Silent divergence here means
+ * quoting a member a limit the contracts will not give them.
+ */
+describe('the app’s haircuts match the deployment', () => {
+  test('a pool share is haircut at 70%', () => {
+    expect(POOL_SHARE_HAIRCUT_BPS).toBe(7_000);
+  });
+
+  test('a bond is haircut at 95%', () => {
+    expect(BOND_HAIRCUT_BPS).toBe(9_500);
+  });
+
+  test('and there is one copy of each', () => {
+    // Three existed: the placeholder's POOL_LTV, the server's tierLimits, and one I added inside
+    // the pool dialog. The only thing keeping them equal was that nobody had changed one.
+    const placeholder = require('node:fs').readFileSync(
+      require('node:path').join(import.meta.dir, '../data/clearPlaceholder.ts'), 'utf8',
+    );
+    expect(placeholder).toContain('POOL_SHARE_HAIRCUT_BPS / 10_000');
+    expect(placeholder).not.toMatch(/const POOL_LTV = 0\./);
+  });
+});

--- a/app/src/lib/clearModel.ts
+++ b/app/src/lib/clearModel.ts
@@ -696,19 +696,42 @@ export function bondElapsed(bond: HeldBond): number {
 }
 
 /**
- * What each product backs on the credit line, and the total.
+ * What each product backs on the credit line.
  *
- * This is the whole reason the two products aren't just savings accounts: money
- * locked in them still raises the limit, at the loan-to-value the tier lends at.
- * The asset-backed tier's limit on Home is this number — one derivation, so Earn
- * and Home can't quote different figures.
+ * This is the whole reason the two products aren't just savings accounts: money locked in them
+ * still raises the limit, at the loan-to-value the tier lends at.
+ *
+ * **Rounded to cents, not to dollars.** Rounding to whole dollars turned $5 of pool position into
+ * "$4.00 backs your limit" — 5 × 0.7 is 3.50, and `Math.round` took it up. Home reads the figure
+ * from the credit contracts and said $3.50, so the two disagreed by fifty cents on the same
+ * quantity, and the one that was wrong was rounding *up*: overstating what backs a member's limit
+ * is the worse direction to be wrong in.
+ *
+ * These still derive from the model rather than from chain, so they agree with the contracts only
+ * while `poolLtv` and `bondLtv` match the registry's haircuts. That is pinned by a test rather
+ * than left to hold by luck.
  */
+const toCents = (value: number) => Math.round(value * 100) / 100;
+
+/*
+ * The haircuts, as `CollateralRegistry` registers them.
+ *
+ * One place, because there were three: the placeholder's POOL_LTV, the server's tierLimits, and a
+ * constant I added inside the pool dialog. Three copies of a number that decides how much credit a
+ * member gets, and the only thing keeping them equal was that nobody had changed one.
+ *
+ * They are co-op parameters set by governance, not by the minute — so stating them is reasonable.
+ * What is not reasonable is stating them repeatedly. A test pins these against the deployment.
+ */
+export const POOL_SHARE_HAIRCUT_BPS = 7_000;
+export const BOND_HAIRCUT_BPS = 9_500;
+
 export function poolBacking(data: EarnData): number {
-  return Math.round(data.pool.position * data.poolLtv);
+  return toCents(data.pool.position * data.poolLtv);
 }
 
 export function bondsBacking(data: EarnData): number {
-  return Math.round(bondsWorth(data.bonds) * data.bondLtv);
+  return toCents(bondsWorth(data.bonds) * data.bondLtv);
 }
 
 export function assetBackedLimit(data: EarnData): number {


### PR DESCRIPTION
Reported from the demo: **$5 into the pool, Earn said $4.00 backs the limit and Home said $3.50.** Home was right — it reads the credit contracts.

`5 × 0.70 = 3.50`, and `poolBacking` put it through `Math.round`, which took it to 4. `YieldPoolCard` then formatted the already-rounded whole dollar with cents, so it read "$4.00" — precise-looking and wrong.

Rounded to **cents** now, not dollars.

Worth naming the direction: it rounded **up**, so a member was told more of their money was backing their limit than actually was. Of the two ways to be wrong about somebody's credit, that's the worse one.

## The docblock was making a promise it had stopped keeping

> *"one derivation, so Earn and Home can't quote different figures"*

That stopped being true when Home started reading the chain, and this is what it looked like. It now says what's actually the case: these derive from the model, and they agree with the contracts only while the app's haircuts match the registry's.

## Which now lives in one place instead of three

The pool haircut existed as the placeholder's `POOL_LTV`, the server's `tierLimits`, and a constant **I added inside the pool dialog last week** — three copies of a number that decides how much credit a member gets, kept equal only by nobody having changed one.

The app now has a single pair of constants, the placeholder derives from them, and tests pin all three sides against the registry as deployed: `POOL_SHARE` 7000 bps, `BOND` 9500. Move a haircut in governance and three tests fail, each naming its file.

## Verification

391 tests, 8 new — including the reported case asserted by number (`poolBacking(5) === 3.5`, and explicitly `!== 4`).