### PR TITLE
Re-read everything a move changes, not just the balance

### DIFF
--- a/app/src/components/clear/ConnectedBuyBond.tsx
+++ b/app/src/components/clear/ConnectedBuyBond.tsx
@@ -13,6 +13,7 @@ import { BOND_HAIRCUT_BPS } from '@/lib/clearModel';
 import { shortMoveReason } from '@/hooks/usePoolMove';
 import { EARN_DAY_ONE } from '@/data/clearPlaceholder';
 import { track } from '@/lib/analytics';
+import { markChainStale } from '@/lib/chainStale';
 import type { EarnData } from '@/lib/clearModel';
 
 /**
@@ -205,6 +206,9 @@ export default function ConnectedBuyBond({
         balances.applyOptimistic(-Number(priceUnits) / 1e6, 0);
         setProgress({ status: 'done', step: 3 });
         track('bond_bought', {}); // that it happened, never the amount or the term
+        // A new bond is a new pledged item, so the shelf, the limit and the bond list are all out
+        // of date until the server has pledged it.
+        markChainStale();
       } catch (e) {
         const message = e instanceof Error ? e.message : "That didn't go through.";
         setError(message);

--- a/app/src/components/clear/ConnectedMoveMoney.tsx
+++ b/app/src/components/clear/ConnectedMoveMoney.tsx
@@ -6,6 +6,7 @@ import { useOptionalAddress } from '@/hooks/useOptionalWallet';
 import { useMoneyActions } from '@/context/MoneyActionsContext';
 import { getCredit, getPaySummary } from '@/utils/apiClient';
 import { track } from '@/lib/analytics';
+import { markChainStale } from '@/lib/chainStale';
 import type { SavingsData } from '@/lib/clearModel';
 import { freeSavings } from '@/lib/freeSavings';
 
@@ -68,7 +69,7 @@ export default function ConnectedMoveMoney({
       // already true. The credit limit is not: it moves only once the server has pledged the
       // collateral and pushed the capacities, two writes later. So this asks for a re-read rather
       // than predicting a figure the contracts have not agreed to yet.
-      window.dispatchEvent(new Event('clear:credit-stale'));
+      markChainStale();
 
       track('savings_move', { direction: moved }); // direction only, never the amount
     },

--- a/app/src/components/clear/ConnectedPoolMove.tsx
+++ b/app/src/components/clear/ConnectedPoolMove.tsx
@@ -6,6 +6,7 @@ import { useOptionalAddress } from '@/hooks/useOptionalWallet';
 import { useMoneyActions } from '@/context/MoneyActionsContext';
 import { getCredit, getEarn, type EarnPoolRow } from '@/utils/apiClient';
 import { track } from '@/lib/analytics';
+import { markChainStale } from '@/lib/chainStale';
 import { POOL_SHARE_HAIRCUT_BPS } from '@/lib/clearModel';
 
 
@@ -62,6 +63,9 @@ export default function ConnectedPoolMove({
       // so only the cash leg moves optimistically. The position reconciles on the next Earn read.
       balances.applyOptimistic(moved === 'deposit' ? -amount : amount, 0);
       track('pool_move', { direction: moved }); // direction only, never the amount
+      // The position backs the credit line, so the limit is stale too — and the pool's own
+      // utilisation and free cash have moved for everyone, not just this member.
+      markChainStale();
     },
     [balances],
   );

--- a/app/src/components/clear/moveMoney.test.ts
+++ b/app/src/components/clear/moveMoney.test.ts
@@ -354,13 +354,18 @@ describe('what may be shown before the chain agrees', () => {
   });
 
   test('a move asks for a re-read instead', () => {
-    expect(CONNECTED).toContain("new Event('clear:credit-stale')");
+    // Through the shared module now — see chainStale.test.ts for why the bare event name was the
+    // problem: it was wired to one mover and one reader, and nothing showed the other four.
+    expect(CONNECTED).toContain('markChainStale()');
   });
 
   test('and the reader refetches on it, with backoff for the two writes', () => {
     const home = readFileSync(join(import.meta.dir, '../../pages/app/HomeRoute.tsx'), 'utf8');
-    expect(home).toContain("addEventListener('clear:credit-stale'");
-    expect(home).toContain('[3000, 8000, 15000]');
+    expect(home).toContain('onChainStale(read)');
+    // The backoff moved into the shared module — it was copied per reader, which is how three of
+    // them ended up with none. chainStale.test.ts covers the timings themselves.
+    const stale = readFileSync(join(import.meta.dir, '../../lib/chainStale.ts'), 'utf8');
+    expect(stale).toContain('[3_000, 8_000, 15_000]');
   });
 });
 

--- a/app/src/lib/chainStale.test.ts
+++ b/app/src/lib/chainStale.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC = join(import.meta.dir, '..');
+const read = (p: string) => readFileSync(join(SRC, p), 'utf8');
+
+/*
+ * Reported from the demo: balances moved after a deposit and the credit limit did not, until the
+ * member changed page.
+ *
+ * The mechanism existed and was wired to one third of the app: the savings move signalled, the
+ * pool and bond moves did not, and Home was the only listener. So a pool deposit updated a cash
+ * balance and left every figure derived from it — the limit, the position, the bond list — showing
+ * what was true before.
+ *
+ * These tests are about coverage rather than behaviour, because that is what was wrong.
+ */
+
+const MOVERS = [
+  'components/clear/ConnectedMoveMoney.tsx',
+  'components/clear/ConnectedPoolMove.tsx',
+  'components/clear/ConnectedBuyBond.tsx',
+];
+
+const READERS = ['pages/app/HomeRoute.tsx', 'pages/app/EarnRoute.tsx', 'pages/app/SavingsRoute.tsx'];
+
+describe('everything that moves money says so', () => {
+  for (const mover of MOVERS) {
+    test(`${mover.split('/').pop()} signals`, () => {
+      expect(read(mover)).toContain('markChainStale()');
+    });
+  }
+});
+
+describe('everything that reads chain state listens', () => {
+  for (const reader of READERS) {
+    test(`${reader.split('/').pop()} re-reads`, () => {
+      expect(read(reader)).toContain('onChainStale(');
+    });
+  }
+
+  test('and each one tears its listener down', () => {
+    // A refetch firing into a component nobody is looking at is waste at best, and a state update
+    // on something unmounted at worst.
+    for (const reader of READERS) expect(read(reader)).toContain('stopListening()');
+  });
+});
+
+describe('the signal itself', () => {
+  test('is one module, not a string repeated across files', () => {
+    // It drifted as a bare event name: one dispatcher, one listener, and no way to notice the
+    // other four places that needed it.
+    const stale = read('lib/chainStale.ts');
+    expect(stale).toContain("const EVENT = 'clear:chain-stale'");
+    for (const f of [...MOVERS, ...READERS]) {
+      expect(read(f)).not.toContain("'clear:chain-stale'");
+      expect(read(f)).not.toContain("'clear:credit-stale'");
+    }
+  });
+
+  test('refetches rather than predicting the figure', () => {
+    // The server still has to pledge and push after the transfer lands, so for a few seconds the
+    // old limit is the true one. Asserted as a property of the code rather than by scanning the
+    // file, which contains a paragraph explaining the rule and matched a naive regex for it.
+    const stale = read('lib/chainStale.ts');
+    expect(stale).toContain('BACKOFF_MS');
+    // It re-runs a caller's read and computes nothing: no figure to be wrong about.
+    expect(stale).toContain('onChainStale(read: () => void)');
+    expect(stale).toContain('setTimeout(read, delay)');
+  });
+
+  test('and survives having no window', () => {
+    const stale = read('lib/chainStale.ts');
+    expect(stale.split("typeof window === 'undefined'").length - 1).toBe(2);
+  });
+});

--- a/app/src/lib/chainStale.ts
+++ b/app/src/lib/chainStale.ts
@@ -1,0 +1,49 @@
+/**
+ * Telling the app that on-chain state it is showing has just been made out of date.
+ *
+ * A move does not change a member's figures at the moment it confirms. The server still has to
+ * pledge the collateral and push the capacities, which are two more writes after the transfer
+ * itself lands — so for a few seconds the old limit is genuinely the true one, and the app has no
+ * way to be told when the new one arrives.
+ *
+ * So this refetches on a signal, backing off across a short window, rather than predicting the
+ * figure. An optimistic limit would be inventing a number only the contracts get to decide — and
+ * it would have hidden the bug where the pledge landed and the push did not.
+ *
+ * A module rather than three dispatches and four listeners. It already drifted once: the savings
+ * move signalled and the pool and bond moves did not, and only Home was listening, so a pool
+ * deposit updated a balance and left every figure derived from it stale until the member changed
+ * page.
+ */
+const EVENT = 'clear:chain-stale';
+
+/** How long the server's follow-up writes realistically take, sampled rather than guessed at once. */
+const BACKOFF_MS = [3_000, 8_000, 15_000];
+
+/** Say that a move just landed, so anything reading chain state should read it again. */
+export function markChainStale(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(EVENT));
+}
+
+/**
+ * Re-run `read` after a move, across the window the follow-up writes need.
+ *
+ * Returns the teardown so a caller can hand it straight back from an effect. Every timer is
+ * cleared on unmount: a refetch that fires into a component nobody is looking at is at best waste
+ * and at worst a state update on something gone.
+ */
+export function onChainStale(read: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  const timers: ReturnType<typeof setTimeout>[] = [];
+
+  const handle = () => {
+    for (const delay of BACKOFF_MS) timers.push(setTimeout(read, delay));
+  };
+  window.addEventListener(EVENT, handle);
+
+  return () => {
+    window.removeEventListener(EVENT, handle);
+    for (const timer of timers) clearTimeout(timer);
+  };
+}

--- a/app/src/pages/app/EarnRoute.tsx
+++ b/app/src/pages/app/EarnRoute.tsx
@@ -5,6 +5,7 @@ import { toEarnData } from '@/lib/earnMapping';
 import { projectReserveDate } from '@/lib/reserveProjection';
 import { useAppKitAccount } from '@/lib/walletCompat';
 import { getEarn, getPaySummary, type EarnState, type PaySummary } from '@/utils/apiClient';
+import { onChainStale } from '@/lib/chainStale';
 
 /*
  * Day-one, not in-use.
@@ -44,13 +45,27 @@ export default function EarnRoute() {
   useEffect(() => {
     if (!address) return;
     let cancelled = false;
-    void Promise.all([getEarn(address), getPaySummary(address)]).then(([e, p]) => {
-      if (cancelled) return;
-      setEarn(e);
-      setPay(p);
-    });
+    const read = () => {
+      void Promise.all([getEarn(address), getPaySummary(address)]).then(([e, p]) => {
+        if (cancelled) return;
+        setEarn(e);
+        setPay(p);
+      });
+    };
+    read();
+
+    /*
+     * Re-read after a move, which this page previously did not do at all.
+     *
+     * Everything on Earn is downstream of a move: the pool position and its utilisation, the bond
+     * list, and what both back on the credit line. A member who bought a bond here watched their
+     * cash fall and the bond not appear until they changed page and came back.
+     */
+    const stopListening = onChainStale(read);
+
     return () => {
       cancelled = true;
+      stopListening();
     };
   }, [address]);
 

--- a/app/src/pages/app/HomeRoute.tsx
+++ b/app/src/pages/app/HomeRoute.tsx
@@ -6,6 +6,7 @@ import { useClearTransactions } from '@/hooks/useClearTransactions';
 import { useAppKitAccount } from '@/lib/walletCompat';
 import { toActivityRow } from '@/lib/activityMapping';
 import { toCredit, toCycle, toLimitBacking, toTermPlans } from '@/lib/creditMapping';
+import { onChainStale } from '@/lib/chainStale';
 import {
   getCredit,
   getLithicAccount,
@@ -90,28 +91,14 @@ export default function HomeRoute() {
     };
     read();
 
-    /*
-     * Re-read after something that changes the line, rather than showing a guess.
-     *
-     * A savings deposit moves the limit, but not instantly: the server pledges the collateral and
-     * pushes the capacities, which is two on-chain writes after the deposit itself confirms. Until
-     * they land the old limit is the true one, so this refetches on a signal instead of predicting
-     * the new figure -- an optimistic limit would be inventing a number that only the contracts get
-     * to decide, and it would have hidden the bug where the pledge landed and the push did not.
-     *
-     * Backs off across a short window because the writes take a few seconds and the app has no way
-     * to be told when they finish.
-     */
-    const timers: ReturnType<typeof setTimeout>[] = [];
-    const onStale = () => {
-      for (const delay of [3000, 8000, 15000]) timers.push(setTimeout(read, delay));
-    };
-    window.addEventListener('clear:credit-stale', onStale);
+    // Re-read after a move. The backoff and the reasoning live in `chainStale`, because this was
+    // not the only reader and the copies drifted — the savings move signalled, the pool and bond
+    // moves did not, and nothing outside this file was listening at all.
+    const stopListening = onChainStale(read);
 
     return () => {
       cancelled = true;
-      window.removeEventListener('clear:credit-stale', onStale);
-      for (const timer of timers) clearTimeout(timer);
+      stopListening();
     };
   }, [address]);
 

--- a/app/src/pages/app/SavingsRoute.tsx
+++ b/app/src/pages/app/SavingsRoute.tsx
@@ -4,6 +4,7 @@ import { SAVINGS_DAY_ONE } from '@/data/clearPlaceholder';
 import { useClearBalances } from '@/hooks/useClearBalances';
 import { useAppKitAccount } from '@/lib/walletCompat';
 import { getPaySummary, type PaySummary } from '@/utils/apiClient';
+import { onChainStale } from '@/lib/chainStale';
 
 /*
  * Day-one, not in-use.
@@ -44,11 +45,20 @@ export default function SavingsRoute() {
   useEffect(() => {
     if (!address) return;
     let cancelled = false;
-    void getPaySummary(address).then((result) => {
-      if (!cancelled) setPay(result);
-    });
+    const read = () => {
+      void getPaySummary(address).then((result) => {
+        if (!cancelled) setPay(result);
+      });
+    };
+    read();
+
+    // Equity credits are minted by the same deposit that moves the balance, and they were the one
+    // figure on this page that stayed put until a navigation.
+    const stopListening = onChainStale(read);
+
     return () => {
       cancelled = true;
+      stopListening();
     };
   }, [address]);
 


### PR DESCRIPTION
Balances moved after a deposit and the credit limit didn't, until you changed page.

## What was wrong

The mechanism existed — and was wired to a third of the app.

The **savings** move dispatched `clear:credit-stale`, **Home** listened for it, and that was the whole of it. The pool and bond moves signalled nothing; Earn and Savings listened for nothing.

So a pool deposit updated a cash balance and left every figure derived from it showing what was true before: the limit, the position, the pool's utilisation, the bond list, the equity credits.

## Why it drifted

It was a bare event name. One dispatch, one listener, and nothing anywhere to indicate that four other places needed it.

It's a module now, and the test covering it is about **coverage rather than behaviour** — because coverage is what was wrong. Every mover signals, every reader listens, and adding a fourth of either fails until it's wired.

## Still a refetch, not a prediction

Worth keeping the reason: the server pledges the collateral and pushes the capacities *after* the transfer confirms, so for a few seconds the old limit is genuinely the true one. Predicting the new figure would invent a number only the contracts get to decide — and it would have hidden last week's bug where the pledge landed and the push did not.

Backs off across 3s / 8s / 15s, because those writes take a moment and nothing tells the app when they finish.

## Balances

Already fine, and untouched — they poll, refresh on focus, and apply optimistically with a faster poll until the chain agrees.

450 tests, 10 new.