### PR TITLE
Hear it from the server instead of guessing, and reach every device

### DIFF
--- a/app/server/src/services/chain/savingsCollateralService.ts
+++ b/app/server/src/services/chain/savingsCollateralService.ts
@@ -1,6 +1,7 @@
 import { ethers } from 'ethers';
 import { getContractAddress } from '../../config/contracts.js';
 import { savingsIntentService } from '../savingsIntentService.js';
+import { websocketService } from '../websocketService.js';
 
 /*
  * Making savings back a credit line.
@@ -69,6 +70,32 @@ function operatorKey(): string | null {
  * exactly the case being guarded, and a per-request value cannot see the other request.
  */
 const inFlight = new Map<string, Promise<CollateralSyncResult>>();
+
+/**
+ * Tell every device this member has open that their figures have changed.
+ *
+ * The app was guessing: a move triggered three refetches at 3, 8 and 15 seconds, on the hope that
+ * the pledge and the capacity push would have landed by then. That is a guess in both directions —
+ * it refetches when nothing has changed, and it stops before a slow chain finishes.
+ *
+ * It is also per-tab. A deposit made on a desktop left a phone showing the old figures until it
+ * was reopened, because a `window` event does not leave the window it was dispatched in.
+ *
+ * This is sent after the writes actually complete, over the socket the app already holds open per
+ * wallet — so it is exact, and it reaches every device rather than the one that did the moving.
+ */
+async function announceChainChanged(wallet: string): Promise<void> {
+  try {
+    await websocketService.broadcastToAddress(wallet.toLowerCase(), 'chain:changed', {
+      wallet: wallet.toLowerCase(),
+      at: new Date().toISOString(),
+    });
+  } catch (error) {
+    // Best-effort. The app still has its backoff, so a member on a dead socket gets the old
+    // behaviour rather than none.
+    console.error('[collateral] broadcast failed', error instanceof Error ? error.message : error);
+  }
+}
 
 export interface CollateralSyncResult {
   ok: boolean;
@@ -176,6 +203,9 @@ async function runSync(wallet: string, kind: string, targetUnits: bigint): Promi
       }
     }
 
+    // After the writes, not before: the point is that the figures are already new when a device
+    // is told to read them again.
+    await announceChainChanged(member);
     return { ok: true, pledgedUnits: targetUnits.toString(), txHash };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown error';
@@ -329,6 +359,7 @@ export async function syncBondCollateral(wallet: string): Promise<CollateralSync
       await push.wait();
     }
 
+    await announceChainChanged(member);
     return { ok: true, pledgedUnits: String(held.size) };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown error';

--- a/app/src/context/NotificationContext.tsx
+++ b/app/src/context/NotificationContext.tsx
@@ -4,6 +4,7 @@ import { useDeedNFTData } from '@/hooks/useDeedNFTData';
 import { usePushNotifications } from '@/hooks/usePushNotifications';
 import { useAppBadge } from '@/hooks/useAppBadge';
 import { useWebSocket } from '@/hooks/useWebSocket';
+import { markChainSettled } from '@/lib/chainStale';
 import { usePortfolio } from '@/context/PortfolioContext';
 
 export interface Notification {
@@ -531,16 +532,32 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
       }
     };
 
+    /*
+     * The server has finished the writes behind a move, so every figure derived from them is now
+     * readable. Turned straight into the local stale signal, so every page already listening for
+     * that gets it without knowing a socket exists.
+     *
+     * It lives here because this is where an app-wide socket already is — `useWebSocket` opens a
+     * connection per caller, and a third one to carry two lines would be a real cost for a
+     * cosmetic separation. It is not a notification, and the name says so.
+     *
+     * This is also what makes a deposit on a desktop reach a phone: the server broadcasts to the
+     * wallet, not to the tab that asked, so every device holding that wallet open refreshes.
+     */
+    const handleChainChanged = () => markChainSettled();
+
     socket.on('transfer_received', handleTransferReceived);
     socket.on('transfer_sent', handleTransferSent);
     socket.on('balance_update', handleBalanceUpdate);
     socket.on('price_update', handlePriceUpdate);
+    socket.on('chain:changed', handleChainChanged);
 
     return () => {
       socket.off('transfer_received', handleTransferReceived);
       socket.off('transfer_sent', handleTransferSent);
       socket.off('balance_update', handleBalanceUpdate);
       socket.off('price_update', handlePriceUpdate);
+      socket.off('chain:changed', handleChainChanged);
     };
   }, [socket, wsConnected, address, addNotification, holdings]);
 

--- a/app/src/lib/chainStale.test.ts
+++ b/app/src/lib/chainStale.test.ts
@@ -77,9 +77,11 @@ describe('the signal itself', () => {
     // It drifted as a bare event name: one dispatcher, one listener, and no way to notice the
     // other four places that needed it.
     const stale = read('lib/chainStale.ts');
-    expect(stale).toContain("const EVENT = 'clear:chain-stale'");
+    expect(stale).toContain("const STALE = 'clear:chain-stale'");
+    expect(stale).toContain("const SETTLED = 'clear:chain-settled'");
     for (const f of [...MOVERS, ...READERS]) {
       expect(read(f)).not.toContain("'clear:chain-stale'");
+      expect(read(f)).not.toContain("'clear:chain-settled'");
       expect(read(f)).not.toContain("'clear:credit-stale'");
     }
   });
@@ -97,6 +99,59 @@ describe('the signal itself', () => {
 
   test('and survives having no window', () => {
     const stale = read('lib/chainStale.ts');
-    expect(stale.split("typeof window === 'undefined'").length - 1).toBe(2);
+    // Three entry points, three guards: two dispatchers and the subscriber.
+    expect(stale.split("typeof window === 'undefined'").length - 1).toBe(3);
+  });
+});
+
+/*
+ * The two signals, and why the split matters.
+ *
+ * A backoff is a guess about when the server's writes finish. The server knows exactly, and the
+ * app already holds a socket per wallet — so the guess became the fallback for a member whose
+ * socket is not connected, and the exact answer does the work.
+ *
+ * It also fixes something the local event could never do: a `window` event does not leave the
+ * window it was dispatched in, so a deposit made on a desktop left a phone showing old figures
+ * until it was reopened. The server broadcasts to the wallet, not to the tab that asked.
+ */
+describe('hearing it from the server beats guessing', () => {
+  test('a settled signal reads at once, with nothing scheduled', () => {
+    const stale = read('lib/chainStale.ts');
+    expect(stale).toContain('const onConfirmed = () => read();');
+    // A backoff after a correct read would be three redundant reads.
+    const confirmed = stale.slice(stale.indexOf('const onConfirmed'), stale.indexOf('window.addEventListener(STALE'));
+    expect(confirmed).not.toContain('setTimeout');
+  });
+
+  test('the guess is still there for a member with no socket', () => {
+    const stale = read('lib/chainStale.ts');
+    expect(stale).toContain('const onGuess = ()');
+    expect(stale).toContain('BACKOFF_MS');
+  });
+
+  test('the server announces after the writes, not before', () => {
+    // The point is that the figures are already new when a device is told to read them.
+    const service = readFileSync(
+      join(SRC, '../server/src/services/chain/savingsCollateralService.ts'), 'utf8',
+    );
+    expect(service).toContain('await announceChainChanged(member);');
+    const sync = service.slice(service.indexOf('async function runSync'));
+    expect(sync.indexOf('pushCapacities')).toBeLessThan(sync.indexOf('announceChainChanged'));
+  });
+
+  test('and it broadcasts to the wallet, not to one connection', () => {
+    // This is what reaches a phone from a desktop.
+    const service = readFileSync(
+      join(SRC, '../server/src/services/chain/savingsCollateralService.ts'), 'utf8',
+    );
+    expect(service).toContain("broadcastToAddress(wallet.toLowerCase(), 'chain:changed'");
+  });
+
+  test('the client turns it into the same local signal every page already hears', () => {
+    const notifications = read('context/NotificationContext.tsx');
+    expect(notifications).toContain("socket.on('chain:changed', handleChainChanged)");
+    expect(notifications).toContain('markChainSettled()');
+    expect(notifications).toContain("socket.off('chain:changed', handleChainChanged)");
   });
 });

--- a/app/src/lib/chainStale.ts
+++ b/app/src/lib/chainStale.ts
@@ -1,33 +1,44 @@
 /**
- * Telling the app that on-chain state it is showing has just been made out of date.
+ * Telling the app that on-chain state it is showing has changed.
  *
- * A move does not change a member's figures at the moment it confirms. The server still has to
- * pledge the collateral and push the capacities, which are two more writes after the transfer
- * itself lands — so for a few seconds the old limit is genuinely the true one, and the app has no
- * way to be told when the new one arrives.
+ * Two signals, because there are two things worth saying and they deserve different behaviour.
  *
- * So this refetches on a signal, backing off across a short window, rather than predicting the
- * figure. An optimistic limit would be inventing a number only the contracts get to decide — and
- * it would have hidden the bug where the pledge landed and the push did not.
+ * **`markChainStale`** — a move just landed, and the server still has to pledge the collateral and
+ * push the capacities. Those are two more writes after the transfer itself, so for a few seconds
+ * the old figures are genuinely the true ones. Nothing knows when they finish, so this refetches
+ * across a short backoff. It is a guess, and it is wrong in both directions: it reads when nothing
+ * has changed, and it gives up before a slow chain is done.
  *
- * A module rather than three dispatches and four listeners. It already drifted once: the savings
- * move signalled and the pool and bond moves did not, and only Home was listening, so a pool
- * deposit updated a balance and left every figure derived from it stale until the member changed
- * page.
+ * **`markChainSettled`** — the server has finished those writes and said so over the socket. No
+ * guessing: read once, now. This is the signal that should do the work; the backoff above is what
+ * covers a member whose socket is not connected.
+ *
+ * Neither predicts a figure. An optimistic limit would be inventing a number only the contracts
+ * get to decide — and it would have hidden the bug where the pledge landed and the push did not.
+ *
+ * A module rather than a bare event name, because as a bare name it drifted: one dispatcher, one
+ * listener, and nothing to show that four other places needed it.
  */
-const EVENT = 'clear:chain-stale';
+const STALE = 'clear:chain-stale';
+const SETTLED = 'clear:chain-settled';
 
-/** How long the server's follow-up writes realistically take, sampled rather than guessed at once. */
+/** How long the server's follow-up writes realistically take, when nothing can tell us. */
 const BACKOFF_MS = [3_000, 8_000, 15_000];
 
-/** Say that a move just landed, so anything reading chain state should read it again. */
+/** A move landed. The figures behind it may not have caught up yet. */
 export function markChainStale(): void {
   if (typeof window === 'undefined') return;
-  window.dispatchEvent(new Event(EVENT));
+  window.dispatchEvent(new Event(STALE));
+}
+
+/** The server finished the writes behind a move. Read now. */
+export function markChainSettled(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(SETTLED));
 }
 
 /**
- * Re-run `read` after a move, across the window the follow-up writes need.
+ * Re-run `read` when chain state changes, however we come to hear about it.
  *
  * Returns the teardown so a caller can hand it straight back from an effect. Every timer is
  * cleared on unmount: a refetch that fires into a component nobody is looking at is at best waste
@@ -37,13 +48,19 @@ export function onChainStale(read: () => void): () => void {
   if (typeof window === 'undefined') return () => {};
   const timers: ReturnType<typeof setTimeout>[] = [];
 
-  const handle = () => {
+  const onGuess = () => {
     for (const delay of BACKOFF_MS) timers.push(setTimeout(read, delay));
   };
-  window.addEventListener(EVENT, handle);
+  // Settled means the writes are already done, so there is nothing to wait for and nothing to
+  // schedule — a backoff here would only add three redundant reads after a correct one.
+  const onConfirmed = () => read();
+
+  window.addEventListener(STALE, onGuess);
+  window.addEventListener(SETTLED, onConfirmed);
 
   return () => {
-    window.removeEventListener(EVENT, handle);
+    window.removeEventListener(STALE, onGuess);
+    window.removeEventListener(SETTLED, onConfirmed);
     for (const timer of timers) clearTimeout(timer);
   };
 }


### PR DESCRIPTION
Two questions, one answer.

## No, the window shouldn't be extended

A backoff is a **guess** about when the server's writes finish, and it's wrong in both directions: it refetches when nothing has changed, and it gives up before a slow chain is done. Making the guess longer makes the first problem worse to soften the second.

The server knows exactly when those writes land, and **the app already holds a socket open per wallet**. So the collateral sync now broadcasts after the pledge and the capacity push complete, and the app reads once, then — instead of three times on a hope.

## And that's the same reason desktop didn't reach mobile

The signal was a `window` event, which doesn't leave the window it was dispatched in.

The broadcast goes to the **wallet**, not to the connection that asked — so every device holding that account open refreshes. The mobile PWA included, without a hard reload.

## Two signals

- **`markChainStale`** — a move landed, the writes may not have caught up. Keeps the backoff, now serving its real purpose: covering a member whose socket is down.
- **`markChainSettled`** — the server finished. Reads once, with nothing scheduled. A backoff after a correct read would only be three redundant reads.

Neither predicts a figure, which is still the point: an optimistic limit would invent a number only the contracts get to decide.

## One thing worth flagging

The socket handler lives in `NotificationContext` — not where it belongs conceptually, but where an app-wide socket already exists. `useWebSocket` opens a connection per caller, and a third connection to carry two lines is a real cost for a cosmetic separation. The handler is named for what it does rather than where it sits.

458 tests, 5 new. All 15 lint problems in `NotificationContext` are pre-existing — verified by stashing.