### PR TITLE
Refresh the equity credits too, and make the test able to say so

### DIFF
--- a/app/src/lib/chainStale.test.ts
+++ b/app/src/lib/chainStale.test.ts
@@ -33,10 +33,35 @@ describe('everything that moves money says so', () => {
   }
 });
 
+/**
+ * Which chain-derived reads each route makes, and therefore which have to refresh.
+ *
+ * Named per file rather than checked in the abstract, because "the file mentions onChainStale"
+ * was the assertion that let this through the first time: HomeRoute listened for its credit read
+ * and not for its equity read, the test saw the listener and passed, and the credits feeding the
+ * savings card and the ELPA row stayed stale until a page change.
+ */
+const CHAIN_READS: Record<string, string[]> = {
+  'pages/app/HomeRoute.tsx': ['getCredit(address)', 'getPaySummary(address)'],
+  'pages/app/EarnRoute.tsx': ['getEarn(address)', 'getPaySummary(address)'],
+  'pages/app/SavingsRoute.tsx': ['getPaySummary(address)'],
+};
+
 describe('everything that reads chain state listens', () => {
   for (const reader of READERS) {
     test(`${reader.split('/').pop()} re-reads`, () => {
       expect(read(reader)).toContain('onChainStale(');
+    });
+  }
+
+  for (const [file, calls] of Object.entries(CHAIN_READS)) {
+    test(`${file.split('/').pop()} refreshes every read it makes, not just one`, () => {
+      const source = read(file);
+      // Each call has to sit inside the `read` the listener re-runs. Anything outside it is a
+      // figure that goes stale the moment somebody moves money.
+      const readFn = source.slice(source.indexOf('const read = () => {'), source.indexOf('onChainStale('));
+      expect(readFn.length).toBeGreaterThan(0);
+      for (const call of calls) expect(readFn).toContain(call);
     });
   }
 

--- a/app/src/pages/app/HomeRoute.tsx
+++ b/app/src/pages/app/HomeRoute.tsx
@@ -67,26 +67,27 @@ export default function HomeRoute() {
     };
   }, []);
 
+  /*
+   * Everything on this page a move can change, read together.
+   *
+   * One effect and one listener on purpose. As two, the credit read refreshed after a deposit and
+   * the equity ledger did not — so the limit moved while the credits feeding the savings card and
+   * the ELPA row sat at their old figures until the member changed page. They are downstream of
+   * the same deposit; splitting them was splitting one fact into two that could disagree.
+   */
   useEffect(() => {
     if (!address) return;
     let cancelled = false;
-    void getPaySummary(address).then((result) => {
-      if (!cancelled) setPay(result);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [address]);
 
-  useEffect(() => {
-    if (!address) return;
-    let cancelled = false;
     // Null covers both "no credit line" and "could not read the chain", and the route distinguishes
     // them with a 503 for the second. Either way the placeholder stands rather than a zeroed line:
     // telling a member their credit is gone because an RPC timed out is the worse mistake.
     const read = () => {
       void getCredit(address).then((result) => {
         if (!cancelled) setCredit(result);
+      });
+      void getPaySummary(address).then((result) => {
+        if (!cancelled) setPay(result);
       });
     };
     read();


### PR DESCRIPTION
Same bug as yesterday's, one level finer — and my own test walked straight past it.

## What was wrong

Home makes **three** reads. I wired the credit one to the stale signal and left the equity ledger unwired.

So after a deposit the limit updated and the credits didn't — and those credits are what the **savings card** and the **ELPA row** show on Home, and what sits under the **balance and the bar** on Savings. Exactly what was reported.

The two reads are downstream of the same deposit, so they're one effect now with one listener. Splitting them was splitting one fact into two that could disagree, and they did.

## The test is the more useful half

It asserted that each route file *mentioned* `onChainStale`. HomeRoute did — for the read that was already working. A file-level check can't tell a route that refreshes everything from one that refreshes one thing, and that's precisely the difference here.

It now **names the chain reads each route makes** and requires every one of them to sit inside the function the listener re-runs:

```
'pages/app/HomeRoute.tsx':    ['getCredit(address)', 'getPaySummary(address)'],
'pages/app/EarnRoute.tsx':    ['getEarn(address)',   'getPaySummary(address)'],
'pages/app/SavingsRoute.tsx': ['getPaySummary(address)'],
```

Verified by deleting the equity read from the effect and watching it fail — the check I should have run when I wrote the first version rather than after you found what it missed.

## On vested credits

You're right that we won't know until something vests. Vested and vesting come from the same `getPaySummary` call, so if vesting refreshes correctly now, vested will too — same read, same listener. Worth confirming once a 30-day vest lands rather than assuming.

453 tests, 3 new.