### PR TITLE
One summary box, and bonds join the pattern

### DIFF
--- a/app/src/PreviewApp.tsx
+++ b/app/src/PreviewApp.tsx
@@ -304,6 +304,41 @@ function PoolMovePreview() {
   );
 }
 
+/** A bond — the same modal, one destination further, with the one exception it has to carry. */
+function BondPreview() {
+  const [months, setMonths] = useState(24);
+  // The reference's own figures: $5,000 face at 24 months costs $4,367.19.
+  const price = 4367.19;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <MoveMoneyDialog
+        open
+        onOpenChange={() => {}}
+        destination="bond"
+        direction="deposit"
+        onDirectionChange={() => {}}
+        cashReady={6200}
+        savingsTotal={0}
+        savingsFree={0}
+        credits={0}
+        creditsGoal={0}
+        bond={{
+          termOptions: [6, 12, 24, 36],
+          months,
+          onMonthsChange: setMonths,
+          priceToday: price,
+          maturesShort: 'Aug 2028',
+          maturesLong: 'Aug 25, 2028',
+          ratePercent: 7,
+          haircutBps: 9_500,
+        }}
+        onMove={() => {}}
+      />
+    </div>
+  );
+}
+
 /** A charge arriving — the approval screen and the state after it. */
 function ChargeApprovalPreview() {
   const [splitInto, setSplitInto] = useState(4);
@@ -443,6 +478,7 @@ export default function PreviewApp() {
           <Route path="/charge" element={<ChargeApprovalPreview />} />
           <Route path="/move-money" element={<MoveMoneyPreview />} />
           <Route path="/pool" element={<PoolMovePreview />} />
+          <Route path="/bond" element={<BondPreview />} />
 
           <Route
             path="*"

--- a/app/src/components/clear/ConnectedBuyBond.tsx
+++ b/app/src/components/clear/ConnectedBuyBond.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { readContract } from '@wagmi/core';
 import { parseUnits } from 'viem';
-import BuyBondDialog from './BuyBondDialog';
+import MoveMoneyDialog from './MoveMoneyDialog';
 import { useClearBalances } from '@/hooks/useClearBalances';
 import { useOptionalAddress, useOptionalSmartWalletClient } from '@/hooks/useOptionalWallet';
 import { ACTIVE_CHAIN_ID, clearContracts } from '@/lib/clearNetwork';
@@ -9,6 +9,7 @@ import { wagmiAdapter } from '@/AppKitProvider';
 import { scBuyBond } from '@/lib/sendCalls';
 import { getEarn } from '@/utils/apiClient';
 import { toEarnData } from '@/lib/earnMapping';
+import { BOND_HAIRCUT_BPS } from '@/lib/clearModel';
 import { EARN_DAY_ONE } from '@/data/clearPlaceholder';
 import { track } from '@/lib/analytics';
 import type { EarnData } from '@/lib/clearModel';
@@ -53,6 +54,11 @@ export default function ConnectedBuyBond({
   const [data, setData] = useState<EarnData>(EARN_DAY_ONE);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [months, setMonths] = useState(24);
+  const [face, setFace] = useState(0);
+  // Quoted by the chain for the chosen face and term. Null until both are known and the quote has
+  // come back — the screen shows nothing rather than a price the contract has not agreed to.
+  const [priceToday, setPriceToday] = useState<number | null>(null);
 
   // Read, not passed. A page holding a mapped model would hand fixtures to a screen that spends
   // money, which is the mistake the savings dialog was fixed for.
@@ -67,6 +73,44 @@ export default function ConnectedBuyBond({
       cancelled = true;
     };
   }, [address, open]);
+
+  const maturityDate = useMemo(() => {
+    const d = new Date();
+    d.setMonth(d.getMonth() + months);
+    return d;
+  }, [months]);
+
+  /*
+   * The price, quoted by the chain for exactly what is on screen.
+   *
+   * `calculateRequiredDeposit` is what the deposit contract will charge and what the approval is
+   * for. Deriving it in the app from a modelled curve would be two figures that agree until the
+   * curve moves — and the approval would be the one that fails.
+   */
+  useEffect(() => {
+    const c = clearContracts(ACTIVE_CHAIN_ID);
+    if (!open || !c?.burnerBondDeposit || face <= 0) {
+      setPriceToday(null);
+      return;
+    }
+    let cancelled = false;
+    void readContract(wagmiAdapter.wagmiConfig, {
+      address: c.burnerBondDeposit,
+      abi: DEPOSIT_ABI,
+      functionName: 'calculateRequiredDeposit',
+      args: [c.usdc, parseUnits(face.toFixed(2), 6), BigInt(Math.floor(maturityDate.getTime() / 1000))],
+      chainId: ACTIVE_CHAIN_ID,
+    })
+      .then((units) => {
+        if (!cancelled) setPriceToday(Number(units as bigint) / 1e6);
+      })
+      .catch(() => {
+        if (!cancelled) setPriceToday(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, face, maturityDate]);
 
   const onBuy = useCallback(
     async (purchase: { face: number; maturity: { date: Date } }) => {
@@ -130,16 +174,40 @@ export default function ConnectedBuyBond({
   );
 
   return (
-    <BuyBondDialog
-      data={data}
+    <MoveMoneyDialog
       open={open}
       onOpenChange={(next) => {
-        if (!next) setError(null);
+        if (!next) {
+          setError(null);
+          setFace(0);
+        }
         onOpenChange(next);
       }}
-      onBuy={(p) => void onBuy(p)}
+      destination="bond"
+      direction="deposit"
+      onDirectionChange={() => {
+        /* A bond is one-way before maturity; the route shows an arrow, not a swap. */
+      }}
+      cashReady={balances.cash}
+      savingsTotal={0}
+      savingsFree={0}
+      credits={0}
+      creditsGoal={0}
+      bond={{
+        termOptions: data.terms.map((t) => t.months),
+        months,
+        onMonthsChange: setMonths,
+        // Zero until the chain has quoted it, so the screen never shows a price nothing agreed to.
+        priceToday: priceToday ?? 0,
+        maturesShort: maturityDate.toLocaleDateString('en-US', { month: 'short', year: 'numeric' }),
+        maturesLong: maturityDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
+        ratePercent: data.terms.find((t) => t.months === months)?.rate ?? 0,
+        haircutBps: BOND_HAIRCUT_BPS,
+      }}
       busy={busy}
       error={error}
+      onAmountChange={setFace}
+      onMove={(amount) => void onBuy({ face: amount, maturity: { date: maturityDate } })}
     />
   );
 }

--- a/app/src/components/clear/MoveMoneyDialog.tsx
+++ b/app/src/components/clear/MoveMoneyDialog.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { ArrowLeftRight, Check, Loader2 } from 'lucide-react';
+import { ArrowLeftRight, ArrowRight, Check, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import Modal from './Modal';
 import Keypad from './Keypad';
@@ -36,7 +36,31 @@ export type MoveDirection = 'deposit' | 'withdraw';
  * Where the money is going. The reference is explicit that the pool is "the same component as
  * savings, pointed at a different destination" — so it is a prop rather than a second modal.
  */
-export type MoveDestination = 'savings' | 'pool';
+export type MoveDestination = 'savings' | 'pool' | 'bond';
+
+/**
+ * What a bond needs that neither of the others does.
+ *
+ * Bonds break the one rule the other two keep: everywhere else the number you type is the number
+ * that moves. With a bond you choose **face value** — what you get back — and a smaller,
+ * discounted amount leaves the account. So the hero carries both, with the price stated directly
+ * beneath the face rather than buried in the summary.
+ */
+export interface BondTerms {
+  /** Months offered, e.g. [6, 12, 24, 36]. Chips pick a term; the keypad types the face value. */
+  termOptions: number[];
+  months: number;
+  onMonthsChange: (months: number) => void;
+  /** What leaves the account today, quoted for the chosen face and term. */
+  priceToday: number;
+  /** e.g. "Aug 2028" on the leg, and "Aug 25, 2028" in the summary. */
+  maturesShort: string;
+  maturesLong: string;
+  /** Annual rate, fixed for the life of the bond. */
+  ratePercent: number;
+  /** The haircut a bond is registered at — 9500 bps. */
+  haircutBps: number;
+}
 
 /** What the pool needs that savings does not. Absent for a savings move. */
 export interface PoolTerms {
@@ -66,7 +90,8 @@ function Leg({
 }: {
   label: string;
   name: string;
-  balance: number;
+  /** Omitted when the leg has no running balance to show — a bond, before it exists. */
+  balance?: number;
   note?: string;
   side: 'left' | 'right';
 }) {
@@ -84,18 +109,39 @@ function Leg({
       </p>
       <p className="truncate text-[13px] leading-[1.3]">{name}</p>
       <p className="mt-0.5 truncate text-[11.5px] leading-[1.35] text-muted-foreground">
-        {money(balance, { cents: true })}
-        {note ? ` ${note}` : ''}
+        {balance === undefined ? note : `${money(balance, { cents: true })}${note ? ` ${note}` : ''}`}
       </p>
     </div>
   );
 }
 
-function Row({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+/**
+ * One line of the summary.
+ *
+ * `accent` is what the choice earns — tinted, and always the first row. `gain` is what it does to
+ * the credit limit — green, divided off, and always the last. Between them sit plain facts.
+ */
+function Row({
+  label,
+  value,
+  accent,
+  gain,
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+  gain?: boolean;
+}) {
   return (
-    <div className={cn('flex justify-between text-[12.5px] leading-[2]', accent && 'text-tier-boost-fg')}>
+    <div
+      className={cn(
+        'flex justify-between text-[12.5px] leading-[2]',
+        accent && 'text-tier-boost-fg',
+        gain && 'mt-2 border-t-[0.5px] border-border pt-2',
+      )}
+    >
       <span className={accent ? undefined : 'text-foreground-secondary'}>{label}</span>
-      <span className="tabular-nums">{value}</span>
+      <span className={cn('tabular-nums', gain && 'font-medium text-positive')}>{value}</span>
     </div>
   );
 }
@@ -114,6 +160,7 @@ export interface MoveMoneyProps {
   creditsGoal: number;
   destination?: MoveDestination;
   pool?: PoolTerms;
+  bond?: BondTerms;
   /** e.g. "Jan 2028" — the only number on the screen about the thing they actually want. */
   reachesGoalBy?: string;
   /** e.g. "2 months later" — what a withdrawal costs in time. */
@@ -122,6 +169,14 @@ export interface MoveMoneyProps {
   error?: string | null;
   txHash?: string | null;
   onMove: (amount: number) => void;
+  /**
+   * Reports the amount as it is typed.
+   *
+   * Needed by any destination whose consequences have to be fetched rather than computed — a bond
+   * quotes its price from the chain for the face value on screen, and a price that only appeared
+   * after pressing Buy would be a price nobody agreed to before agreeing to it.
+   */
+  onAmountChange?: (amount: number) => void;
   onAddMoney?: () => void;
   onAutoSave?: () => void;
 }
@@ -138,12 +193,14 @@ export default function MoveMoneyDialog({
   creditsGoal,
   destination = 'savings',
   pool,
+  bond,
   reachesGoalBy,
   goalShift,
   busy = false,
   error = null,
   txHash = null,
   onMove,
+  onAmountChange,
   onAddMoney,
   onAutoSave,
 }: MoveMoneyProps) {
@@ -160,8 +217,18 @@ export default function MoveMoneyDialog({
    */
   const [typed, setTyped] = useState('');
 
+  /** One place that changes the amount, so nothing can move it without the caller hearing. */
+  const changeTyped = (next: string | ((current: string) => string)) => {
+    setTyped((current) => {
+      const value = typeof next === 'function' ? next(current) : next;
+      onAmountChange?.(Number(value) || 0);
+      return value;
+    });
+  };
+
   const isDeposit = direction === 'deposit';
   const isPool = destination === 'pool';
+  const isBond = destination === 'bond';
   // The pool can be fully lent — a state savings does not have. What is free to take is capped by
   // the pool's cash, not by the member's position.
   const poolFree = isPool && pool ? Math.min(savingsFree, pool.freeNow) : savingsFree;
@@ -188,7 +255,7 @@ export default function MoveMoneyDialog({
 
   const swap = () => {
     onDirectionChange(isDeposit ? 'withdraw' : 'deposit');
-    setTyped('');
+    changeTyped('');
   };
 
   const amountBlock = (dim = false) => (
@@ -200,7 +267,9 @@ export default function MoveMoneyDialog({
           Pool is fully lent
         </p>
       )}
-      <p className="mb-0.5 text-[11px] text-muted-foreground">Amount</p>
+      <p className="mb-0.5 text-[11px] text-muted-foreground">
+        {isBond ? 'Face value — what you get back' : 'Amount'}
+      </p>
       <p
         className={cn(
           'font-display text-[38px] font-medium leading-[1.05] tracking-[-1.2px]',
@@ -215,6 +284,14 @@ export default function MoveMoneyDialog({
           .{(typed.split('.')[1] ?? '').padEnd(2, '0').slice(0, 2)}
         </span>
       </p>
+      {/* The one place a bond differs from everything else on screen: what leaves the account is
+          not what was typed. Stated directly under the hero rather than left to the summary. */}
+      {isBond && bond && !over && (
+        <p className="mb-3 text-[13px] text-tier-boost-fg">
+          You pay {money(bond.priceToday, { cents: true })} today
+        </p>
+      )}
+
       {over && (
         // Stated as the difference, because that is the number they can act on — not as a refusal.
         <p className="mb-3 text-[11.5px] text-tier-boost-fg">
@@ -232,27 +309,70 @@ export default function MoveMoneyDialog({
         label="From"
         name={isDeposit ? 'Cash account' : isPool ? 'Yield pool' : 'Savings'}
         balance={isDeposit ? cashReady : isPool ? poolFree : savingsFree}
-        note={isDeposit ? 'ready' : isPool && pool && pool.freeNow < savingsFree ? 'free now' : 'free'}
+        // "free" on every leg, per the reference. It means the same thing in both places — money
+        // that can move — even though what constrains it differs: unallocated on the cash side,
+        // unencumbered on the savings side, and not lent out on the pool's.
+        note={isDeposit ? 'free' : isPool && pool && pool.freeNow < savingsFree ? 'free now' : 'free'}
       />
-      <Leg
-        side="right"
-        label="To"
-        name={isDeposit ? (isPool ? 'Yield pool' : 'Savings') : 'Cash account'}
-        balance={isDeposit ? savingsTotal : cashReady}
-      />
-      <button
-        type="button"
-        onClick={swap}
-        disabled={busy}
-        aria-label="Swap direction"
-        className="absolute left-1/2 top-1/2 z-[2] flex h-[26px] w-[26px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-[0.5px] border-border bg-background ring-4 ring-background disabled:opacity-50"
-      >
-        <ArrowLeftRight className="h-[13px] w-[13px] text-foreground-secondary" />
-      </button>
+      {isBond && bond ? (
+        // A bond has no running balance to show until it exists, so the leg carries the date it
+        // matures instead.
+        <Leg side="right" label="To" name="BurnerBond" note={`Matures ${bond.maturesShort}`} />
+      ) : (
+        <Leg
+          side="right"
+          label="To"
+          name={isDeposit ? (isPool ? 'Yield pool' : 'Savings') : 'Cash account'}
+          balance={isDeposit ? savingsTotal : cashReady}
+        />
+      )}
+
+      {isBond ? (
+        /*
+         * One arrow, not two.
+         *
+         * It sits where the swap sits on the other two, but points one way and its circle is
+         * filled rather than white — so it reads as a direction, not a control. A two-headed swap
+         * would promise a reversal the product cannot do before maturity.
+         */
+        <span
+          aria-hidden
+          className="absolute left-1/2 top-1/2 z-[2] flex h-[26px] w-[26px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-[0.5px] border-border bg-secondary/50 ring-4 ring-background"
+        >
+          <ArrowRight className="h-[14px] w-[14px] text-muted-foreground" />
+        </span>
+      ) : (
+        <button
+          type="button"
+          onClick={swap}
+          disabled={busy}
+          aria-label="Swap direction"
+          className="absolute left-1/2 top-1/2 z-[2] flex h-[26px] w-[26px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-[0.5px] border-border bg-background ring-4 ring-background disabled:opacity-50"
+        >
+          <ArrowLeftRight className="h-[13px] w-[13px] text-foreground-secondary" />
+        </button>
+      )}
     </div>
   );
 
-  const chips = (
+  const chips = isBond && bond ? (
+    <>
+      <p className="mb-[7px] mt-0.5 text-[10px] uppercase tracking-[0.5px] text-muted-foreground">Term</p>
+      <div className="mb-3 flex gap-1.5">
+        {bond.termOptions.map((months) => (
+          <Button
+            key={months}
+            variant="clear"
+            size="xs"
+            className={cn('flex-1', months === bond.months && 'border-tier-boost bg-tier-boost/10 text-tier-boost-fg')}
+            onClick={() => bond.onMonthsChange(months)}
+          >
+            {months} mo
+          </Button>
+        ))}
+      </div>
+    </>
+  ) : (
     <div className="mb-3 flex gap-1.5">
       {presets.map((preset) => (
         <Button
@@ -260,7 +380,7 @@ export default function MoveMoneyDialog({
           variant="clear"
           size="xs"
           className={cn('flex-1', amount === preset && 'border-tier-boost bg-tier-boost/10 text-tier-boost-fg')}
-          onClick={() => setTyped(String(preset))}
+          onClick={() => changeTyped(String(preset))}
         >
           {money(preset)}
         </Button>
@@ -272,7 +392,7 @@ export default function MoveMoneyDialog({
           'flex-1',
           amount === available && available > 0 && 'border-tier-boost bg-tier-boost/10 text-tier-boost-fg',
         )}
-        onClick={() => setTyped(String(available))}
+        onClick={() => changeTyped(String(available))}
       >
         {/* "All free" rather than "All" — it moves everything that can move, and the word does the
             explaining. */}
@@ -281,91 +401,124 @@ export default function MoveMoneyDialog({
     </div>
   );
 
-  const pad = <Keypad onKey={(key) => setTyped((current) => applyKey(current, key))} disabled={busy} />;
+  const pad = <Keypad onKey={(key) => changeTyped((current) => applyKey(current, key))} disabled={busy} />;
 
-  const poolConsequences = pool && (
-    <>
-      {isDeposit ? (
-        <div className="mb-3 rounded-[10px] border-[0.5px] border-tier-boost/40 bg-tier-boost/[0.08] px-3.5 py-3">
-          <Row label="Earning" value={`${pool.apyPercent}% APY`} accent />
+  /**
+   * The summary: one bordered box, five lines, the same shape at every destination.
+   *
+   * It was two containers — a tinted box for what the choice earns, then bare rows under a
+   * hairline. One box does it, with colour carrying the distinction a second container was
+   * carrying: **what this earns** is tinted on its own row at the top, **what it adds to the
+   * credit limit** is green and always last.
+   *
+   * Last and green because it is the one consequence common to all three products, and the one
+   * easiest to forget you are getting — a member reading three different modals should find it in
+   * the same place each time.
+   */
+  const summary = (
+    <div className="mb-3 rounded-[10px] border-[0.5px] border-border px-3.5 py-3">
+      {isBond && bond ? (
+        <>
+          <Row label="You pay today" value={money(bond.priceToday, { cents: true })} />
+          <Row label="You get at maturity" value={money(amount, { cents: true })} />
+          <Row label="Matures" value={bond.maturesLong} />
+          {/* One line, not two. The rate and what it is worth in dollars are the same fact, and a
+              buyer needs both to compare terms — splitting them made the reader multiply. */}
           <Row
-            label="Backs your limit"
-            value={`+${money((amount * pool.haircutBps) / 10_000, { cents: true })}`}
+            label="Yield"
+            value={`${bond.ratePercent.toFixed(1)}% fixed · +${money(Math.max(0, amount - bond.priceToday), { cents: true })}`}
             accent
           />
-        </div>
-      ) : (
-        <div className="mb-3 rounded-[10px] border-[0.5px] border-border bg-secondary/50 px-3.5 py-3">
-          <Row label="Limit" value={`−${money((amount * pool.haircutBps) / 10_000, { cents: true })}`} />
-          {/* Approximate on purpose: the rate moves with utilisation, so a precise figure would be
-              a promise the pool cannot keep. */}
-          <Row label="Yield lost" value={`~${money((amount * pool.apyPercent) / 100, { cents: true })} a year`} />
-          {pool.limitAfter !== undefined && (
-            <p className="mt-[7px] text-[11px] leading-[1.55] text-muted-foreground">
-              Limit falls to {money(pool.limitAfter, { cents: true })}
-              {pool.owed !== undefined
-                ? `, still above the ${money(pool.owed, { cents: true })} you owe.`
-                : '.'}
-            </p>
-          )}
-        </div>
-      )}
-
-      <div className="mb-3.5 border-t-[0.5px] border-border pt-2.5">
-        <Row label="Position after" value={money(after.savings, { cents: true })} />
-        {isDeposit ? (
-          <>
-            <Row label="Yield a year" value={`~${money((after.savings * pool.apyPercent) / 100, { cents: true })}`} />
-            <Row label="Withdraw" value="Any time" />
-          </>
-        ) : (
-          <>
-            <Row label="Arrives" value={over ? 'Some queued' : 'Within 24 hours'} />
-            <Row label="Pool utilization" value={`${Math.round(pool.utilizationBps / 100)}%`} />
-          </>
-        )}
-      </div>
-    </>
-  );
-
-  const consequences = (
-    <>
-      {isDeposit ? (
-        <div className="mb-3 rounded-[10px] border-[0.5px] border-tier-boost/40 bg-tier-boost/[0.08] px-3.5 py-3">
+          <Row
+            label="Adds to your credit limit"
+            value={`+${money((bond.priceToday * bond.haircutBps) / 10_000, { cents: true })}`}
+            gain
+          />
+        </>
+      ) : isPool && pool && isDeposit ? (
+        <>
+          <Row label="Earning" value={`${pool.apyPercent}% APY`} accent />
+          <Row label="Position after" value={money(after.savings, { cents: true })} />
+          <Row
+            label="Yield a year"
+            value={`~${money((after.savings * pool.apyPercent) / 100, { cents: true })}`}
+          />
+          <Row label="Withdraw" value="Any time" />
+          <Row
+            label="Backs your credit limit"
+            value={`+${money((amount * pool.haircutBps) / 10_000, { cents: true })}`}
+            gain
+          />
+        </>
+      ) : isPool && pool ? (
+        <>
+          {/* Taking money out is the same five lines with the signs turned round. The earn row
+              still leads, because what a withdrawal costs in yield is the thing being weighed. */}
+          <Row
+            label="Yield lost"
+            value={`~${money((amount * pool.apyPercent) / 100, { cents: true })} a year`}
+            accent
+          />
+          <Row label="Position after" value={money(after.savings, { cents: true })} />
+          <Row label="Arrives" value={over ? 'Some queued' : 'Within 24 hours'} />
+          <Row label="Pool utilization" value={`${Math.round(pool.utilizationBps / 100)}%`} />
+          <Row
+            label="Your credit limit drops by"
+            value={`−${money((amount * pool.haircutBps) / 10_000, { cents: true })}`}
+            gain
+          />
+        </>
+      ) : isDeposit ? (
+        <>
           <Row label="Credits earned" value={`+${count(amount)}`} accent />
-          <Row label="Your limit rises by" value={`+${money(amount, { cents: true })}`} accent />
-        </div>
-      ) : (
-        // Neutral, not accented. The figures are the point; colouring them would be the warning
-        // tone the reference is explicit about not using.
-        <div className="mb-3 rounded-[10px] border-[0.5px] border-border bg-secondary/50 px-3.5 py-3">
-          <Row label="Credits given up" value={`−${count(amount)}`} />
-          <Row label="Your limit drops by" value={`−${money(amount, { cents: true })}`} />
-          <p className="mt-[7px] text-[11px] leading-[1.55] text-muted-foreground">
-            Vested credits stay. Only the credits this money was still earning are given up.
-          </p>
-        </div>
-      )}
-
-      <div className="mb-3.5 border-t-[0.5px] border-border pt-2.5">
-        <Row label="Savings after" value={money(after.savings, { cents: true })} />
-        {isDeposit ? (
+          <Row label="Savings after" value={money(after.savings, { cents: true })} />
           <Row label="Credits after" value={`${count(after.credits)} of ${count(creditsGoal)}`} />
-        ) : (
+          <Row label={`Reaches ${count(creditsGoal)} by`} value={reachesGoalBy ?? '—'} />
+          {/* Savings backs the line at 100%, so a dollar saved is a dollar of limit. */}
+          <Row
+            label="Adds to your credit limit"
+            value={`+${money(amount, { cents: true })}`}
+            gain
+          />
+        </>
+      ) : (
+        <>
+          <Row label="Credits given up" value={`−${count(amount)}`} accent />
+          <Row label="Savings after" value={money(after.savings, { cents: true })} />
           <Row
             label={`Reaches ${count(creditsGoal)} by`}
             value={`${reachesGoalBy ?? '—'}${goalShift ? ` · ${goalShift}` : ''}`}
           />
-        )}
-        {/* The extra line desktop earns: the only number on the screen about the thing they
-            actually want. Hidden on a narrow modal, which is already tall enough. */}
-        {isDeposit && reachesGoalBy && (
-          <div className="hidden sm:block">
-            <Row label={`Reaches ${count(creditsGoal)} by`} value={reachesGoalBy} />
-          </div>
-        )}
-      </div>
-    </>
+          <Row label="Your credit limit drops by" value={`−${money(amount, { cents: true })}`} gain />
+        </>
+      )}
+    </div>
+  );
+
+  // Kept from the earlier reference. The update that introduced the single summary draws only
+  // deposits, which is not evidence a withdrawal should say less — and this is the sentence that
+  // stops "credits given up" reading as though vested credits were at risk.
+  // The question a member withdrawing is actually asking is whether they stay above what they owe,
+  // so the panel names the limit it lands on rather than only the drop.
+  const landingNote = isPool && !isDeposit && pool?.limitAfter !== undefined && (
+    <p className="mb-3 text-[11px] leading-[1.55] text-muted-foreground">
+      Limit falls to {money(pool.limitAfter, { cents: true })}
+      {pool.owed !== undefined ? `, still above the ${money(pool.owed, { cents: true })} you owe.` : '.'}
+    </p>
+  );
+
+  // Context rather than consequence, which is why desktop moves it under the keypad.
+  const lockNote = isBond && bond && (
+    <p className="mb-3 rounded-[10px] bg-secondary/50 px-3.5 py-[11px] text-[12px] leading-[1.6] text-foreground-secondary">
+      Locked until maturity — but it backs your credit line at {Math.round(bond.haircutBps / 100)}%,
+      so you can borrow against it any time for 0.65% a cycle.
+    </p>
+  );
+
+  const vestingNote = !isPool && !isDeposit && (
+    <p className="mb-3 text-[11px] leading-[1.55] text-muted-foreground">
+      Vested credits stay. Only the credits this money was still earning are given up.
+    </p>
   );
 
   // The pool has a state savings does not: it can be fully lent. Asking for more than is free is
@@ -403,7 +556,7 @@ export default function MoveMoneyDialog({
         size="xs"
         variant="clear"
         className="w-full py-3 text-muted-foreground"
-        onClick={() => setTyped(String(available))}
+        onClick={() => changeTyped(String(available))}
       >
         Move to {isDeposit ? 'savings' : 'cash'}
       </Button>
@@ -417,12 +570,15 @@ export default function MoveMoneyDialog({
             <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
             Moving…
           </>
+        ) : isBond ? (
+          'Buy this bond'
         ) : isPool ? (
           `${isDeposit ? 'Add' : 'Take'} ${money(amount, { cents: true })}`
         ) : (
           `Move ${money(amount, { cents: true })} to ${isDeposit ? 'savings' : 'cash'}`
         )}
       </Button>
+      {isBond ? null : (
       <p className="mt-2.5 text-center text-[11px] leading-[1.55] text-muted-foreground">
         {isPool
           ? isDeposit
@@ -432,6 +588,7 @@ export default function MoveMoneyDialog({
             ? 'Instant. You can move it back any time.'
             : 'Instant. Move it back whenever you like.'}
       </p>
+      )}
     </>
   );
 
@@ -439,11 +596,21 @@ export default function MoveMoneyDialog({
     <Modal
       open={open}
       onOpenChange={onOpenChange}
-      title={isPool ? (isDeposit ? 'Add to the pool' : 'Take from the pool') : 'Move money'}
+      title={
+        isBond
+          ? 'Buy a bond'
+          : isPool
+            ? isDeposit
+              ? 'Add to the pool'
+              : 'Take from the pool'
+            : 'Move money'
+      }
       description={
-        isPool
-          ? 'Move money between your cash account and the yield pool.'
-          : 'Move money between your cash account and savings.'
+        isBond
+          ? 'Choose a face value and a term, and review what the bond costs today.'
+          : isPool
+            ? 'Move money between your cash account and the yield pool.'
+            : 'Move money between your cash account and savings.'
       }
       // The desktop dialog is 360px by default, and the two-column layout below needs the width
       // the reference gives it — a 216px keypad beside a column that still has to fit "Credits
@@ -494,9 +661,17 @@ export default function MoveMoneyDialog({
             {chips}
             {route}
             <div className="mb-3 sm:hidden">{pad}</div>
-            {isPool ? poolConsequences : consequences}
+            {summary}
+            {vestingNote}
+            {landingNote}
+            <div className="sm:hidden">{lockNote}</div>
           </div>
-          <div className="hidden sm:block">{pad}</div>
+          <div className="hidden sm:block">
+            {pad}
+            {/* Context, not consequence, so on desktop it sits on the input side where there is
+                room rather than interrupting the read down the left. */}
+            <div className="mt-3">{lockNote}</div>
+          </div>
           <div className="sm:col-span-2">{action}</div>
         </div>
       )}

--- a/app/src/components/clear/moveMoney.test.ts
+++ b/app/src/components/clear/moveMoney.test.ts
@@ -77,8 +77,8 @@ describe('one component, two directions', () => {
   test('the consequence flips with the direction', () => {
     expect(DIALOG).toContain('Credits earned');
     expect(DIALOG).toContain('Credits given up');
-    expect(DIALOG).toContain('Your limit rises by');
-    expect(DIALOG).toContain('Your limit drops by');
+    expect(DIALOG).toContain('Adds to your credit limit');
+    expect(DIALOG).toContain('Your credit limit drops by');
   });
 
   test('the cost of withdrawing is stated, not moralised', () => {
@@ -86,7 +86,7 @@ describe('one component, two directions', () => {
     // that makes this an equity account rather than a lock-up.
     expect(DIALOG).toContain('Vested credits stay. Only the credits this money was still earning are given up.');
     expect(DIALOG).toContain('Credits given up');
-    expect(DIALOG).toContain('Your limit drops by');
+    expect(DIALOG).toContain('Your credit limit drops by');
     // No confirmation gate in front of it — asserted on the rendered strings, not the file, so a
     // docblock explaining the rule cannot satisfy or break it.
     const rendered = DIALOG.match(/>[^<>{}]*[a-z][^<>{}]*</gi)?.join(' ') ?? '';
@@ -96,7 +96,7 @@ describe('one component, two directions', () => {
   test('swapping clears the amount', () => {
     // The caps differ between directions; carrying an amount that was valid one way into the
     // other would arrive already over the limit.
-    expect(DIALOG).toContain("onDirectionChange(isDeposit ? 'withdraw' : 'deposit');\n    setTyped('');");
+    expect(DIALOG).toContain("onDirectionChange(isDeposit ? 'withdraw' : 'deposit');\n    changeTyped('');");
   });
 
   test('both rails exist and pick by direction', () => {
@@ -215,7 +215,7 @@ describe('never block the keypad', () => {
 
   test('and the affordable amount is offered', () => {
     expect(DIALOG).toContain('instead');
-    expect(DIALOG).toContain('onClick={() => setTyped(String(available))}');
+    expect(DIALOG).toContain('onClick={() => changeTyped(String(available))}');
   });
 
   test('it is not styled as an error', () => {
@@ -225,15 +225,19 @@ describe('never block the keypad', () => {
 });
 
 describe('withdrawing is stated, not warned about', () => {
-  test('its box is neutral while the deposit box is accented', () => {
-    // Colouring the withdrawal figures would be the warning tone the reference rules out.
-    expect(DIALOG).toContain('border-border bg-secondary/50');
-    expect(DIALOG).toContain('border-tier-boost/40');
+  test('one summary box, not a tinted one and a bare list', () => {
+    // Colour does what a second container was doing: the earn row is tinted, the credit-limit
+    // footer is green and divided, and everything sits in one bordered box.
+    expect(DIALOG).toContain('const summary = (');
+    expect(DIALOG).toContain("gain && 'mt-2 border-t-[0.5px] border-border pt-2'");
+    expect(DIALOG).toContain("accent && 'text-tier-boost-fg'");
   });
 
-  test('the vesting note sits inside that box', () => {
-    const box = DIALOG.slice(DIALOG.indexOf('Credits given up'), DIALOG.indexOf('Savings after'));
-    expect(box).toContain('Vested credits stay.');
+  test('the vesting note survives the restructure', () => {
+    // The update that introduced the single summary draws only deposits. That is not evidence a
+    // withdrawal should say less.
+    expect(DIALOG).toContain('const vestingNote =');
+    expect(DIALOG).toContain('Vested credits stay.');
   });
 
   test('each direction keeps its own closing line', () => {
@@ -392,8 +396,16 @@ describe('the pool is the same component, redirected', () => {
 
   test('the withdraw panel names the limit it lands on, not only the drop', () => {
     // The question a member is actually asking is whether they stay above what they owe.
+    expect(DIALOG).toContain('const landingNote =');
     expect(DIALOG).toContain('Limit falls to');
     expect(DIALOG).toContain('you owe');
+  });
+
+  test('and taking from the pool is not described as earning', () => {
+    // The pool branch ignored direction at first, so a withdrawal read "Earning 6.8% APY" and
+    // "Backs your credit limit" — both the wrong sign and the wrong claim.
+    expect(DIALOG).toContain('isPool && pool && isDeposit ?');
+    expect(DIALOG).toContain('Yield lost');
   });
 });
 
@@ -487,5 +499,83 @@ describe('the amount starts empty', () => {
 
   test('typing builds from empty without a leading zero to clear', () => {
     expect(['5', '0'].reduce(applyKey, '')).toBe('50');
+  });
+});
+
+/*
+ * Bonds join the pattern, which takes one extra control and one honest exception.
+ */
+describe('the bond is the third destination, not a third modal', () => {
+  test('it is a destination on the same component', () => {
+    expect(DIALOG).toContain("export type MoveDestination = 'savings' | 'pool' | 'bond'");
+    expect(DIALOG).toContain("const isBond = destination === 'bond';");
+  });
+
+  test('the hero carries face value and the price beneath it', () => {
+    // The one rule bonds break: everywhere else the number you type is the number that moves.
+    // With a bond you choose what you get back, and a smaller, discounted amount leaves.
+    expect(DIALOG).toContain('Face value — what you get back');
+    expect(DIALOG).toContain('You pay {money(bond.priceToday, { cents: true })} today');
+  });
+
+  test('the price is never buried in the summary alone', () => {
+    const heroEnd = DIALOG.indexOf('const chips');
+    expect(DIALOG.slice(0, heroEnd)).toContain('You pay {money(bond.priceToday');
+  });
+
+  test('term is the only chip row', () => {
+    // Face value is typed, so quick amounts would be guesses at a number already in mind — and
+    // unlike savings there is no habitual round figure for a bond.
+    expect(DIALOG).toContain('const chips = isBond && bond ? (');
+    expect(DIALOG).toContain('{months} mo');
+  });
+
+  test('the route shows a direction, not a control', () => {
+    // A two-headed swap would promise a reversal the product cannot do before maturity.
+    expect(DIALOG).toContain('<ArrowRight');
+    expect(DIALOG).toContain('{isBond ? (');
+    const bondArrow = DIALOG.slice(DIALOG.indexOf('{isBond ? (\n        /*'), DIALOG.indexOf('<button\n          type="button"\n          onClick={swap}'));
+    expect(bondArrow).not.toContain('onClick');
+  });
+
+  test('the To leg carries a date, because a bond has no balance yet', () => {
+    expect(DIALOG).toContain('note={`Matures ${bond.maturesShort}`}');
+    expect(DIALOG).toContain('balance === undefined ? note');
+  });
+
+  test('yield is one line, rate and dollars together', () => {
+    // Splitting them made the reader do the multiplication.
+    expect(DIALOG).toContain("% fixed · +${money(Math.max(0, amount - bond.priceToday)");
+  });
+
+  test('and the summary is the same five lines as everywhere else', () => {
+    expect(DIALOG).toContain('You pay today');
+    expect(DIALOG).toContain('You get at maturity');
+    expect(DIALOG).toContain('Adds to your credit limit');
+  });
+
+  test('the lock note is context, so desktop moves it off the read', () => {
+    expect(DIALOG).toContain('const lockNote =');
+    expect(DIALOG).toContain('<div className="sm:hidden">{lockNote}</div>');
+  });
+});
+
+describe('a fetched price needs the amount as it is typed', () => {
+  test('the dialog reports every change, not just the submit', () => {
+    // A price that only appeared after pressing Buy would be a price nobody agreed to before
+    // agreeing to it.
+    expect(DIALOG).toContain('onAmountChange?.(Number(value) || 0)');
+  });
+
+  test('through one setter, so nothing can move it unheard', () => {
+    expect(DIALOG).toContain('const changeTyped =');
+    // Exactly one call to the raw setter, and it is the one inside changeTyped.
+    expect(DIALOG.split('setTyped(').length - 1).toBe(1);
+  });
+
+  test('and the bond quotes its price from the chain for what is on screen', () => {
+    const bond = readFileSync(join(import.meta.dir, 'ConnectedBuyBond.tsx'), 'utf8');
+    expect(bond).toContain("functionName: 'calculateRequiredDeposit'");
+    expect(bond).toContain('onAmountChange={setFace}');
   });
 });


### PR DESCRIPTION
Two changes from the reference; the second is the larger.

## One bordered summary, five lines

It was two containers — a tinted box for what the choice earns, then bare rows under a hairline. One box does it, with **colour carrying the distinction the second container was carrying**: what this earns is tinted on its own row at the top, what it adds to the credit limit is green and always last.

Five lines at every destination, so a member who's read one modal can read any of them. The credit-limit line is last and green because it's the one consequence common to all three products — and the one easiest to forget you're getting.

## Bonds are the third destination, not a third modal

That's what "one modal, three destinations" means, and it takes one extra control and one honest exception:

**Bonds break the rule the other two keep.** Everywhere else the number typed is the number that moves; with a bond you choose **face value** — what you get back — and a smaller, discounted amount leaves. So the hero carries both, with the price stated directly beneath the face rather than buried in the summary.

- **Term is the only chip row** — face value is typed, and there's no habitual round figure for a bond the way there is for savings.
- **The route icon points one way** and its circle is filled, so it reads as a direction rather than a control. A two-headed swap would promise a reversal the product can't do before maturity.
- **The To leg carries the maturity date**, because a bond has no running balance until it exists.
- **Yield is one line** — rate and dollars together, since they're the same fact and splitting them made the reader multiply.

## Two things the work turned up

**The pool summary ignored direction.** Taking money out read *"Earning 6.8% APY"* and *"Backs your credit limit"* — wrong sign and wrong claim. It has its own five lines now, led by what the withdrawal costs in yield.

**A fetched price needs the amount as it's typed.** A bond quotes from the chain for the face value on screen, and the dialog only reported on submit — so the price would have appeared *after* pressing Buy. One setter reports every change now.

Also kept the withdrawal's vesting sentence: the update that introduced the single summary draws only deposits, which isn't evidence a withdrawal should say less.

## Verification

418 tests, 12 new. All three destinations checked in the harness — the bond matches the reference figure for figure: **$4,367.19 / $5,000.00 / +$632.81 / +$4,148.83**.

**Still to do from this reference:** the processing, done and failed states (§05–06). Those are a separate piece and I'd rather ship them on their own than bury them here.