### PR TITLE
Show a move happening, landing, and coming back

### DIFF
--- a/app/src/PreviewApp.tsx
+++ b/app/src/PreviewApp.tsx
@@ -211,6 +211,7 @@ function TermPlansPreview() {
 function MoveMoneyPreview() {
   const [direction, setDirection] = useState<MoveDirection>('deposit');
   const [empty, setEmpty] = useState(false);
+  const [progress, setProgress] = useState<{ status: 'processing' | 'done' | 'failed'; step: number; failureNote?: string } | null>(null);
 
   return (
     <div className="min-h-screen bg-background">
@@ -226,10 +227,26 @@ function MoveMoneyPreview() {
         creditsGoal={15000}
         reachesGoalBy="Jan 2028"
         goalShift="2 months later"
+        progress={progress}
         onMove={() => {}}
       />
 
-      <div className="fixed inset-x-0 bottom-0 z-[60] flex justify-center gap-1 border-t-[0.5px] border-border bg-background/90 p-2 backdrop-blur-sm">
+      <div className="fixed inset-x-0 bottom-0 z-[60] flex flex-wrap justify-center gap-1 border-t-[0.5px] border-border bg-background/90 p-2 backdrop-blur-sm">
+        {([
+          ['moving', { status: 'processing' as const, step: 1 }],
+          ['done', { status: 'done' as const, step: 3 }],
+          ['failed', { status: 'failed' as const, step: 1, failureNote: 'the network was busy' }],
+          ['form', null],
+        ] as const).map(([label, next]) => (
+          <button
+            key={label}
+            type="button"
+            onClick={() => setProgress(next)}
+            className="rounded-md border-[0.5px] border-border px-2 py-1 text-[11px] text-muted-foreground"
+          >
+            {label}
+          </button>
+        ))}
         {([['deposit', false], ['withdraw', false], ['empty', true]] as const).map(([label, isEmpty]) => (
           <button
             key={label}

--- a/app/src/components/clear/ConnectedBuyBond.tsx
+++ b/app/src/components/clear/ConnectedBuyBond.tsx
@@ -10,6 +10,7 @@ import { scBuyBond } from '@/lib/sendCalls';
 import { getEarn } from '@/utils/apiClient';
 import { toEarnData } from '@/lib/earnMapping';
 import { BOND_HAIRCUT_BPS } from '@/lib/clearModel';
+import { shortMoveReason } from '@/hooks/usePoolMove';
 import { EARN_DAY_ONE } from '@/data/clearPlaceholder';
 import { track } from '@/lib/analytics';
 import type { EarnData } from '@/lib/clearModel';
@@ -59,6 +60,7 @@ export default function ConnectedBuyBond({
   // Quoted by the chain for the chosen face and term. Null until both are known and the quote has
   // come back — the screen shows nothing rather than a price the contract has not agreed to.
   const [priceToday, setPriceToday] = useState<number | null>(null);
+  const [progress, setProgress] = useState<{ status: 'processing' | 'done' | 'failed'; step: number; failureNote?: string } | null>(null);
 
   // Read, not passed. A page holding a mapped model would hand fixtures to a screen that spends
   // money, which is the mistake the savings dialog was fixed for.
@@ -127,6 +129,7 @@ export default function ConnectedBuyBond({
 
       setBusy(true);
       setError(null);
+      setProgress({ status: 'processing', step: 0 });
       try {
         const faceValue = purchase.face.toFixed(2);
         const maturityDate = Math.floor(purchase.maturity.date.getTime() / 1000);
@@ -162,10 +165,12 @@ export default function ConnectedBuyBond({
 
         // Ready to allocate falls by what the bond actually cost, not by its face.
         balances.applyOptimistic(-Number(priceUnits) / 1e6, 0);
+        setProgress({ status: 'done', step: 3 });
         track('bond_bought', {}); // that it happened, never the amount or the term
-        onOpenChange(false);
       } catch (e) {
-        setError(e instanceof Error ? e.message : "That didn't go through.");
+        const message = e instanceof Error ? e.message : "That didn't go through.";
+        setError(message);
+        setProgress({ status: 'failed', step: 1, failureNote: shortMoveReason(message) });
       } finally {
         setBusy(false);
       }
@@ -180,6 +185,7 @@ export default function ConnectedBuyBond({
         if (!next) {
           setError(null);
           setFace(0);
+          setProgress(null);
         }
         onOpenChange(next);
       }}
@@ -206,6 +212,11 @@ export default function ConnectedBuyBond({
       }}
       busy={busy}
       error={error}
+      progress={progress}
+      // "See your bonds" belongs on Earn, which is where this was opened from — so closing is the
+      // honest action rather than a route this modal does not own.
+      onAgain={() => onOpenChange(false)}
+      onRetry={() => setProgress(null)}
       onAmountChange={setFace}
       onMove={(amount) => void onBuy({ face: amount, maturity: { date: maturityDate } })}
     />

--- a/app/src/components/clear/ConnectedMoveMoney.tsx
+++ b/app/src/components/clear/ConnectedMoveMoney.tsx
@@ -75,7 +75,7 @@ export default function ConnectedMoveMoney({
     [balances],
   );
 
-  const { busy, error, txHash, move, reset } = useSavingsMove(onMoved);
+  const { busy, error, progress, move, reset } = useSavingsMove(onMoved);
 
   /*
    * Every figure with a real source is read from that source, and the page's `data` is used only
@@ -115,8 +115,12 @@ export default function ConnectedMoveMoney({
       reachesGoalBy={data.savings.onTrackFor}
       busy={busy}
       error={error}
-      txHash={txHash}
+      progress={progress}
       onMove={(amount) => void move(direction, amount)}
+      // The moment right after a deposit is the only moment somebody is inclined to make another,
+      // so "Save more" returns to the form rather than closing.
+      onAgain={reset}
+      onRetry={reset}
       onAddMoney={() => {
         onOpenChange(false);
         openAddMoney();

--- a/app/src/components/clear/ConnectedPoolMove.tsx
+++ b/app/src/components/clear/ConnectedPoolMove.tsx
@@ -66,7 +66,7 @@ export default function ConnectedPoolMove({
     [balances],
   );
 
-  const { busy, error, txHash, move, reset } = usePoolMove(onMoved);
+  const { busy, error, progress, move, reset } = usePoolMove(onMoved);
 
   const position = (pool?.positionCents ?? 0) / 100;
   // What the pool can pay right now. Capacity less what is lent out is the cash on hand, and it is
@@ -107,8 +107,10 @@ export default function ConnectedPoolMove({
       }}
       busy={busy}
       error={error}
-      txHash={txHash}
+      progress={progress}
       onMove={(amount) => void move(direction, amount, freeNow)}
+      onAgain={reset}
+      onRetry={reset}
       onAddMoney={() => {
         onOpenChange(false);
         openAddMoney();

--- a/app/src/components/clear/MoveMoneyDialog.tsx
+++ b/app/src/components/clear/MoveMoneyDialog.tsx
@@ -1,9 +1,11 @@
 import { useMemo, useState } from 'react';
-import { ArrowLeftRight, ArrowRight, Check, Loader2 } from 'lucide-react';
+import { ArrowLeftRight, ArrowRight, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import Modal from './Modal';
 import Keypad from './Keypad';
 import { applyKey } from '@/lib/amountEntry';
+import { AlertMark, Spinner, Steps, Tick } from './MoveProgress';
+import { stepsFor, type MoveStatus } from '@/lib/moveSteps';
 import { money, count } from '@/lib/money';
 import { cn } from '@/lib/utils';
 
@@ -167,7 +169,13 @@ export interface MoveMoneyProps {
   goalShift?: string;
   busy?: boolean;
   error?: string | null;
-  txHash?: string | null;
+  /**
+   * Where the move has got to. Absent while the member is still deciding.
+   *
+   * Replaces a `txHash` that only ever said "done". Money moving deserves more than a spinner in
+   * a button, and a failure deserves more than a red line under the amount.
+   */
+  progress?: { status: MoveStatus; step: number; failureNote?: string } | null;
   onMove: (amount: number) => void;
   /**
    * Reports the amount as it is typed.
@@ -177,6 +185,10 @@ export interface MoveMoneyProps {
    * after pressing Buy would be a price nobody agreed to before agreeing to it.
    */
   onAmountChange?: (amount: number) => void;
+  /** The offer made right after a move lands — "Save more", "See your bonds". */
+  onAgain?: () => void;
+  /** Retry after a failure, with the amount still on screen. */
+  onRetry?: () => void;
   onAddMoney?: () => void;
   onAutoSave?: () => void;
 }
@@ -198,9 +210,11 @@ export default function MoveMoneyDialog({
   goalShift,
   busy = false,
   error = null,
-  txHash = null,
+  progress = null,
   onMove,
   onAmountChange,
+  onAgain,
+  onRetry,
   onAddMoney,
   onAutoSave,
 }: MoveMoneyProps) {
@@ -415,12 +429,18 @@ export default function MoveMoneyDialog({
    * easiest to forget you are getting — a member reading three different modals should find it in
    * the same place each time.
    */
-  const summary = (
+  const summaryRows = (past = false) => (
     <div className="mb-3 rounded-[10px] border-[0.5px] border-border px-3.5 py-3">
       {isBond && bond ? (
         <>
-          <Row label="You pay today" value={money(bond.priceToday, { cents: true })} />
-          <Row label="You get at maturity" value={money(amount, { cents: true })} />
+          {/* Done leads with the gain, not the payment: the member already knows what left their
+              account — they confirmed it. What they bought is the difference and a date. */}
+          <Row label={past ? 'You paid' : 'You pay today'} value={money(bond.priceToday, { cents: true })} />
+          <Row
+            label={past ? 'You gain' : 'You get at maturity'}
+            value={money(past ? Math.max(0, amount - bond.priceToday) : amount, { cents: true })}
+            accent={past}
+          />
           <Row label="Matures" value={bond.maturesLong} />
           {/* One line, not two. The rate and what it is worth in dollars are the same fact, and a
               buyer needs both to compare terms — splitting them made the reader multiply. */}
@@ -430,7 +450,7 @@ export default function MoveMoneyDialog({
             accent
           />
           <Row
-            label="Adds to your credit limit"
+            label={past ? 'Your limit rose by' : 'Adds to your credit limit'}
             value={`+${money((bond.priceToday * bond.haircutBps) / 10_000, { cents: true })}`}
             gain
           />
@@ -445,7 +465,7 @@ export default function MoveMoneyDialog({
           />
           <Row label="Withdraw" value="Any time" />
           <Row
-            label="Backs your credit limit"
+            label={past ? 'Your credit limit rose by' : 'Backs your credit limit'}
             value={`+${money((amount * pool.haircutBps) / 10_000, { cents: true })}`}
             gain
           />
@@ -471,12 +491,12 @@ export default function MoveMoneyDialog({
       ) : isDeposit ? (
         <>
           <Row label="Credits earned" value={`+${count(amount)}`} accent />
-          <Row label="Savings after" value={money(after.savings, { cents: true })} />
-          <Row label="Credits after" value={`${count(after.credits)} of ${count(creditsGoal)}`} />
+          <Row label={past ? 'Savings' : 'Savings after'} value={money(after.savings, { cents: true })} />
+          <Row label={past ? 'Credits' : 'Credits after'} value={`${count(after.credits)} of ${count(creditsGoal)}`} />
           <Row label={`Reaches ${count(creditsGoal)} by`} value={reachesGoalBy ?? '—'} />
           {/* Savings backs the line at 100%, so a dollar saved is a dollar of limit. */}
           <Row
-            label="Adds to your credit limit"
+            label={past ? 'Your credit limit rose by' : 'Adds to your credit limit'}
             value={`+${money(amount, { cents: true })}`}
             gain
           />
@@ -525,6 +545,114 @@ export default function MoveMoneyDialog({
   // not a mistake to refuse — pay what is there and queue the rest, which is what the contract's
   // requestWithdrawal exists for.
   const canQueue = isPool && !isDeposit && over;
+
+  /*
+   * The three things that actually happen, named.
+   *
+   * The reference draws savings and bonds; the others follow the same shape — money leaves, the
+   * thing it is going into takes it, and the consequence a member cares about lands. That last
+   * step is the least obvious and the one most worth watching, because it is why a locked
+   * position is not a locked-away position.
+   */
+  const stepLabels = isBond
+    ? ['Paid from your cash account', 'Issuing the bond', 'Adding it to your credit line']
+    : isPool
+      ? isDeposit
+        ? ['Taken from your cash account', 'Adding to the pool', 'Adding it to your credit line']
+        : ['Redeeming from the pool', 'Returning to your cash account', 'Updating your credit line']
+      : isDeposit
+        ? ['Taken from your cash account', 'Adding to your savings', `Crediting ${count(amount)} equity credits`]
+        : ['Taken from your savings', 'Returning to your cash account', 'Updating your credit line'];
+
+  const movingTitle = isBond
+    ? 'Buying your bond'
+    : `${isDeposit ? 'Moving' : 'Taking'} ${money(amount, { cents: true })}`;
+
+  const movingSub = isBond && bond
+    ? `${money(bond.priceToday, { cents: true })} → ${money(amount, { cents: true })} at maturity`
+    : isDeposit
+      ? `Cash account → ${isPool ? 'Yield pool' : 'Savings'}`
+      : `${isPool ? 'Yield pool' : 'Savings'} → Cash account`;
+
+  const doneTitle = isBond
+    ? 'Bond bought'
+    : isPool
+      ? `${money(amount, { cents: true })} ${isDeposit ? 'added' : 'taken'}`
+      : isDeposit
+        ? `${money(amount, { cents: true })} saved`
+        : `${money(amount, { cents: true })} moved`;
+
+  const progressView = progress && (
+    <>
+      <div className="py-2 text-center">
+        {progress.status === 'processing' ? <Spinner /> : progress.status === 'done' ? <Tick /> : <AlertMark />}
+        <p className="mb-1 mt-4 text-[19px] font-medium">
+          {/* "Nothing moved" is the headline, not the error. The only question a member has when
+              something fails with their money is whether they still have it. */}
+          {progress.status === 'processing' ? movingTitle : progress.status === 'done' ? doneTitle : 'Nothing moved'}
+        </p>
+        <p className="text-[12.5px] text-foreground-secondary">
+          {progress.status === 'processing'
+            ? movingSub
+            : progress.status === 'done'
+              ? isBond && bond
+                ? `${money(amount, { cents: true })} face · matures ${bond.maturesLong}`
+                : 'Just now'
+              : `Your ${money(amount, { cents: true })} is still in your ${isDeposit ? 'cash account' : isPool ? 'pool position' : 'savings'}`}
+        </p>
+      </div>
+
+      <div className="mb-3 mt-4">
+        {progress.status === 'done' ? (
+          summaryRows(true)
+        ) : (
+          <Steps
+            steps={
+              progress.status === 'failed'
+                ? // Taken, then returned. A member who watched money leave needs to watch it come
+                  // back, not be told it never left.
+                  [
+                    { label: stepLabels[0], state: 'done' as const },
+                    { label: `Returned — ${progress.failureNote ?? 'it did not go through'}`, state: 'done' as const },
+                  ]
+                : stepsFor(stepLabels, progress.step, progress.status)
+            }
+          />
+        )}
+      </div>
+
+      {progress.status === 'processing' && (
+        <p className="rounded-[10px] bg-secondary/50 px-3.5 py-[11px] text-[12px] leading-[1.6] text-foreground-secondary">
+          Usually a few seconds. <strong className="font-medium text-foreground">You can close this</strong> — it
+          finishes on its own{isBond ? '.' : ' and lands in your activity either way.'}
+        </p>
+      )}
+
+      {progress.status === 'done' && (
+        <>
+          <Button size="xs" className="mb-2 w-full py-3" onClick={() => onOpenChange(false)}>
+            Done
+          </Button>
+          {/* The moment right after a deposit is the only moment somebody is inclined to make
+              another. */}
+          <Button size="xs" variant="clear" className="w-full text-xs" onClick={onAgain}>
+            {isBond ? 'See your bonds' : isPool ? 'Add more' : 'Save more'}
+          </Button>
+        </>
+      )}
+
+      {progress.status === 'failed' && (
+        <>
+          <Button size="xs" className="mb-2 w-full py-3" onClick={onRetry}>
+            Try again
+          </Button>
+          <Button size="xs" variant="clear" className="w-full text-xs" onClick={() => onOpenChange(false)}>
+            Not now
+          </Button>
+        </>
+      )}
+    </>
+  );
 
   const action = canQueue ? (
     <>
@@ -619,20 +747,8 @@ export default function MoveMoneyDialog({
       // below 640px, the same breakpoint the grid uses, so the two never disagree.
       className={nothingReady ? undefined : 'sm:max-w-[640px] sm:p-[21px]'}
     >
-      {txHash ? (
-        <div className="py-2 text-center">
-          <div className="mx-auto mb-3 flex h-11 w-11 items-center justify-center rounded-full bg-positive/15">
-            <Check className="h-[22px] w-[22px] text-positive" strokeWidth={2.4} />
-          </div>
-          <p className="text-2xl font-medium">{money(amount, { cents: true })}</p>
-          <p className="mt-1 text-xs text-muted-foreground">
-            Moved to {isDeposit ? 'savings' : 'cash'}
-            {isDeposit ? ` · ${count(amount)} in equity credits` : ''}
-          </p>
-          <Button size="xs" variant="clear" className="mt-4 w-full" onClick={() => onOpenChange(false)}>
-            Done
-          </Button>
-        </div>
+      {progress ? (
+        progressView
       ) : nothingReady ? (
         <>
           <p className="mb-2 text-[10px] uppercase tracking-[0.5px] text-muted-foreground">Nothing to move</p>
@@ -661,7 +777,7 @@ export default function MoveMoneyDialog({
             {chips}
             {route}
             <div className="mb-3 sm:hidden">{pad}</div>
-            {summary}
+            {summaryRows()}
             {vestingNote}
             {landingNote}
             <div className="sm:hidden">{lockNote}</div>

--- a/app/src/components/clear/MoveProgress.tsx
+++ b/app/src/components/clear/MoveProgress.tsx
@@ -1,0 +1,81 @@
+import { Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { StepState } from '@/lib/moveSteps';
+
+/**
+ * What a move looks like while it is happening, and after.
+ *
+ * A spinner inside the button is too quiet for money moving, so the modal replaces its own
+ * content. The member sees what is happening, that it went through, and that they are free to
+ * walk away.
+ *
+ * **Three named steps, not a bare spinner.** They are the three things that actually happen, in
+ * order, and somebody who has just handed over money can watch it land. If one stalls, the screen
+ * already shows which — a spinner that stalls says only that something is wrong somewhere.
+ */
+
+export function Spinner() {
+  return (
+    <div
+      aria-hidden
+      className="mx-auto h-11 w-11 animate-spin rounded-full border-[2.5px] border-border border-t-tier-boost"
+    />
+  );
+}
+
+export function Tick() {
+  return (
+    <div className="mx-auto flex h-[46px] w-[46px] items-center justify-center rounded-full bg-positive/15">
+      <Check className="h-[23px] w-[23px] text-positive" strokeWidth={2.5} />
+    </div>
+  );
+}
+
+/**
+ * The failure mark, deliberately not a red cross.
+ *
+ * Nothing went wrong with the member's money — it is still theirs, in the account it started in.
+ * A red X would say otherwise before the headline gets a chance to.
+ */
+export function AlertMark() {
+  return (
+    <div className="mx-auto flex h-[46px] w-[46px] items-center justify-center rounded-full bg-secondary/60">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" className="text-foreground-secondary" aria-hidden>
+        <path d="M12 8v5M12 16.5v.01" />
+        <circle cx="12" cy="12" r="9" />
+      </svg>
+    </div>
+  );
+}
+
+export function Steps({ steps }: { steps: StepState[] }) {
+  return (
+    <div className="rounded-[10px] border-[0.5px] border-border px-3.5 py-3 text-[12.5px] leading-[2.1]">
+      {steps.map((step) => (
+        <div
+          key={step.label}
+          className={cn(
+            'flex items-center gap-[9px]',
+            step.state === 'done' && 'text-foreground-secondary',
+            step.state === 'active' && 'text-foreground',
+            step.state === 'waiting' && 'text-muted-foreground',
+          )}
+        >
+          <span className="flex w-[15px] shrink-0 items-center justify-center">
+            {step.state === 'done' ? (
+              <Check className="h-[13px] w-[13px] text-positive" strokeWidth={3} />
+            ) : (
+              <span
+                className={cn(
+                  'inline-block rounded-full',
+                  step.state === 'active' ? 'h-[7px] w-[7px] bg-tier-boost' : 'h-1.5 w-1.5 bg-border',
+                )}
+              />
+            )}
+          </span>
+          {step.label}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/src/components/clear/moveMoney.test.ts
+++ b/app/src/components/clear/moveMoney.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { applyKey } from '@/lib/amountEntry';
+import { stepsFor } from '@/lib/moveSteps';
 import { freeSavings } from '@/lib/freeSavings';
 
 const DIALOG = readFileSync(join(import.meta.dir, 'MoveMoneyDialog.tsx'), 'utf8');
@@ -228,7 +229,7 @@ describe('withdrawing is stated, not warned about', () => {
   test('one summary box, not a tinted one and a bare list', () => {
     // Colour does what a second container was doing: the earn row is tinted, the credit-limit
     // footer is green and divided, and everything sits in one bordered box.
-    expect(DIALOG).toContain('const summary = (');
+    expect(DIALOG).toContain('const summaryRows = (past = false) => (');
     expect(DIALOG).toContain("gain && 'mt-2 border-t-[0.5px] border-border pt-2'");
     expect(DIALOG).toContain("accent && 'text-tier-boost-fg'");
   });
@@ -577,5 +578,113 @@ describe('a fetched price needs the amount as it is typed', () => {
     const bond = readFileSync(join(import.meta.dir, 'ConnectedBuyBond.tsx'), 'utf8');
     expect(bond).toContain("functionName: 'calculateRequiredDeposit'");
     expect(bond).toContain('onAmountChange={setFace}');
+  });
+});
+
+/*
+ * A spinner inside the button is too quiet for money moving, so the modal replaces its own
+ * content — and a failure gets more than a red line under the amount.
+ */
+const PROGRESS = readFileSync(join(import.meta.dir, 'MoveProgress.tsx'), 'utf8');
+const SAVINGS_HOOK = readFileSync(join(import.meta.dir, '../../hooks/useSavingsMove.ts'), 'utf8');
+
+describe('a move shows itself happening', () => {
+  test('three named steps, not a bare spinner', () => {
+    // If one stalls the screen already shows which; a spinner that stalls says only that
+    // something is wrong somewhere.
+    expect(DIALOG).toContain('const stepLabels =');
+    expect(DIALOG).toContain('Taken from your cash account');
+    expect(DIALOG).toContain('Adding to your savings');
+    expect(DIALOG).toContain('Crediting ${count(amount)} equity credits');
+  });
+
+  test('the steps are named per destination', () => {
+    expect(DIALOG).toContain('Issuing the bond');
+    expect(DIALOG).toContain('Adding it to your credit line');
+  });
+
+  test('and they advance on events, not on a timer', () => {
+    // A progress bar that moves on its own lies when something stalls, which is exactly when a
+    // member is watching it.
+    expect(SAVINGS_HOOK).toContain("setProgress({ status: 'processing', step: 0 })");
+    expect(SAVINGS_HOOK).toContain("setProgress({ status: 'done'");
+    expect(SAVINGS_HOOK).not.toContain('setTimeout');
+    expect(SAVINGS_HOOK).not.toContain('setInterval');
+  });
+
+  test('the member is told they can walk away', () => {
+    // The instinct with money in flight is to sit and stare. It is also true — the transaction is
+    // already submitted.
+    expect(DIALOG).toContain('You can close this');
+    expect(DIALOG).toContain('finishes on its own');
+  });
+});
+
+describe('done repeats what was promised, past tense', () => {
+  test('the same five lines, relabelled', () => {
+    // Same numbers the member saw before confirming, so nothing arrives as a surprise.
+    expect(DIALOG).toContain("past ? 'Your credit limit rose by' : 'Adds to your credit limit'");
+    expect(DIALOG).toContain("past ? 'Savings' : 'Savings after'");
+    expect(DIALOG).toContain('summaryRows(true)');
+  });
+
+  test('and the bond leads with the gain, not the payment', () => {
+    // The member already knows what left their account — they confirmed it. What they bought is
+    // the difference and a date.
+    expect(DIALOG).toContain("past ? 'You gain' : 'You get at maturity'");
+    expect(DIALOG).toContain('past ? Math.max(0, amount - bond.priceToday) : amount');
+  });
+
+  test('the next move is offered where somebody is inclined to make one', () => {
+    expect(DIALOG).toContain("isBond ? 'See your bonds' : isPool ? 'Add more' : 'Save more'");
+  });
+});
+
+describe('a failure answers the only question that matters', () => {
+  test('"Nothing moved" is the headline, not the error', () => {
+    expect(DIALOG).toContain("'Nothing moved'");
+    expect(DIALOG).toContain('is still in your');
+  });
+
+  test('the steps stay and show the reversal', () => {
+    // Somebody who watched money leave needs to watch it come back, not be told it never left.
+    expect(DIALOG).toContain("state: 'done' as const }");
+    expect(DIALOG).toContain('Returned — ${progress.failureNote');
+  });
+
+  test('the reason is short enough for one line', () => {
+    // Chain errors are paragraphs. The full message stays in `error` for a console.
+    const pool = readFileSync(join(import.meta.dir, '../../hooks/usePoolMove.ts'), 'utf8');
+    expect(pool).toContain('export function shortMoveReason');
+    expect(pool).toContain("return 'the network was busy'");
+  });
+
+  test('and there is one implementation of it, not one per destination', () => {
+    expect(SAVINGS_HOOK).toContain("import { shortMoveReason }");
+    expect(SAVINGS_HOOK).not.toContain('function shortReason');
+  });
+
+  test('the mark is not a red cross', () => {
+    // Nothing went wrong with the member's money — it is still theirs, in the account it started
+    // in. A red X would say otherwise before the headline gets a chance to.
+    expect(PROGRESS).toContain('export function AlertMark');
+    expect(PROGRESS).not.toContain('negative');
+  });
+});
+
+describe('which step is where', () => {
+  test('processing marks everything before the current one done', () => {
+    const steps = stepsFor(['a', 'b', 'c'], 1, 'processing');
+    expect(steps.map((s) => s.state)).toEqual(['done', 'active', 'waiting']);
+  });
+
+  test('done marks all of them done, whatever the step says', () => {
+    // A confirmed move is finished even if the step counter never caught up.
+    expect(stepsFor(['a', 'b', 'c'], 0, 'done').every((s) => s.state === 'done')).toBe(true);
+  });
+
+  test('a failure leaves nothing active', () => {
+    // Nothing is in flight once it has come back.
+    expect(stepsFor(['a', 'b', 'c'], 1, 'failed').some((s) => s.state === 'active')).toBe(false);
   });
 });

--- a/app/src/hooks/usePoolMove.ts
+++ b/app/src/hooks/usePoolMove.ts
@@ -25,10 +25,21 @@ const POOL_READ_ABI = [
 
 export type MoveDirection = 'deposit' | 'withdraw';
 
+/** Shared with the savings move: a reason short enough to sit under "Returned". */
+export function shortMoveReason(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes('user rejected') || lower.includes('denied')) return 'you cancelled it';
+  if (lower.includes('insufficient')) return 'there was not enough to cover it';
+  if (lower.includes('timeout') || lower.includes('network')) return 'the network was busy';
+  return 'it did not go through';
+}
+
 export interface PoolMoveState {
   busy: boolean;
   error: string | null;
   txHash: string | null;
+  /** Where the move has got to — see `useSavingsMove` for why steps follow events, not a timer. */
+  progress: { status: 'processing' | 'done' | 'failed'; step: number; failureNote?: string } | null;
   /** `freeNow` is what the pool can pay; anything above it is queued rather than refused. */
   move: (direction: MoveDirection, amount: number, freeNow: number) => Promise<void>;
   reset: () => void;
@@ -40,6 +51,7 @@ export function usePoolMove(onMoved?: (direction: MoveDirection, amount: number)
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
+  const [progress, setProgress] = useState<PoolMoveState['progress']>(null);
 
   const move = useCallback(
     async (direction: MoveDirection, amount: number, freeNow: number) => {
@@ -61,6 +73,7 @@ export function usePoolMove(onMoved?: (direction: MoveDirection, amount: number)
 
       setBusy(true);
       setError(null);
+      setProgress({ status: 'processing', step: 0 });
       try {
         const chainClient = getClientForChain
           ? await getClientForChain({ id: chainId }).catch(() => undefined)
@@ -90,9 +103,12 @@ export function usePoolMove(onMoved?: (direction: MoveDirection, amount: number)
         }
 
         setTxHash(hash);
+        setProgress({ status: 'done', step: 3 });
         onMoved?.(direction, Math.min(amount, direction === 'withdraw' ? freeNow || amount : amount));
       } catch (e) {
-        setError(e instanceof Error ? e.message : "That didn't go through.");
+        const message = e instanceof Error ? e.message : "That didn't go through.";
+        setError(message);
+        setProgress({ status: 'failed', step: 1, failureNote: shortMoveReason(message) });
       } finally {
         setBusy(false);
       }
@@ -103,7 +119,8 @@ export function usePoolMove(onMoved?: (direction: MoveDirection, amount: number)
   const reset = useCallback(() => {
     setError(null);
     setTxHash(null);
+    setProgress(null);
   }, []);
 
-  return { busy, error, txHash, move, reset };
+  return { busy, error, txHash, progress, move, reset };
 }

--- a/app/src/hooks/useSavingsMove.ts
+++ b/app/src/hooks/useSavingsMove.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useOptionalAddress, useOptionalSmartWalletClient } from './useOptionalWallet';
+import { shortMoveReason } from './usePoolMove';
 import { ACTIVE_CHAIN_ID } from '@/lib/clearNetwork';
 import { scDeposit, scRedeem } from '@/lib/sendCalls';
 import { gaslessDeposit, gaslessRedeem } from '@/lib/gaslessMoney';
@@ -30,11 +31,22 @@ export type MoveDirection = 'deposit' | 'withdraw';
 export interface SavingsMoveState {
   busy: boolean;
   error: string | null;
-  /** Set once it has landed — the dialog becomes a receipt rather than closing. */
+  /** Set once it has landed. */
   txHash: string | null;
+  /**
+   * Where the move has got to, for the screen that replaces the form while it happens.
+   *
+   * Steps advance on real events, not on a timer: taken once the transaction is submitted, and
+   * done once it is confirmed. A progress bar that moves on its own is a progress bar that lies
+   * when something stalls, which is exactly the moment a member is watching it.
+   */
+  progress: { status: 'processing' | 'done' | 'failed'; step: number; failureNote?: string } | null;
   move: (direction: MoveDirection, amount: number) => Promise<void>;
   reset: () => void;
 }
+
+/** How many steps the screen names. Done means all of them are behind you. */
+const stepLabelsLength = 3;
 
 export function useSavingsMove(
   onMoved?: (direction: MoveDirection, amount: number) => void,
@@ -44,6 +56,7 @@ export function useSavingsMove(
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
+  const [progress, setProgress] = useState<SavingsMoveState['progress']>(null);
 
   const move = useCallback(
     async (direction: MoveDirection, amount: number) => {
@@ -58,6 +71,7 @@ export function useSavingsMove(
 
       setBusy(true);
       setError(null);
+      setProgress({ status: 'processing', step: 0 });
       try {
         const chainId = ACTIVE_CHAIN_ID;
         // Six decimals, and a string rather than a float: the amount becomes token micros, and
@@ -80,9 +94,13 @@ export function useSavingsMove(
         }
 
         setTxHash(hash);
+        setProgress({ status: 'done', step: stepLabelsLength });
         onMoved?.(direction, amount);
       } catch (e) {
-        setError(e instanceof Error ? e.message : "That didn't go through.");
+        const message = e instanceof Error ? e.message : "That didn't go through.";
+        setError(message);
+        // The money did not move, and that is the headline. The reason is a subline.
+        setProgress({ status: 'failed', step: 1, failureNote: shortMoveReason(message) });
       } finally {
         setBusy(false);
       }
@@ -93,7 +111,8 @@ export function useSavingsMove(
   const reset = useCallback(() => {
     setError(null);
     setTxHash(null);
+    setProgress(null);
   }, []);
 
-  return { busy, error, txHash, move, reset };
+  return { busy, error, txHash, progress, move, reset };
 }

--- a/app/src/lib/moveSteps.ts
+++ b/app/src/lib/moveSteps.ts
@@ -1,0 +1,23 @@
+/**
+ * What a move's steps are, and how far along they are.
+ *
+ * Pure, and separate from the components that draw them — the rules about which step is done, in
+ * flight or waiting are testable without a DOM, and the pad component keeps exporting only
+ * components.
+ */
+export type MoveStatus = 'processing' | 'done' | 'failed';
+
+export interface StepState {
+  label: string;
+  /** `done` has happened, `active` is in flight, `waiting` has not started. */
+  state: 'done' | 'active' | 'waiting';
+}
+
+/** The steps for a move, given where it is going and how far it has got. */
+export function stepsFor(labels: string[], step: number, status: MoveStatus): StepState[] {
+  return labels.map((label, index) => ({
+    label,
+    state:
+      status === 'done' || index < step ? 'done' : index === step && status === 'processing' ? 'active' : 'waiting',
+  }));
+}


### PR DESCRIPTION
A spinner inside the button is too quiet for money moving, so the modal replaces its own content. Three states, all three destinations.

## Processing

**Three named steps, not a bare spinner.** They're the three things that actually happen, in order, and somebody who's just handed over money can watch it land. If one stalls the screen already shows which — a spinner that stalls says only that something is wrong somewhere.

Named per destination, and the last is always the least obvious: *adding it to your credit line*, which is why a locked position isn't a locked-away position.

**They advance on events, not a timer.** A progress bar that moves on its own lies when something stalls — exactly the moment a member is watching it. There's no `setTimeout` anywhere near this, and a test says so.

**"You can close this" is the sentence that matters.** The instinct with money in flight is to sit and stare. It also happens to be true: the transaction is already submitted.

## Done

**The same five lines, past tense** — *adds to your credit limit* becomes *your credit limit rose by*. Same numbers the member saw before confirming, so nothing arrives as a surprise.

The bond's version **leads with the gain rather than the payment**: the member already knows what left their account, they confirmed it. What they bought is $632.81 and a date.

The next move sits underneath, because right after a deposit is the only moment somebody is inclined to make another.

## Failed

**"Nothing moved" is the headline, not the error.** The only question a member has when something fails with their money is whether they still have it — so that's answered first and the reason is a subline.

The steps **stay on screen and show the reversal** — taken, then returned. Somebody who watched money leave needs to watch it come back, not be told it never left.

The mark is deliberately **not a red cross**: nothing went wrong with their money, and a red X would say otherwise before the headline could.

Chain errors are paragraphs, so the reason is shortened to fit one line — one implementation, not one per destination, with the full message still in `error` for a console.

## Verification

433 tests, 15 new. All three states checked in the harness against the reference, including the step-state rules tested directly now that they're pure.