### PR TITLE
Start the amount at zero so the pad is ready to type into

### DIFF
--- a/app/src/components/clear/MoveMoneyDialog.tsx
+++ b/app/src/components/clear/MoveMoneyDialog.tsx
@@ -147,7 +147,18 @@ export default function MoveMoneyDialog({
   onAddMoney,
   onAutoSave,
 }: MoveMoneyProps) {
-  const [typed, setTyped] = useState('250');
+  /*
+   * Starts empty, showing $0.00.
+   *
+   * A prefilled figure has to be cleared before it can be replaced, and on a keypad that means
+   * pressing backspace three times before typing the first digit of what you actually wanted. The
+   * chips are there for anyone who does want a round number; the pad is for everyone else, and it
+   * should be ready to type into.
+   *
+   * Empty rather than the string "0", so the first keypress replaces nothing — `applyKey` already
+   * treats a leading zero as a value to overwrite, but starting empty means it never has to.
+   */
+  const [typed, setTyped] = useState('');
 
   const isDeposit = direction === 'deposit';
   const isPool = destination === 'pool';

--- a/app/src/components/clear/moveMoney.test.ts
+++ b/app/src/components/clear/moveMoney.test.ts
@@ -462,3 +462,30 @@ describe('the pool pledges what it holds', () => {
     expect(POOL).toContain('getCredit(address)');
   });
 });
+
+/*
+ * The pad should be ready to type into.
+ *
+ * A prefilled amount has to be cleared before it can be replaced, which on a keypad means pressing
+ * backspace three times before the first digit of what you actually wanted.
+ */
+describe('the amount starts empty', () => {
+  test('nothing is prefilled', () => {
+    expect(DIALOG).toContain("const [typed, setTyped] = useState('');");
+    expect(DIALOG).not.toContain("useState('250')");
+  });
+
+  test('an empty amount reads as $0.00, not as blank', () => {
+    // The figure is the anchor of the screen; an empty space where it belongs reads as broken.
+    expect(DIALOG).toContain("Number(typed.split('.')[0] || 0)");
+    expect(DIALOG).toContain("(typed.split('.')[1] ?? '').padEnd(2, '0')");
+  });
+
+  test('and the action is inert until something is typed', () => {
+    expect(DIALOG).toContain('disabled={busy || amount <= 0}');
+  });
+
+  test('typing builds from empty without a leading zero to clear', () => {
+    expect(['5', '0'].reduce(applyKey, '')).toBe('50');
+  });
+});


### PR DESCRIPTION
Savings and the pool both opened prefilled at **$250**. A prefilled figure has to be cleared before it can be replaced, and on a keypad that means three backspaces before the first digit of what somebody actually wanted — which is most people, since the whole reason this screen has a pad rather than three buttons is that members move amounts like $3,400.

Empty rather than the string `"0"`, so the first keypress replaces nothing. The figure still reads **$0.00**: the amount is the anchor of the screen, and a blank space where it belongs reads as broken rather than as ready.

The action starts inert and turns on when there's something to move. It already worked that way — it was just never reachable, because the screen opened with a valid amount already in it.

This also makes **opening** consistent with **swapping**, which already cleared to zero for its own reason: the caps differ between directions, so an amount carried across could arrive already over the limit.

## Verified

Both destinations open at `$0.00` with the button disabled, and two keypresses reaches `$42.00` with the button live. 398 tests, 4 new.