### PR TITLE
Take the server off the VITE_ var, and stop the docs teaching it

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -362,11 +362,11 @@ The application uses a comprehensive set of reusable UI components built with sh
    
    Edit `.env` and add your API keys:
    ```env
-   # Alchemy API Keys (optional - for production)
-   VITE_ALCHEMY_ETH_MAINNET=https://eth-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-   VITE_ALCHEMY_ETH_SEPOLIA=https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY
-   VITE_ALCHEMY_BASE_MAINNET=https://base-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-   VITE_ALCHEMY_BASE_SEPOLIA=https://base-sepolia.g.alchemy.com/v2/YOUR_API_KEY
+   # NOTE: there is no VITE_ALCHEMY_* here, and there must not be. Vite compiles VITE_* into
+   # the bundle it serves, and an Alchemy URL carries the API key in its path — setting one
+   # publishes the key to every visitor. Ours was taken that way and spent on chains we do not
+   # even support. The Alchemy key goes in the SERVER env as ALCHEMY_API_KEY; the browser uses
+   # public RPC, and anything needing the key goes through the API.
 
    # Infura API Keys (optional - for production)
    VITE_INFURA_ETH_MAINNET=https://mainnet.infura.io/v3/YOUR_PROJECT_ID
@@ -412,9 +412,14 @@ The project uses several tools to maintain code quality:
 ### Required
 None for development (uses public RPC endpoints)
 
-### Optional (for production)
-- `VITE_ALCHEMY_*` - Alchemy API endpoints for better performance
-- `VITE_INFURA_*` - Infura API endpoints as fallback
+### Optional
+- `VITE_INFURA_PROJECT_ID` / `VITE_INFURA_*` - Infura endpoints. A project ID is public by design,
+  but restrict it by domain in the Infura dashboard.
+
+### Never in the client
+- `VITE_ALCHEMY_*` - removed. A VITE_ var is compiled into the public bundle, and an Alchemy URL
+  has the key in it. Set `ALCHEMY_API_KEY` on the server instead. `npm run build` runs
+  `scripts/scanBundleSecrets.mjs`, which fails the build if a provider key reaches `dist/`.
 
 ## Networks
 

--- a/app/server/src/services/membershipRegistryService.ts
+++ b/app/server/src/services/membershipRegistryService.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers';
+import { getRpcUrl } from '../utils/rpc.js';
 import type { MemberMembershipPlan, MemberRecord } from './memberStore.js';
 
 const MEMBERSHIP_REGISTRY_ABI = [
@@ -42,13 +43,19 @@ function normalizePrivateKey(rawValue: string | undefined): string | null {
   return null;
 }
 
+/*
+ * Server RPC comes from the shared resolver, not from a VITE_ var.
+ *
+ * This used to fall back to `process.env.VITE_ALCHEMY_BASE_SEPOLIA` — a keyed Alchemy URL, read on
+ * the server, under a name that means "compile this into the browser bundle". It worked, which is
+ * why nobody noticed it was reading the same variable that was publishing our key.
+ *
+ * getRpcUrl already does custom → Alchemy (built from ALCHEMY_API_KEY) → public node, and it reads
+ * BASE_SEPOLIA_RPC_URL as the custom, so both explicit overrides below survive. One key, one
+ * resolver, no VITE_ anything.
+ */
 function membershipRpcUrl(): string {
-  return (
-    process.env.MEMBERSHIP_RPC_URL?.trim()
-    || process.env.BASE_SEPOLIA_RPC_URL?.trim()
-    || process.env.VITE_ALCHEMY_BASE_SEPOLIA?.trim()
-    || 'https://sepolia.base.org'
-  );
+  return process.env.MEMBERSHIP_RPC_URL?.trim() || getRpcUrl(membershipChainId());
 }
 
 function membershipChainId(): number {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -149,11 +149,8 @@ export const SUPPORTED_NETWORKS = [
 Create `app/.env`:
 
 ```env
-# API Keys (optional - for production)
-VITE_ALCHEMY_ETH_MAINNET=https://eth-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-VITE_ALCHEMY_ETH_SEPOLIA=https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY
-VITE_ALCHEMY_BASE_MAINNET=https://base-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-VITE_ALCHEMY_BASE_SEPOLIA=https://base-sepolia.g.alchemy.com/v2/YOUR_API_KEY
+# No VITE_ALCHEMY_* — VITE_* is compiled into the public bundle and an Alchemy URL contains the
+# API key. Put the key in the server env as ALCHEMY_API_KEY; the browser uses public RPC.
 
 # Infura API Keys (optional - for production)
 VITE_INFURA_ETH_MAINNET=https://mainnet.infura.io/v3/YOUR_PROJECT_ID
@@ -360,7 +357,8 @@ export const NETWORK_CONFIG = {
   ethereum: {
     chainId: 1,
     name: "Ethereum",
-    rpcUrl: process.env.VITE_ALCHEMY_ETH_MAINNET,
+    // Public RPC only — never a keyed provider URL. See the note in networks.ts.
+    rpcUrl: import.meta.env.VITE_INFURA_ETH_MAINNET,
     contracts: {
       DeedNFT: "0x...",
       Validator: "0x...",


### PR DESCRIPTION
Deleting the eight `VITE_ALCHEMY_*` vars from Vercel turned up two things that would have quietly kept the pattern alive.

## The server was reading one

`membershipRegistryService`'s RPC resolver fell back to:

```ts
|| process.env.VITE_ALCHEMY_BASE_SEPOLIA?.trim()
```

A keyed Alchemy URL, read **on the server**, under a name that means *"compile this into the browser bundle."* It worked — which is exactly why nobody noticed it was reading the same variable that was publishing our key.

Now it uses the shared `getRpcUrl`, which already does custom → Alchemy (built from `ALCHEMY_API_KEY`) → public node, and already reads `BASE_SEPOLIA_RPC_URL` as the custom. Both explicit overrides survive. One key, one resolver.

## And the docs told people to do it

`app/README.md` and `docs/installation.md` both listed the four `VITE_ALCHEMY_*` endpoints under **"optional - for production"** — the instruction that produced this in the first place, and the one place a fix in code cannot reach. Replaced with why not to, and where the key actually goes.

## Vercel state

| | |
|---|---|
| 8 × `VITE_ALCHEMY_*` | **deleted**, every environment |
| `VITE_MAPBOX_PRIVATE_TOKEN` | **deleted** — unread since the map switched to the public token |
| `VITE_STRIPE_PUBLISHABLE_KEY` | kept; a publishable key is meant to be published |

470 tests. Server typechecks — the two remaining errors are in `@coinbase/cdp-sdk` and predate this.