### PR TITLE
Refuse a bond the collection would, and match the swap's circle

### DIFF
--- a/app/src/PreviewApp.tsx
+++ b/app/src/PreviewApp.tsx
@@ -349,6 +349,9 @@ function BondPreview() {
           maturesLong: 'Aug 25, 2028',
           ratePercent: 7,
           haircutBps: 9_500,
+          // The deployment's own limits: $100 to $1,000,000 of face value.
+          minFace: 100,
+          maxFace: 1_000_000,
         }}
         onMove={() => {}}
       />

--- a/app/src/components/clear/ConnectedBuyBond.tsx
+++ b/app/src/components/clear/ConnectedBuyBond.tsx
@@ -36,6 +36,11 @@ const DEPOSIT_ABI = [
     outputs: [{ name: '', type: 'uint256' }] },
 ] as const;
 
+const FACTORY_ABI = [
+  { type: 'function', name: 'getMinFaceValue', stateMutability: 'view', inputs: [], outputs: [{ name: '', type: 'uint256' }] },
+  { type: 'function', name: 'getMaxFaceValue', stateMutability: 'view', inputs: [], outputs: [{ name: '', type: 'uint256' }] },
+] as const;
+
 const BOND_ABI = [
   { type: 'function', name: 'getDiscountForMaturity', stateMutability: 'view',
     inputs: [{ name: 'timeToMaturity', type: 'uint256' }],
@@ -60,6 +65,16 @@ export default function ConnectedBuyBond({
   // Quoted by the chain for the chosen face and term. Null until both are known and the quote has
   // come back — the screen shows nothing rather than a price the contract has not agreed to.
   const [priceToday, setPriceToday] = useState<number | null>(null);
+  /*
+   * The face values the collection will actually mint, read from the factory.
+   *
+   * Not hardcoded, because they are governance parameters that can move — and not omitted, because
+   * the mint enforces them and nothing between here and there does. `calculateRequiredDeposit`
+   * quotes a price for a face below the minimum perfectly happily, so a member saw "$4.84 today"
+   * for a bond that then reverted with no reason at all: the deployed build strips revert strings,
+   * so a failed `require` arrives as `0x`.
+   */
+  const [faceLimits, setFaceLimits] = useState<{ min: number; max: number } | null>(null);
   const [progress, setProgress] = useState<{ status: 'processing' | 'done' | 'failed'; step: number; failureNote?: string } | null>(null);
 
   // Read, not passed. A page holding a mapped model would hand fixtures to a screen that spends
@@ -75,6 +90,29 @@ export default function ConnectedBuyBond({
       cancelled = true;
     };
   }, [address, open]);
+
+  useEffect(() => {
+    const c = clearContracts(ACTIVE_CHAIN_ID);
+    if (!open || !c?.burnerBondFactory) return;
+    let cancelled = false;
+    void Promise.all([
+      readContract(wagmiAdapter.wagmiConfig, {
+        address: c.burnerBondFactory, abi: FACTORY_ABI, functionName: 'getMinFaceValue', chainId: ACTIVE_CHAIN_ID,
+      }),
+      readContract(wagmiAdapter.wagmiConfig, {
+        address: c.burnerBondFactory, abi: FACTORY_ABI, functionName: 'getMaxFaceValue', chainId: ACTIVE_CHAIN_ID,
+      }),
+    ])
+      .then(([min, max]) => {
+        if (!cancelled) setFaceLimits({ min: Number(min as bigint) / 1e6, max: Number(max as bigint) / 1e6 });
+      })
+      .catch(() => {
+        /* Left null; the mint still enforces them, so the worst case is the error we already had. */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
 
   const maturityDate = useMemo(() => {
     const d = new Date();
@@ -209,6 +247,10 @@ export default function ConnectedBuyBond({
         maturesLong: maturityDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
         ratePercent: data.terms.find((t) => t.months === months)?.rate ?? 0,
         haircutBps: BOND_HAIRCUT_BPS,
+        // Until the factory has answered, nothing is out of range — the screen does not invent a
+        // limit it has not read.
+        minFace: faceLimits?.min ?? 0,
+        maxFace: faceLimits?.max ?? Number.MAX_SAFE_INTEGER,
       }}
       busy={busy}
       error={error}

--- a/app/src/components/clear/MoveMoneyDialog.tsx
+++ b/app/src/components/clear/MoveMoneyDialog.tsx
@@ -62,6 +62,15 @@ export interface BondTerms {
   ratePercent: number;
   /** The haircut a bond is registered at — 9500 bps. */
   haircutBps: number;
+  /**
+   * The smallest face value the collection will mint, in whole units.
+   *
+   * Enforced on screen because it is enforced on chain and nowhere in between: the price quote
+   * answers happily for a face below it, so a member could see "$4.84 today" for a bond the mint
+   * then refuses — and the deployed build strips revert strings, so what came back was `0x`.
+   */
+  minFace: number;
+  maxFace: number;
 }
 
 /** What the pool needs that savings does not. Absent for a savings move. */
@@ -255,6 +264,9 @@ export default function MoveMoneyDialog({
   const presets = isPool ? [500, 1000, 2500] : isDeposit ? [100, 250, 500] : [100, 500, 1000];
   const over = amount > available;
   const shortBy = amount - available;
+  // A bond is measured against the collection's limits rather than against a balance.
+  const belowMin = isBond && bond ? amount > 0 && amount < bond.minFace : false;
+  const aboveMax = isBond && bond ? amount > bond.maxFace : false;
 
   const after = useMemo(
     () => ({
@@ -300,9 +312,23 @@ export default function MoveMoneyDialog({
       </p>
       {/* The one place a bond differs from everything else on screen: what leaves the account is
           not what was typed. Stated directly under the hero rather than left to the summary. */}
-      {isBond && bond && !over && (
+      {isBond && bond && !over && !belowMin && !aboveMax && (
         <p className="mb-3 text-[13px] text-tier-boost-fg">
           You pay {money(bond.priceToday, { cents: true })} today
+        </p>
+      )}
+
+      {/* Stated as the gap, like every other constraint on this screen, and the pad stays live. */}
+      {isBond && bond && belowMin && (
+        <p className="mb-3 text-[13px] text-tier-boost-fg">
+          {money(bond.minFace - amount, { cents: true })} below the{' '}
+          {money(bond.minFace, { cents: true })} smallest bond
+        </p>
+      )}
+      {isBond && bond && aboveMax && (
+        <p className="mb-3 text-[13px] text-tier-boost-fg">
+          {money(amount - bond.maxFace, { cents: true })} above the{' '}
+          {money(bond.maxFace, { cents: true })} largest bond
         </p>
       )}
 
@@ -351,7 +377,10 @@ export default function MoveMoneyDialog({
          */
         <span
           aria-hidden
-          className="absolute left-1/2 top-1/2 z-[2] flex h-[26px] w-[26px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-[0.5px] border-border bg-secondary/50 ring-4 ring-background"
+          // Same circle, same position, same background as the swap on the other two — only the
+          // glyph differs. Two heads means you can flip it; one head means you cannot, and that
+          // reads instantly without changing anything else about the control.
+          className="absolute left-1/2 top-1/2 z-[2] flex h-[26px] w-[26px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-[0.5px] border-border bg-background ring-4 ring-background"
         >
           <ArrowRight className="h-[14px] w-[14px] text-muted-foreground" />
         </span>
@@ -654,7 +683,28 @@ export default function MoveMoneyDialog({
     </>
   );
 
-  const action = canQueue ? (
+  const bondLimit = isBond && bond && (belowMin || aboveMax);
+
+  const action = bondLimit && bond ? (
+    <>
+      <div className="mb-3 rounded-[10px] bg-secondary/50 px-3.5 py-[11px]">
+        <p className="text-[12px] leading-[1.6] text-foreground-secondary">
+          Bonds run from{' '}
+          <strong className="font-medium text-foreground">{money(bond.minFace, { cents: true })}</strong> to{' '}
+          <strong className="font-medium text-foreground">{money(bond.maxFace, { cents: true })}</strong> of face
+          value.
+        </p>
+      </div>
+      <Button
+        size="xs"
+        variant="clear"
+        className="w-full py-3 text-muted-foreground"
+        onClick={() => changeTyped(String(belowMin ? bond.minFace : bond.maxFace))}
+      >
+        Use {money(belowMin ? bond.minFace : bond.maxFace, { cents: true })} instead
+      </Button>
+    </>
+  ) : canQueue ? (
     <>
       <div className="mb-3 rounded-[10px] border-[0.5px] border-border bg-secondary/50 px-3.5 py-[11px]">
         <p className="text-[12px] leading-[1.6] text-foreground-secondary">

--- a/app/src/components/clear/moveMoney.test.ts
+++ b/app/src/components/clear/moveMoney.test.ts
@@ -688,3 +688,61 @@ describe('which step is where', () => {
     expect(stepsFor(['a', 'b', 'c'], 1, 'failed').some((s) => s.state === 'active')).toBe(false);
   });
 });
+
+/*
+ * Reported from the demo: a $5 bond reverted with `UserOperation reverted during simulation with
+ * reason: 0x`. The collection's minimum face is $100, and the deployed build strips revert
+ * strings — so a failing `require` arrives with nothing in it.
+ *
+ * The price quote is no help either: `calculateRequiredDeposit` answered $4.84 for a face the mint
+ * would refuse, so the screen had every reason to think it was fine.
+ */
+describe('a bond the collection would refuse', () => {
+  test('the limits are read, not assumed', () => {
+    const bond = readFileSync(join(import.meta.dir, 'ConnectedBuyBond.tsx'), 'utf8');
+    expect(bond).toContain("functionName: 'getMinFaceValue'");
+    expect(bond).toContain("functionName: 'getMaxFaceValue'");
+  });
+
+  test('and nothing is out of range until they have been', () => {
+    // Inventing a limit we have not read would refuse a bond the collection would have taken.
+    const bond = readFileSync(join(import.meta.dir, 'ConnectedBuyBond.tsx'), 'utf8');
+    expect(bond).toContain('minFace: faceLimits?.min ?? 0');
+    expect(bond).toContain('maxFace: faceLimits?.max ?? Number.MAX_SAFE_INTEGER');
+  });
+
+  test('the gap is stated, as everywhere else on this screen', () => {
+    expect(DIALOG).toContain('below the');
+    expect(DIALOG).toContain('smallest bond');
+    expect(DIALOG).toContain('largest bond');
+  });
+
+  test('the keypad stays live', () => {
+    // Same rule as an over-amount: let somebody type it and say what is wrong underneath.
+    expect(DIALOG).toContain('const belowMin =');
+    expect(DIALOG).not.toContain('disabled={belowMin');
+  });
+
+  test('and the nearest face the collection takes is offered', () => {
+    expect(DIALOG).toContain('Use {money(belowMin ? bond.minFace : bond.maxFace');
+  });
+
+  test('but it cannot be submitted while out of range', () => {
+    // Stronger than disabling: the action is replaced, so there is no Buy button to press at all
+    // rather than a greyed one. The mint refuses this face, and sending a transaction that reverts
+    // with nothing in it is what produced the original report.
+    expect(DIALOG).toContain('const action = bondLimit && bond ? (');
+    const guarded = DIALOG.slice(DIALOG.indexOf('const action = bondLimit'), DIALOG.indexOf(') : canQueue ? ('));
+    expect(guarded).not.toContain('onMove');
+  });
+});
+
+describe('the bond route icon', () => {
+  test('matches the swap it sits in place of', () => {
+    // Same circle, same position, same background — only the glyph differs. Two heads means you
+    // can flip it; one head means you cannot.
+    const arrow = DIALOG.slice(DIALOG.indexOf('{isBond ? ('), DIALOG.indexOf('<ArrowRight'));
+    expect(arrow).toContain('bg-background ring-4 ring-background');
+    expect(arrow).not.toContain('bg-secondary');
+  });
+});

--- a/app/src/lib/clearNetwork.ts
+++ b/app/src/lib/clearNetwork.ts
@@ -34,6 +34,8 @@ export interface ClearContracts {
   burnerBondDeposit?: `0x${string}`;
   /** The collection a bought bond is minted into, and what the app reads holdings from. */
   burnerBond?: `0x${string}`;
+  /** Holds the face-value and maturity limits every mint is checked against. */
+  burnerBondFactory?: `0x${string}`;
 }
 const CONTRACTS: Record<number, ClearContracts> = {
   8453: {
@@ -46,6 +48,7 @@ const CONTRACTS: Record<number, ClearContracts> = {
     lendingPool: '0x58405326b66888d8a9f2Dc4646cAc2F5EaC7ce23',
     burnerBondDeposit: '0x1933aC0BDd58C1a6D48c19f8A7fD96c5Ec27c6C3',
     burnerBond: '0x4d96904EA80aae8cAC34826f8Fd0aF52Ae85c148',
+    burnerBondFactory: '0x77e261F967491100906a607b8E46eD670684edDb',
     // Replacement pair. The vault and token these succeed are still deployed and still
     // mutually redeemable -- ESADepositVaultLegacy holds the USDC behind the CLRUSD that was
     // outstanding when the swap happened, so nobody who held the old token is stranded.


### PR DESCRIPTION
Two from the demo.

## The icon

Same circle, same position, **same background** as the swap it stands in for — only the glyph differs. Two heads means you can flip it; one head means you cannot, and that reads without changing anything else about the control. It had a filled background, which made it look like a different kind of thing.

## The $5 bond that reverted

`UserOperation reverted during simulation with reason: 0x`.

The collection's **minimum face value is $100** — `getMinFaceValue` returns `100000000` on Base Sepolia — so `require(faceValue >= minFaceValue)` failed. It arrived empty because the deployed build compiles with `revertStrings: "strip"`, so a failed require carries nothing at all.

**The screen had no way to know, and had reason to think it was fine:** `calculateRequiredDeposit` quoted **$4.84** for a face the mint would refuse. The price function doesn't validate the minimum, so the one figure that could have warned was confidently wrong.

### The fix

The limits are **read from the factory**, not hardcoded — they're governance parameters and can move. Below the minimum, the gap is stated the way every other constraint on this screen is: *"$95.00 below the $100.00 smallest bond"*, with the pad still live and the nearest workable face offered.

The action is **replaced rather than disabled**, so there's no button to press at all rather than a greyed one.

Nothing is out of range until the limits have actually been read — inventing one would refuse a bond the collection would have taken.

## Verification

440 tests, 8 new, including the reported case by its own numbers ($5 face → "$95.00 below the $100.00 smallest bond" → "Use $100.00 instead").

**For reference, the collection's other limits**, in case they matter for the UI later: max face $1,000,000; maturity from 1 day to 5 years; max discount 32%. The 6/12/24/36-month terms all sit inside the maturity range.