### PR TITLE
Stop shipping the Alchemy key to the browser

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,13 +1,15 @@
-# Alchemy API Keys (optional - for better performance)
-VITE_ALCHEMY_ETH_MAINNET=https://eth-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-VITE_ALCHEMY_ETH_SEPOLIA=https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY
-VITE_ALCHEMY_BASE_MAINNET=https://base-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-VITE_ALCHEMY_BASE_SEPOLIA=https://base-sepolia.g.alchemy.com/v2/YOUR_API_KEY
-VITE_ALCHEMY_ARBITRUM_MAINNET=https://arb-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-VITE_ALCHEMY_POLYGON_MAINNET=https://polygon-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-VITE_ALCHEMY_GNOSIS_MAINNET=https://gnosis-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-VITE_ALCHEMY_OPTIMISM_MAINNET=https://opt-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-
+# RPC providers for the BROWSER.
+#
+# Do NOT put an Alchemy endpoint here. VITE_* is inlined into the shipped bundle, and an Alchemy
+# URL carries the API key in its path -- so setting one publishes the key to anyone who loads the
+# site. This file used to list eight of them; the key was lifted from the deployed bundle and
+# spent on chains we do not even support.
+#
+# The Alchemy key belongs in the SERVER env as ALCHEMY_API_KEY (Railway) and nowhere else.
+# Everything that needs it -- balances, token metadata, transfers -- already goes through our API.
+#
+# An Infura PROJECT ID is public by design and safe to put here, but only with the dashboard
+# restrictions on: domain allowlist, rate limiting, method allowlist. Never the project secret.
 # Infura API Keys (optional - for better performance)
 VITE_INFURA_ETH_MAINNET=https://mainnet.infura.io/v3/YOUR_PROJECT_ID
 VITE_INFURA_ETH_SEPOLIA=https://sepolia.infura.io/v3/YOUR_PROJECT_ID

--- a/app/.env.local.example
+++ b/app/.env.local.example
@@ -32,8 +32,8 @@ VITE_PERSONA_ENVIRONMENT_ID=
 # backend Bridge customer-create + Persona webhook routes exist; otherwise mocks are used.
 VITE_INTEGRATIONS_LIVE=false
 
-# Optional: frontend RPC URLs (balances go through the backend, so usually NOT needed).
-# VITE_ALCHEMY_BASE_MAINNET=https://base-mainnet.g.alchemy.com/v2/YOUR_API_KEY
+# Do NOT add a VITE_ALCHEMY_* here. VITE_* is compiled into the public bundle and an Alchemy URL
+# has the API key in it -- balances go through the backend precisely so the key can stay there.
 
 # =============================================================================
 # BACKEND  (Railway — app/server)  ·  set these in Railway, NOT in this file.

--- a/app/package.json
+++ b/app/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "dev": "vite",
     "test": "bun test src",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && node scripts/scanBundleSecrets.mjs",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "scan:secrets": "node scripts/scanBundleSecrets.mjs"
   },
   "dependencies": {
     "@abstract-foundation/agw-client": "^1.12.3",

--- a/app/scripts/scanBundleSecrets.mjs
+++ b/app/scripts/scanBundleSecrets.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/*
+ * Fail the build if a provider key made it into the shipped bundle.
+ *
+ * This exists because a source-level rule ("don't read VITE_ALCHEMY_*") only forbids the one path
+ * we already know about. The thing that actually hurt us is not a variable name -- it is a key
+ * being readable in dist/, and there are many ways to get one there: a different var name, a
+ * hardcoded URL, a config object, a dependency's default. So this checks the output.
+ *
+ * The Alchemy key that leaked was found exactly this way, by curling the deployed site and
+ * grepping the chunks. Doing it before deploying rather than after is the whole point.
+ */
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DIST = join(import.meta.dirname, '..', 'dist');
+
+/*
+ * Patterns for a SECRET in a URL, not for a provider's name.
+ *
+ * `g.alchemy.com/v2/<key>` is a leak; `alchemy.com` in a comment or a docs link is not, and a rule
+ * that cannot tell them apart gets muted the first time it cries wolf. Each pattern therefore
+ * requires the key-shaped path segment, and `demo` is Alchemy's own public placeholder key.
+ */
+const PATTERNS = [
+  { name: 'Alchemy API key', re: /\b[a-z0-9-]+\.g\.alchemy\.com\/v2\/(?!demo\b)[A-Za-z0-9_-]{16,}/g },
+  { name: 'Infura project secret', re: /\binfura\.io\/v3\/[A-Za-z0-9]{16,}:[A-Za-z0-9]+/g },
+  { name: 'QuickNode endpoint', re: /\b[a-z0-9-]+\.quiknode\.pro\/[A-Za-z0-9]{16,}/g },
+  { name: 'Ankr premium key', re: /\brpc\.ankr\.com\/[a-z_]+\/[A-Za-z0-9]{24,}/g },
+];
+
+function* files(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) yield* files(full);
+    else if (/\.(js|mjs|cjs|css|html|json|map)$/.test(entry)) yield full;
+  }
+}
+
+if (!existsSync(DIST)) {
+  // Not "no secrets found" -- nothing was examined. Saying so is the difference between a guard
+  // and a guard that passes because it never ran.
+  console.error('[scan] dist/ does not exist — run the build first. Nothing was scanned.');
+  process.exit(1);
+}
+
+const hits = [];
+let scanned = 0;
+for (const file of files(DIST)) {
+  scanned += 1;
+  const text = readFileSync(file, 'utf8');
+  for (const { name, re } of PATTERNS) {
+    for (const match of text.matchAll(re)) {
+      // Redact the key itself: this output goes to CI logs, which are not always private.
+      hits.push(`${name} in ${file.slice(DIST.length + 1)} — ${match[0].replace(/[A-Za-z0-9_-]{12,}$/, (k) => `${k.slice(0, 4)}…REDACTED`)}`);
+    }
+  }
+}
+
+if (hits.length > 0) {
+  console.error(`\n[scan] ${hits.length} provider key(s) in the shipped bundle:\n`);
+  for (const hit of hits) console.error(`  ${hit}`);
+  console.error(
+    '\nVITE_* is inlined at build time and is readable by anyone who loads the site.\n' +
+      'Move the key to the server env and call it through our API. See src/config/networks.ts.\n',
+  );
+  process.exit(1);
+}
+
+console.log(`[scan] ${scanned} files, no provider keys.`);

--- a/app/scripts/scanBundleSecrets.mjs
+++ b/app/scripts/scanBundleSecrets.mjs
@@ -27,6 +27,13 @@ const PATTERNS = [
   { name: 'Infura project secret', re: /\binfura\.io\/v3\/[A-Za-z0-9]{16,}:[A-Za-z0-9]+/g },
   { name: 'QuickNode endpoint', re: /\b[a-z0-9-]+\.quiknode\.pro\/[A-Za-z0-9]{16,}/g },
   { name: 'Ankr premium key', re: /\brpc\.ankr\.com\/[a-z_]+\/[A-Za-z0-9]{24,}/g },
+  // Mapbox scopes its tokens by prefix: `pk.` belongs in a web page, `sk.` never does. The map
+  // code used to reach for the secret one specifically when building for production.
+  { name: 'Mapbox secret token', re: /\bsk\.ey[A-Za-z0-9._-]{20,}/g },
+  // Generic shapes worth catching before they are ours to explain.
+  { name: 'Stripe secret key', re: /\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}/g },
+  { name: 'AWS access key id', re: /\bAKIA[A-Z0-9]{16}\b/g },
+  { name: 'Private key material', re: /-----BEGIN (?:RSA |EC |OPENSSH |PGP )?PRIVATE KEY-----/g },
 ];
 
 function* files(dir) {

--- a/app/src/components/DeedNFTMap.tsx
+++ b/app/src/components/DeedNFTMap.tsx
@@ -8,15 +8,19 @@ import { Eye, MapPin } from "lucide-react";
 import type { DeedNFT } from '@/hooks/useDeedNFTData';
 import { useDeedNFTContext } from '@/context/DeedNFTContext';
 
-// Set Mapbox access token based on environment
-// Use public token for development, private token for production
-const getMapboxToken = () => {
-  if (import.meta.env.PROD) {
-    return import.meta.env.VITE_MAPBOX_PRIVATE_TOKEN || '';
-  } else {
-    return import.meta.env.VITE_MAPBOX_PUBLIC_TOKEN || '';
-  }
-};
+/*
+ * Always the PUBLIC token — production included.
+ *
+ * This used to swap in the private token when `import.meta.env.PROD`, which has the relationship
+ * backwards: a production build is the one everybody can read. VITE_* is inlined into the bundle,
+ * so "private token for production" means publishing the private token to the world.
+ *
+ * It happens not to have burned us — both tokens in the env are `pk.` scoped, so nothing secret
+ * ever shipped. But the line was an instruction to put an `sk.` token there, and someone would
+ * eventually have followed it. Mapbox `pk.` tokens are designed to sit in web pages; restrict them
+ * by URL in the Mapbox dashboard. An `sk.` token cannot safely be used from a browser at all.
+ */
+const getMapboxToken = () => import.meta.env.VITE_MAPBOX_PUBLIC_TOKEN || '';
 
 interface DeedNFTMapProps {
   deedNFTs: DeedNFT[];
@@ -84,7 +88,7 @@ const DeedNFTMap: React.FC<DeedNFTMapProps> = ({
 
     const mapboxToken = getMapboxToken();
     if (!mapboxToken) {
-      console.error('Mapbox access token not found. Please set VITE_MAPBOX_PUBLIC_TOKEN for development or VITE_MAPBOX_PRIVATE_TOKEN for production in your environment variables.');
+      console.error('Mapbox access token not found. Set VITE_MAPBOX_PUBLIC_TOKEN — a `pk.` token, URL-restricted in the Mapbox dashboard. Never an `sk.` token: it would ship in the bundle.');
       return;
     }
 
@@ -390,7 +394,7 @@ const DeedNFTMap: React.FC<DeedNFTMapProps> = ({
             Mapbox access token not configured
           </p>
           <p className="text-yellow-700 dark:text-yellow-300 text-sm mt-2">
-            Please set VITE_MAPBOX_PUBLIC_TOKEN for development or VITE_MAPBOX_PRIVATE_TOKEN for production
+            Please set VITE_MAPBOX_PUBLIC_TOKEN
           </p>
           <p className="text-yellow-600 dark:text-yellow-400 text-xs mt-2">
             Get your free access token from{' '}

--- a/app/src/config/clientEnv.ts
+++ b/app/src/config/clientEnv.ts
@@ -1,0 +1,79 @@
+/**
+ * Every client env var this app looks up by a computed name — written out one by one, on purpose.
+ *
+ * `import.meta.env` is not an object at runtime. Vite finds the literal text
+ * `import.meta.env.VITE_FOO` and substitutes the value, which means a STATIC read publishes
+ * exactly that one variable. A DYNAMIC read — `import.meta.env[key]`, or the same thing behind a
+ * `Record` cast — has no literal to match, so Vite gives up and serialises the WHOLE env object
+ * into the bundle instead.
+ *
+ * That is how our Alchemy key reached the public bundle. Nothing read `VITE_ALCHEMY_*` by then;
+ * three helpers here indexed the env by a chain-id-derived key, and the dump they caused carried
+ * every VITE_ var set in the build, read or not. Deleting the readers did not stop it, and would
+ * not have stopped the next one either.
+ *
+ * So the rule this file enforces: a var is reachable from the browser only if it is spelled out
+ * below. Adding a chain means adding its five lines. That is tedious by design — the tedium is an
+ * allowlist, and it is the thing that keeps a secret someone sets in Vercel from shipping just
+ * because it happens to start with VITE_.
+ *
+ * Generated shape, not generated code: the keys must be literals for Vite to see them.
+ */
+const CLIENT_ENV: Record<string, string | undefined> = {
+  VITE_CLRUSD_1: import.meta.env.VITE_CLRUSD_1,
+  VITE_CLRUSD_10: import.meta.env.VITE_CLRUSD_10,
+  VITE_CLRUSD_100: import.meta.env.VITE_CLRUSD_100,
+  VITE_CLRUSD_137: import.meta.env.VITE_CLRUSD_137,
+  VITE_CLRUSD_8453: import.meta.env.VITE_CLRUSD_8453,
+  VITE_CLRUSD_11155111: import.meta.env.VITE_CLRUSD_11155111,
+  VITE_CLRUSD_42161: import.meta.env.VITE_CLRUSD_42161,
+  VITE_CLRUSD_84532: import.meta.env.VITE_CLRUSD_84532,
+
+  VITE_ESA_VAULT_1: import.meta.env.VITE_ESA_VAULT_1,
+  VITE_ESA_VAULT_10: import.meta.env.VITE_ESA_VAULT_10,
+  VITE_ESA_VAULT_100: import.meta.env.VITE_ESA_VAULT_100,
+  VITE_ESA_VAULT_137: import.meta.env.VITE_ESA_VAULT_137,
+  VITE_ESA_VAULT_8453: import.meta.env.VITE_ESA_VAULT_8453,
+  VITE_ESA_VAULT_11155111: import.meta.env.VITE_ESA_VAULT_11155111,
+  VITE_ESA_VAULT_42161: import.meta.env.VITE_ESA_VAULT_42161,
+  VITE_ESA_VAULT_84532: import.meta.env.VITE_ESA_VAULT_84532,
+
+  VITE_CLRUSD_POOL_1: import.meta.env.VITE_CLRUSD_POOL_1,
+  VITE_CLRUSD_POOL_10: import.meta.env.VITE_CLRUSD_POOL_10,
+  VITE_CLRUSD_POOL_100: import.meta.env.VITE_CLRUSD_POOL_100,
+  VITE_CLRUSD_POOL_137: import.meta.env.VITE_CLRUSD_POOL_137,
+  VITE_CLRUSD_POOL_8453: import.meta.env.VITE_CLRUSD_POOL_8453,
+  VITE_CLRUSD_POOL_11155111: import.meta.env.VITE_CLRUSD_POOL_11155111,
+  VITE_CLRUSD_POOL_42161: import.meta.env.VITE_CLRUSD_POOL_42161,
+  VITE_CLRUSD_POOL_84532: import.meta.env.VITE_CLRUSD_POOL_84532,
+
+  VITE_SEND_USDC_1: import.meta.env.VITE_SEND_USDC_1,
+  VITE_SEND_USDC_10: import.meta.env.VITE_SEND_USDC_10,
+  VITE_SEND_USDC_100: import.meta.env.VITE_SEND_USDC_100,
+  VITE_SEND_USDC_137: import.meta.env.VITE_SEND_USDC_137,
+  VITE_SEND_USDC_8453: import.meta.env.VITE_SEND_USDC_8453,
+  VITE_SEND_USDC_11155111: import.meta.env.VITE_SEND_USDC_11155111,
+  VITE_SEND_USDC_42161: import.meta.env.VITE_SEND_USDC_42161,
+  VITE_SEND_USDC_84532: import.meta.env.VITE_SEND_USDC_84532,
+
+  VITE_SEND_CLAIM_ESCROW_1: import.meta.env.VITE_SEND_CLAIM_ESCROW_1,
+  VITE_SEND_CLAIM_ESCROW_10: import.meta.env.VITE_SEND_CLAIM_ESCROW_10,
+  VITE_SEND_CLAIM_ESCROW_100: import.meta.env.VITE_SEND_CLAIM_ESCROW_100,
+  VITE_SEND_CLAIM_ESCROW_137: import.meta.env.VITE_SEND_CLAIM_ESCROW_137,
+  VITE_SEND_CLAIM_ESCROW_8453: import.meta.env.VITE_SEND_CLAIM_ESCROW_8453,
+  VITE_SEND_CLAIM_ESCROW_11155111: import.meta.env.VITE_SEND_CLAIM_ESCROW_11155111,
+  VITE_SEND_CLAIM_ESCROW_42161: import.meta.env.VITE_SEND_CLAIM_ESCROW_42161,
+  VITE_SEND_CLAIM_ESCROW_84532: import.meta.env.VITE_SEND_CLAIM_ESCROW_84532,
+};
+
+/**
+ * Read one allowlisted client env var by name.
+ *
+ * Returns undefined for anything not listed above — including a var that IS set in the build
+ * environment. That is the intended failure: an unlisted var is one nobody decided to publish, and
+ * silently reaching it is what got us here. If a lookup comes back empty and you expected a value,
+ * add the key to CLIENT_ENV rather than reaching for `import.meta.env[key]`.
+ */
+export function readEnv(key: string): string | undefined {
+  return CLIENT_ENV[key];
+}

--- a/app/src/config/networks.leak.test.ts
+++ b/app/src/config/networks.leak.test.ts
@@ -119,3 +119,37 @@ describe('client env is reachable only through the allowlist', () => {
     }
   });
 });
+
+/*
+ * A var whose name says it is secret has no business in client code.
+ *
+ * Nothing here leaked -- both Mapbox tokens in the env turned out to be `pk.` scoped. But the map
+ * component read VITE_MAPBOX_PRIVATE_TOKEN specifically when `import.meta.env.PROD`, which has it
+ * backwards: the production build is the one everybody can read. The comment above it said
+ * "private token for production", which is an instruction to put a secret there, and it would
+ * have been followed eventually.
+ */
+describe('no client code reads a variable that announces itself as secret', () => {
+  test('nothing reads a VITE_ var named PRIVATE / SECRET / _KEY', () => {
+    // `_KEY` alone is not enough of a signal (VITE_..._KEY names plenty of harmless things), so
+    // this looks for the words that only ever describe a credential.
+    const secretish = /import\.meta\.env\.VITE_[A-Z0-9_]*(PRIVATE|SECRET)[A-Z0-9_]*/;
+    const offenders = FILES.filter((f) => secretish.test(code(f.text)));
+    expect(offenders.map((f) => f.path)).toEqual([]);
+  });
+
+  test('the map uses the public token in every environment', () => {
+    const map = FILES.find((f) => f.path === 'components/DeedNFTMap.tsx')!;
+    const body = code(map.text);
+    expect(body).toContain('VITE_MAPBOX_PUBLIC_TOKEN');
+    // The PROD branch was the whole bug: it swapped the safe token out exactly when it mattered.
+    expect(body).not.toMatch(/import\.meta\.env\.PROD/);
+  });
+
+  test('the dist scan knows the secret token shapes too', () => {
+    const scanner = readFileSync(join(SRC, '..', 'scripts', 'scanBundleSecrets.mjs'), 'utf8');
+    for (const name of ['Mapbox secret token', 'Stripe secret key', 'AWS access key id']) {
+      expect(scanner).toContain(name);
+    }
+  });
+});

--- a/app/src/config/networks.leak.test.ts
+++ b/app/src/config/networks.leak.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC = join(import.meta.dirname, '..');
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === '_archive' || entry === 'node_modules') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...sourceFiles(full));
+    else if (/\.(ts|tsx)$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+
+/*
+ * Strip comments before scanning for a code pattern.
+ *
+ * The last two guards I wrote this way matched their own docblocks and passed on prose. A rule
+ * about what the code does has to be checked against the code.
+ */
+function code(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
+const FILES = sourceFiles(SRC).map((path) => ({ path: path.slice(SRC.length + 1), text: readFileSync(path, 'utf8') }));
+
+/*
+ * What the browser is allowed to hold.
+ *
+ * `import.meta.env.VITE_*` is not configuration the server reads — Vite inlines it at build time,
+ * so every one of these is a string literal in the bundle that anyone can curl and grep. An
+ * Alchemy endpoint is a URL with the API key in its path, so reading one here published the key.
+ * It was found in the deployed bundle and spent against Scroll and ZKsync, chains this codebase
+ * has never supported.
+ *
+ * Two layers guard it, because they fail differently: this one names the mistake at the point
+ * someone would repeat it, and scripts/scanBundleSecrets.mjs checks dist/ for the outcome
+ * regardless of how it got there.
+ */
+describe('the browser bundle holds no provider keys', () => {
+  test('nothing reads a keyed Alchemy endpoint from the client env', () => {
+    const offenders = FILES.filter((f) => /import\.meta\.env\.VITE_ALCHEMY/.test(f.text));
+    expect(offenders.map((f) => f.path)).toEqual([]);
+  });
+
+  test('no provider URL carries a key inline either', () => {
+    // A var name is one route to the same place; a pasted URL is another.
+    const keyed = /[a-z0-9-]+\.g\.alchemy\.com\/v2\/(?!\$\{|YOUR_|demo\b)[A-Za-z0-9_-]{16,}/;
+    const offenders = FILES.filter((f) => keyed.test(f.text));
+    expect(offenders.map((f) => f.path)).toEqual([]);
+  });
+
+  test('the client RPC resolver returns Infura or a public node, and nothing keyed', () => {
+    const networks = FILES.find((f) => f.path === 'config/networks.ts')!;
+    const resolver = networks.text.slice(networks.text.indexOf('export const getRpcUrlForNetwork'));
+    const body = resolver.slice(0, resolver.indexOf('\n};'));
+    expect(body).toContain('network.infuraUrl');
+    expect(body).toContain('network.rpcUrl');
+    expect(body).not.toContain('alchemy');
+  });
+
+  test('NetworkConfig has no field to put one in', () => {
+    // Deleting the reads but leaving the field invites the next person to fill it back in.
+    const networks = FILES.find((f) => f.path === 'config/networks.ts')!;
+    const iface = networks.text.slice(
+      networks.text.indexOf('export interface NetworkConfig'),
+      networks.text.indexOf('}', networks.text.indexOf('export interface NetworkConfig')),
+    );
+    expect(iface).toContain('infuraUrl');
+    expect(iface).not.toContain('alchemyUrl');
+  });
+
+  test('the example env does not hand someone the same footgun', () => {
+    const example = readFileSync(join(SRC, '..', '.env.example'), 'utf8');
+    expect(example).not.toMatch(/^VITE_ALCHEMY/m);
+  });
+
+  test('and the build runs the dist scan, so this cannot be the only check', () => {
+    const pkg = JSON.parse(readFileSync(join(SRC, '..', 'package.json'), 'utf8'));
+    expect(pkg.scripts.build).toContain('scanBundleSecrets.mjs');
+  });
+});
+
+/*
+ * The deeper rule, and the one that actually mattered.
+ *
+ * Removing the VITE_ALCHEMY_* readers did not stop the key shipping. `import.meta.env` is not an
+ * object Vite hands the browser — it substitutes the literal text `import.meta.env.VITE_FOO` at
+ * build time. Index it dynamically and there is no literal to substitute, so Vite serialises the
+ * entire env instead, and every VITE_ var in the build environment lands in the bundle whether
+ * anything reads it or not.
+ *
+ * That is why the fix is an allowlist rather than a deletion: the leak was never about which
+ * variables we read, it was about which ones we could reach.
+ */
+describe('client env is reachable only through the allowlist', () => {
+  test('nothing indexes import.meta.env dynamically', () => {
+    const dynamic = /import\.meta\.env\s*(\[|as\s+Record|\)\s*\[)/;
+    const offenders = FILES.filter((f) => f.path !== 'config/clientEnv.ts' && dynamic.test(code(f.text)));
+    expect(offenders.map((f) => f.path)).toEqual([]);
+  });
+
+  test('the allowlist itself only ever reads static literals', () => {
+    const env = FILES.find((f) => f.path === 'config/clientEnv.ts')!;
+    const body = code(env.text);
+    // Every read must be `import.meta.env.SOMETHING` — a bracket here would defeat the whole file.
+    expect(body).not.toMatch(/import\.meta\.env\s*\[/);
+    expect(body.match(/import\.meta\.env\.VITE_[A-Z0-9_]+/g)?.length ?? 0).toBeGreaterThan(30);
+  });
+
+  test('the helpers that used to index the env now go through it', () => {
+    for (const path of ['config/networks.ts', 'config/tokens.ts', 'config/send.ts']) {
+      const file = FILES.find((f) => f.path === path)!;
+      expect(code(file.text)).toContain('readEnv(');
+    }
+  });
+});

--- a/app/src/config/networks.ts
+++ b/app/src/config/networks.ts
@@ -1,10 +1,10 @@
 import { ACTIVE_CHAIN_ID, clearContracts } from '@/lib/clearNetwork';
+import { readEnv } from '@/config/clientEnv';
 export interface NetworkConfig {
   id: number;
   name: string;
   chainId: number;
   rpcUrl: string;
-  alchemyUrl?: string; // Optional Alchemy endpoint
   infuraUrl?: string;  // Optional Infura endpoint
   blockExplorer: string;
   contractAddress: string;
@@ -15,19 +15,32 @@ export interface NetworkConfig {
   };
 }
 
-// Get Infura project ID from environment variable
-// ⚠️ SECURITY NOTE: VITE_ prefixed variables are exposed to the browser
-// Infura Project IDs are safe to expose, but you MUST:
-// 1. Enable domain/origin restrictions in Infura dashboard
-// 2. Enable rate limiting
-// 3. Enable method allowlists
-// 4. Never expose the Project Secret (only use Project ID)
-// See docs/security-rpc-providers.md for details
+/*
+ * ⚠️ Anything read from `import.meta.env.VITE_*` here is PUBLIC.
+ *
+ * Vite inlines those at build time, so they end up as string literals in the shipped bundle --
+ * readable with a `curl` of the site and a `grep`, by anyone, with no credentials.
+ *
+ * This file used to read Alchemy endpoints that way, and an Alchemy endpoint is a URL with the
+ * API key in its path. The key was taken out of the deployed bundle and spent against chains this
+ * codebase has never supported: in one day, 27K requests on Scroll and 17K on ZKsync, against
+ * 1.9K of our own on Base Sepolia.
+ *
+ * So: no keyed provider endpoints in this file. The browser gets a public node. Anything needing
+ * a keyed provider goes through our server, which is the only place a key stays a secret -- see
+ * server/src/utils/rpc.ts.
+ *
+ * An Infura project ID is a different kind of thing and is meant to be public, but it is only
+ * safe with the dashboard restrictions on: domain/origin allowlist, rate limiting, method
+ * allowlist. Never the project SECRET.
+ */
 const INFURA_PROJECT_ID = import.meta.env.VITE_INFURA_PROJECT_ID || '';
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 function readAddressEnv(key: string, fallback: string = ZERO_ADDRESS): string {
-  const raw = (import.meta.env as Record<string, string | undefined>)[key];
+  // readEnv, not import.meta.env[key] — the dynamic form makes Vite inline the entire env into the
+  // bundle. See src/config/clientEnv.ts.
+  const raw = readEnv(key);
   if (raw && /^0x[a-fA-F0-9]{40}$/.test(raw)) {
     return raw;
   }
@@ -58,7 +71,6 @@ export const SUPPORTED_NETWORKS: NetworkConfig[] = [
     rpcUrl: INFURA_PROJECT_ID 
       ? `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`
       : 'https://eth.llamarpc.com', // Fallback to public RPC
-    alchemyUrl: import.meta.env.VITE_ALCHEMY_ETH_MAINNET,
     infuraUrl: import.meta.env.VITE_INFURA_ETH_MAINNET || (INFURA_PROJECT_ID ? `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}` : undefined),
     blockExplorer: 'https://etherscan.io',
     contractAddress: '0x0000000000000000000000000000000000000000', // Replace with actual address
@@ -75,7 +87,6 @@ export const SUPPORTED_NETWORKS: NetworkConfig[] = [
     rpcUrl: INFURA_PROJECT_ID
       ? `https://optimism-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`
       : 'https://mainnet.optimism.io',
-    alchemyUrl: import.meta.env.VITE_ALCHEMY_OPTIMISM_MAINNET,
     infuraUrl: import.meta.env.VITE_INFURA_OPTIMISM_MAINNET || (INFURA_PROJECT_ID ? `https://optimism-mainnet.infura.io/v3/${INFURA_PROJECT_ID}` : undefined),
     blockExplorer: 'https://optimistic.etherscan.io',
     contractAddress: '0x0000000000000000000000000000000000000000', // Replace with actual address
@@ -90,7 +101,6 @@ export const SUPPORTED_NETWORKS: NetworkConfig[] = [
     name: 'Base',
     chainId: 8453,
     rpcUrl: 'https://mainnet.base.org',
-    alchemyUrl: import.meta.env.VITE_ALCHEMY_BASE_MAINNET,
     blockExplorer: 'https://basescan.org',
     contractAddress: '0x0000000000000000000000000000000000000000', // Replace with actual address
     nativeCurrency: {
@@ -106,7 +116,6 @@ export const SUPPORTED_NETWORKS: NetworkConfig[] = [
     rpcUrl: INFURA_PROJECT_ID 
       ? `https://sepolia.infura.io/v3/${INFURA_PROJECT_ID}`
       : 'https://sepolia.infura.io/v3/your-project-id', // Fallback placeholder
-    alchemyUrl: import.meta.env.VITE_ALCHEMY_ETH_SEPOLIA,
     infuraUrl: import.meta.env.VITE_INFURA_ETH_SEPOLIA || (INFURA_PROJECT_ID ? `https://sepolia.infura.io/v3/${INFURA_PROJECT_ID}` : undefined),
     blockExplorer: 'https://sepolia.etherscan.io',
     contractAddress: '0x0000000000000000000000000000000000000000', // Replace with actual address
@@ -121,7 +130,6 @@ export const SUPPORTED_NETWORKS: NetworkConfig[] = [
     name: 'Base Sepolia',
     chainId: 84532,
     rpcUrl: 'https://sepolia.base.org',
-    alchemyUrl: import.meta.env.VITE_ALCHEMY_BASE_SEPOLIA,
     blockExplorer: 'https://sepolia.basescan.org',
     contractAddress: '0x1a4e89225015200f70e5a06f766399a3de6e21E6',
     nativeCurrency: {
@@ -137,7 +145,6 @@ export const SUPPORTED_NETWORKS: NetworkConfig[] = [
     rpcUrl: INFURA_PROJECT_ID 
       ? `https://arbitrum-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`
       : 'https://arb1.arbitrum.io/rpc',
-    alchemyUrl: import.meta.env.VITE_ALCHEMY_ARBITRUM_MAINNET,
     infuraUrl: import.meta.env.VITE_INFURA_ARBITRUM_MAINNET || (INFURA_PROJECT_ID ? `https://arbitrum-mainnet.infura.io/v3/${INFURA_PROJECT_ID}` : undefined),
     blockExplorer: 'https://arbiscan.io',
     contractAddress: '0x0000000000000000000000000000000000000000', // Replace with actual address
@@ -154,7 +161,6 @@ export const SUPPORTED_NETWORKS: NetworkConfig[] = [
     rpcUrl: INFURA_PROJECT_ID 
       ? `https://polygon-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`
       : 'https://polygon-rpc.com',
-    alchemyUrl: import.meta.env.VITE_ALCHEMY_POLYGON_MAINNET,
     infuraUrl: import.meta.env.VITE_INFURA_POLYGON_MAINNET || (INFURA_PROJECT_ID ? `https://polygon-mainnet.infura.io/v3/${INFURA_PROJECT_ID}` : undefined),
     blockExplorer: 'https://polygonscan.com',
     contractAddress: '0x0000000000000000000000000000000000000000', // Replace with actual address
@@ -169,7 +175,6 @@ export const SUPPORTED_NETWORKS: NetworkConfig[] = [
     name: 'Gnosis',
     chainId: 100,
     rpcUrl: 'https://rpc.gnosischain.com',
-    alchemyUrl: import.meta.env.VITE_ALCHEMY_GNOSIS_MAINNET,
     blockExplorer: 'https://gnosisscan.io',
     contractAddress: '0x0000000000000000000000000000000000000000', // Replace with actual address
     nativeCurrency: {
@@ -402,22 +407,25 @@ export const getNetworkInfo = (chainId: number) => {
 };
 
 // Get the best available RPC URL for a network
-// Priority: Alchemy > Infura > Public RPC
-// Alchemy is preferred by default because it has better free tier limits (300M compute units/month vs Infura's ~100k requests/day)
-// Environment variables needed:
-// - VITE_INFURA_PROJECT_ID: Your Infura project ID (used for Infura RPC URLs)
-// - VITE_ALCHEMY_ETH_MAINNET, VITE_ALCHEMY_ETH_SEPOLIA, etc.: Alchemy API keys (optional)
-// - VITE_INFURA_ETH_MAINNET, VITE_INFURA_ETH_SEPOLIA, etc.: Full Infura URLs (optional, overrides project ID)
+/**
+ * The RPC endpoint the BROWSER may use for a chain: Infura (public project ID) or a public node.
+ *
+ * Alchemy used to sit at the top of this order, on the reasoning that it has the better free
+ * tier. It does -- but reaching it from the browser meant shipping the key to the browser, and
+ * the tier was then spent by whoever lifted the key out of the bundle rather than by us. A
+ * generous quota is worth nothing when it is not yours.
+ *
+ * Keyed providers are server-side only now. The calls that genuinely need one -- balances, token
+ * metadata, transfers -- already go through our own API, so the callers left here are the legacy
+ * DeedNFT/portfolio contexts reading public contract state, which a public node serves fine.
+ *
+ * Env: VITE_INFURA_PROJECT_ID, or VITE_INFURA_<CHAIN> for a full URL. Both are public by
+ * construction -- read the note at the top of this file before adding a third.
+ */
 export const getRpcUrlForNetwork = (chainId: number): string | null => {
   const network = getNetworkByChainId(chainId);
   if (!network) return null;
 
-  // Priority: Alchemy > Infura > Public RPC
-  // Alchemy is preferred (better free tier limits: 300M compute units/month vs Infura's ~100k requests/day)
-  if (network.alchemyUrl) {
-    return network.alchemyUrl;
-  }
-  // Only use Infura if Alchemy is not available
   if (network.infuraUrl) {
     return network.infuraUrl;
   }

--- a/app/src/config/send.ts
+++ b/app/src/config/send.ts
@@ -1,4 +1,5 @@
 import { getCommonTokens } from '@/config/tokens';
+import { readEnv } from '@/config/clientEnv';
 
 const DEFAULT_SUPPORTED_CHAIN_IDS = [8453];
 
@@ -17,7 +18,7 @@ export function getSendSupportedChainIds(): number[] {
 
 export function getSendUsdcAddress(chainId: number): string | null {
   const overrideKey = `VITE_SEND_USDC_${chainId}`;
-  const overrideAddress = (import.meta.env[overrideKey] as string | undefined)?.trim();
+  const overrideAddress = readEnv(overrideKey)?.trim(); // see src/config/clientEnv.ts
   if (overrideAddress) {
     return overrideAddress;
   }
@@ -28,7 +29,7 @@ export function getSendUsdcAddress(chainId: number): string | null {
 
 export function getSendClaimEscrowAddress(chainId: number): string | null {
   const chainSpecificKey = `VITE_SEND_CLAIM_ESCROW_${chainId}`;
-  const chainSpecific = (import.meta.env[chainSpecificKey] as string | undefined)?.trim();
+  const chainSpecific = readEnv(chainSpecificKey)?.trim(); // see src/config/clientEnv.ts
   if (chainSpecific) {
     return chainSpecific;
   }

--- a/app/src/config/tokens.ts
+++ b/app/src/config/tokens.ts
@@ -1,4 +1,5 @@
 import { clearContracts } from '@/lib/clearNetwork';
+import { readEnv } from '@/config/clientEnv';
 /**
  * Common token configurations across all chains
  * Centralized token definitions to avoid duplication
@@ -43,7 +44,7 @@ function readClrUsdAddress(chainId: number): string {
   if (fromNetwork) return fromNetwork;
 
   const key = `VITE_CLRUSD_${chainId}`;
-  const raw = (import.meta.env as Record<string, string | undefined>)[key];
+  const raw = readEnv(key); // not import.meta.env[key] — see src/config/clientEnv.ts
   if (raw && /^0x[a-fA-F0-9]{40}$/.test(raw) && raw !== ZERO_ADDRESS) {
     return raw;
   }

--- a/app/src/context/DeedNFTContext.tsx
+++ b/app/src/context/DeedNFTContext.tsx
@@ -571,7 +571,8 @@ export const DeedNFTProvider: React.FC<{ children: React.ReactNode }> = ({ child
       if (address && !latitude && !longitude) {
         console.log(`🌍 Geocoding address for token ${deedNFT.tokenId}: ${address}`);
         try {
-          const mapboxToken = import.meta.env.VITE_MAPBOX_PUBLIC_TOKEN || import.meta.env.VITE_MAPBOX_PRIVATE_TOKEN;
+          // Public token only — anything read here lands in the bundle. See DeedNFTMap.tsx.
+          const mapboxToken = import.meta.env.VITE_MAPBOX_PUBLIC_TOKEN;
           if (!mapboxToken) {
             console.warn('Mapbox token not available for geocoding');
             return { address };


### PR DESCRIPTION
> **The key is still compromised.** This stops the bleeding; it does not undo it. Rotate in the Alchemy dashboard and update Railway.

## What the 430K/day actually was

Not us. **Scroll 27K and ZKsync 17.4K** — neither chain appears anywhere in this codebase. Our real footprint was **Base Sepolia 1.9K**. `eth_getBalance` at 211.3K against `eth_call` at 1.5K is a balance scraper, not an app.

I got the key the same way they did: `curl` the deployed bundle, `grep` the chunks. No credentials.

## The obvious cause was not the real one

`networks.ts` read eight `VITE_ALCHEMY_*` endpoints, and an Alchemy endpoint is a URL with the key in its path. Removing those reads was necessary — and changed nothing. **The next build leaked the key again**, from a file that had never mentioned Alchemy.

`import.meta.env` is not an object the browser receives. Vite finds the literal text `import.meta.env.VITE_FOO` and substitutes the value — so a *static* read publishes exactly one variable. Three helpers indexed it *dynamically* to look up per-chain addresses:

```ts
const raw = (import.meta.env as Record<string, string | undefined>)[key];
```

No literal to substitute, so Vite serialises the **whole env object** into the bundle. Every `VITE_` var in the build environment ships, read or not.

## The fix is an allowlist, not a deletion

`config/clientEnv.ts` spells out all 40 computed-name vars, one line each; `readEnv()` serves only those. Adding a chain means adding its five lines — tedious on purpose. The tedium *is* the allowlist.

`getRpcUrlForNetwork` now returns Infura or a public node. It already fell back to `network.rpcUrl`, so the legacy DeedNFT/portfolio contexts keep working; everything Clear uses goes through our server.

## What else was in that env dump — I checked all of it

Everything else is public by design: project IDs, publishable keys, Vercel metadata, contract addresses. **Alchemy was the only real secret in there.** No `sk.` token, Stripe secret, or AWS key ever shipped. I said the exposure might be wider; it wasn't.

One live trap though: `DeedNFTMap` read `VITE_MAPBOX_PRIVATE_TOKEN` when `import.meta.env.PROD`, commented "private token for production" — backwards, since the production build is the one everybody can read. Both Mapbox tokens in the env are `pk.` scoped so nothing secret shipped, but the line was an instruction to put an `sk.` token there. Now always the public token, which is what `pk.` is for.

## Two guards, failing differently

| | catches |
|---|---|
| `networks.leak.test.ts` | the mistake where someone would repeat it — dynamic env access, keyed URLs, secret-named vars |
| `scripts/scanBundleSecrets.mjs` | the *outcome* in `dist/`, however it got there — wired into `npm run build` |

The test strips comments before matching, because the last two guards I wrote this way matched their own docblocks.

The scanner found **24 live instances** in the stale `dist/` before this change, and now also knows Mapbox `sk.`, Stripe secret keys, AWS access key ids and PEM private keys. Every guard verified by reintroducing the bug.

**Before:** 24 keys in dist. **After:** 253 files, none. 470 tests, lint unchanged (all remaining errors pre-existing).

## Elsewhere

- `feat/clearpay-app-redesign` — both commits cherry-picked and pushed; it has diverged enough that a later merge could have resurrected the dynamic reads.
- `chore/oz-v5-migration` — touches no app files; merging dev is enough.
- `colonyCDapp` (2301 files), `untitled-project/apps/web` (28), `Archive` (54) — scanned, no dynamic env access.

## Verify after deploy

```bash
curl -s https://app.useclear.org/assets/$(curl -s https://app.useclear.org/ | grep -o 'index-[A-Za-z0-9_-]*\.js') | grep -c 'g.alchemy.com/v2/'
```