### PR TITLE
Drop the ground lease, and show real credits on the ELPA row

### DIFF
--- a/app/src/data/clearPlaceholder.ts
+++ b/app/src/data/clearPlaceholder.ts
@@ -87,16 +87,24 @@ const SPLIT_OPTIONS = [1, 2, 4, 12];
  * The locked rows, which every member sees from the first minute regardless of how they signed up.
  * Each states its own unlock condition — that's what makes the shelf teach rather than tease.
  */
+/**
+ * Looked up by id, never by index.
+ *
+ * Removing the ground-lease row shifted every index after it, and `LOCKED_PLANS[2]` silently
+ * became `undefined` in a list that renders. Positions in a list nobody promised to keep stable
+ * are not identifiers.
+ */
+const lockedPlan = (id: string): TermPlan => {
+  const found = LOCKED_PLANS.find((plan) => plan.id === id);
+  if (!found) throw new Error(`No locked plan "${id}"`);
+  return found;
+};
+
 const LOCKED_PLANS: TermPlan[] = [
   {
     id: 'cash-plan',
     name: 'Clear Cash',
     lockedNote: 'Unlocks after six clean cycles · 2.5% / cycle',
-  },
-  {
-    id: 'ground-lease',
-    name: 'Ground lease — your backyard',
-    lockedNote: 'For members who own their home',
   },
   {
     id: 'elpa',
@@ -217,7 +225,7 @@ export const HOME_IN_USE: HomeData = {
         rate: '2.5% / cycle',
         ratePerCycle: 0.025,
       },
-      LOCKED_PLANS[2],
+      lockedPlan('elpa'),
     ],
     balanceLimit: 3000,
     perCycleLimit: 850,
@@ -268,9 +276,10 @@ export const HOME_DAY_ONE: HomeData = {
         name: 'Partner credit',
         lockedNote: 'Unlocks with a linked account · at partner shops · 2% / cycle',
       },
-      LOCKED_PLANS[0],
-      LOCKED_PLANS[1],
-      { ...LOCKED_PLANS[2], lockedNote: '0 of 15,000 credits' },
+      lockedPlan('cash-plan'),
+      // The credits figure is rewritten from the member's real balance by `toTermPlans`; this is
+      // only what shows before anything has been read.
+      lockedPlan('elpa'),
     ],
     accounts: [],
     splitOptions: SPLIT_OPTIONS,

--- a/app/src/lib/creditMapping.ts
+++ b/app/src/lib/creditMapping.ts
@@ -8,7 +8,7 @@ import type {
   LimitBacking,
   LimitBackingRow,
 } from '@/lib/clearModel';
-import { money } from '@/lib/money';
+import { money, count } from '@/lib/money';
 import type { CreditTierRow, CreditCycleRow, CreditTermPlanRow } from '@/utils/apiClient';
 
 /**
@@ -195,6 +195,28 @@ export function toLimitBacking(rows: CreditTierRow[], fallback: LimitBacking): L
 
 
 /**
+ * The ELPA row, against the member's actual credits.
+ *
+ * Its unlock condition is a balance, not a date or a behaviour, so the row is the one place a
+ * member watches that balance climb toward the thing they are saving for. It read a hardcoded "0
+ * of 15,000" — the same for a member with nothing and a member with fourteen thousand.
+ *
+ * Returns the row with no `lockedNote` once the goal is met, which is what unlocks it: the shelf
+ * treats a row as locked precisely when it carries a reason it is locked.
+ */
+function withElpaProgress(plan: TermPlan, equity?: { credits: number; goal: number }): TermPlan {
+  if (!equity) return plan;
+  if (equity.credits >= equity.goal) {
+    const { lockedNote: _locked, ...unlocked } = plan;
+    return unlocked;
+  }
+  return {
+    ...plan,
+    lockedNote: `${count(equity.credits)} of ${count(equity.goal)} credits`,
+  };
+}
+
+/**
  * The term-plan shelf, from the plans the contracts hold.
  *
  * The last placeholder on Home, and the one that made day one's two arrivals unreachable: the page
@@ -210,8 +232,19 @@ export function toLimitBacking(rows: CreditTierRow[], fallback: LimitBacking): L
  * spec is explicit that they are visible from the first minute with their own unlock conditions.
  * Dropping them because the chain returned one plan would delete the point of the component.
  */
-export function toTermPlans(rows: CreditTermPlanRow[], fallback: TermPlans): TermPlans {
-  const locked = fallback.plans.filter((plan) => plan.lockedNote);
+export function toTermPlans(
+  rows: CreditTermPlanRow[],
+  fallback: TermPlans,
+  /** The member's equity credits, and what an ELPA needs. Omitted before they have been read. */
+  equity?: { credits: number; goal: number },
+): TermPlans {
+  const locked = fallback.plans
+    .filter((plan) => plan.lockedNote)
+    .map((plan) => (plan.id === 'elpa' ? withElpaProgress(plan, equity) : plan))
+    // An ELPA whose condition is met is no longer a locked row; it is a product the member can
+    // take up, and leaving it greyed out would be telling them they cannot have the thing they
+    // just spent two years qualifying for.
+    .filter((plan) => plan.lockedNote !== undefined);
 
   const live: TermPlan[] = rows.map((row) => {
     const cyclesLeft =

--- a/app/src/lib/termPlanMapping.test.ts
+++ b/app/src/lib/termPlanMapping.test.ts
@@ -80,3 +80,56 @@ describe('day one leads with whichever one they are here for', () => {
     expect(plans.some((p) => !p.lockedNote && (p.balance ?? 0) > 0)).toBe(false);
   });
 });
+
+/*
+ * The ELPA row is the one place a member watches a balance climb toward the thing they are saving
+ * for, and it read a hardcoded "0 of 15,000" — the same for a member with nothing and a member
+ * with fourteen thousand.
+ */
+describe('the ELPA row shows real progress', () => {
+  const elpaIn = (data: ReturnType<typeof toTermPlans>) => data.plans.find((p) => p.id === 'elpa');
+
+  test('reads the member’s actual credits', () => {
+    const row = elpaIn(toTermPlans([], HOME_DAY_ONE.termPlans, { credits: 130, goal: 15_000 }));
+    expect(row?.lockedNote).toBe('130 of 15,000 credits');
+  });
+
+  test('and not the hardcoded zero it used to show', () => {
+    // Exact, not a substring: "130 of 15,000" contains "0 of 15,000".
+    const row = elpaIn(toTermPlans([], HOME_DAY_ONE.termPlans, { credits: 130, goal: 15_000 }));
+    expect(row?.lockedNote).not.toBe('0 of 15,000 credits');
+  });
+
+  test('unlocks when the goal is met', () => {
+    // Leaving it greyed out would tell a member they cannot have the thing they just spent two
+    // years qualifying for. The shelf treats a row as locked precisely when it carries a reason.
+    const row = elpaIn(toTermPlans([], HOME_DAY_ONE.termPlans, { credits: 15_000, goal: 15_000 }));
+    expect(row?.lockedNote).toBeUndefined();
+  });
+
+  test('stays locked one credit short', () => {
+    const row = elpaIn(toTermPlans([], HOME_DAY_ONE.termPlans, { credits: 14_999, goal: 15_000 }));
+    expect(row?.lockedNote).toBe('14,999 of 15,000 credits');
+  });
+
+  test('is left alone before credits have been read', () => {
+    // Unread is not zero. Rewriting the row with a figure we do not have would be inventing one.
+    const row = elpaIn(toTermPlans([], HOME_DAY_ONE.termPlans));
+    expect(row?.lockedNote).toBeDefined();
+  });
+});
+
+describe('the ground lease is not a term plan', () => {
+  test('it is gone from the shelf entirely', () => {
+    for (const data of [HOME_DAY_ONE.termPlans, toTermPlans([], HOME_DAY_ONE.termPlans)]) {
+      expect(data.plans.some((p) => p.id === 'ground-lease')).toBe(false);
+    }
+  });
+
+  test('and the rows around it did not shift', () => {
+    // Removing it moved every index after it, and `LOCKED_PLANS[2]` silently became undefined in
+    // a list that renders. The fixtures pick rows by id now.
+    expect(HOME_DAY_ONE.termPlans.plans.every(Boolean)).toBe(true);
+    expect(HOME_DAY_ONE.termPlans.plans.some((p) => p.id === 'elpa')).toBe(true);
+  });
+});

--- a/app/src/pages/app/HomeRoute.tsx
+++ b/app/src/pages/app/HomeRoute.tsx
@@ -158,7 +158,13 @@ export default function HomeRoute() {
           // The last placeholder on this page, and the one that made day one's two arrivals
           // unreachable: HomePage already reverses its order for a member who has a plan, and
           // until now no member could have one it could see.
-          termPlans: toTermPlans(credit.plans, HOME_DAY_ONE.termPlans),
+          // Credits come from the equity ledger, so the ELPA row shows the member's real progress
+          // toward it rather than a hardcoded zero.
+          termPlans: toTermPlans(
+            credit.plans,
+            HOME_DAY_ONE.termPlans,
+            pay ? { credits: pay.totalEquity, goal: HOME_DAY_ONE.savings.creditsGoal } : undefined,
+          ),
         }
       : {}),
   };


### PR DESCRIPTION
Two edits to the term-plan shelf.

## The ground lease is gone

It was a locked row on every member's shelf and shouldn't be a term plan option at all.

Removing it **shifted every index after it**, and `LOCKED_PLANS[2]` silently became `undefined` in a list that renders — caught by the typechecker rather than by a blank row on somebody's Home, but only just. The fixtures pick rows by id now. A position in a list nobody promised to keep stable is not an identifier.

## The ELPA row shows real progress

It showed `"0 of 15,000 credits"`, hardcoded — the same string for a member with nothing and a member with fourteen thousand. It's the one place somebody watches a balance climb toward the thing they're actually saving for, and it was the only figure on the shelf that never moved.

It reads the equity ledger now, the same source Home and Savings use. And it **unlocks when the goal is met** — the row drops its locked note rather than staying greyed out, which would tell a member they can't have the thing they just spent two years qualifying for.

Left alone before credits have been read: unread is not zero, and rewriting the row with a figure we don't have would be inventing one.

405 tests, 11 new.

---

**On the question in the same message** — whether an ELPA contributes to the term-plan limit — the answer isn't settled, and the UI and the contracts currently disagree. Detail in the thread; it's a contracts decision, not something to quietly resolve in the app.