### PR TITLE
Push to the connection, not to the polling subscription

### DIFF
--- a/app/server/src/services/websocketBroadcast.test.ts
+++ b/app/server/src/services/websocketBroadcast.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { websocketService } from './websocketService.js';
+
+/*
+ * The bug this pins down.
+ *
+ * `clients` is the POLLING registry. A backgrounded tab emits `unsubscribe` so the server stops
+ * spending Alchemy calls on it, which deletes its entry. `broadcastToAddress` used to iterate that
+ * same map — so the cost optimisation quietly made every backgrounded tab unreachable, which is
+ * precisely the phone in your pocket that the push was built to reach.
+ *
+ * These drive the real singleton rather than asserting on source text. The previous guards for
+ * this feature checked that files *mentioned* the wiring, and stayed green the whole time it did
+ * not work.
+ */
+
+type Emitted = { event: string; data: unknown };
+
+function fakeSocket(id: string, connected = true) {
+  const sent: Emitted[] = [];
+  return { id, connected, sent, emit: (event: string, data: unknown) => sent.push({ event, data }) };
+}
+
+function install(sockets: ReturnType<typeof fakeSocket>[]) {
+  const map = new Map(sockets.map((s) => [s.id, s]));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const service = websocketService as any;
+  service.io = { sockets: { sockets: map } };
+  service.clients = new Map();
+  service.connectionAddress = new Map();
+  return service;
+}
+
+const WALLET = '0x7ec1D6b69398af413edC94692FB167A3864A86cF';
+
+describe('a push reaches a connection that stopped polling', () => {
+  let socket: ReturnType<typeof fakeSocket>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let service: any;
+
+  beforeEach(() => {
+    socket = fakeSocket('sock-1');
+    service = install([socket]);
+  });
+
+  test('a backgrounded tab — identified, not subscribed — still gets the event', () => {
+    // Exactly the state after `unsubscribe`: known connection, no polling entry.
+    service.connectionAddress.set('sock-1', WALLET.toLowerCase());
+    service.broadcastToAddress(WALLET, 'chain:changed', { at: 'now' });
+    expect(socket.sent).toEqual([{ event: 'chain:changed', data: { at: 'now' } }]);
+  });
+
+  test('and being in the polling registry is not what earns it', () => {
+    // The inverse: subscribed but never identified. Reaching this socket would mean broadcast is
+    // still reading `clients`, which is the bug.
+    service.clients.set('sock-1', { address: WALLET.toLowerCase(), chainIds: [84532], subscriptions: [] });
+    service.broadcastToAddress(WALLET, 'chain:changed', {});
+    expect(socket.sent).toEqual([]);
+  });
+
+  test('a different wallet is not told about someone else’s deposit', () => {
+    service.connectionAddress.set('sock-1', '0x000000000000000000000000000000000000dead');
+    service.broadcastToAddress(WALLET, 'chain:changed', {});
+    expect(socket.sent).toEqual([]);
+  });
+
+  test('address matching survives checksum casing', () => {
+    service.connectionAddress.set('sock-1', WALLET.toLowerCase());
+    service.broadcastToAddress(WALLET.toUpperCase().replace('0X', '0x'), 'chain:changed', {});
+    expect(socket.sent.length).toBe(1);
+  });
+
+  test('a dead socket is skipped rather than thrown at', () => {
+    const dead = fakeSocket('sock-2', false);
+    service = install([dead]);
+    service.connectionAddress.set('sock-2', WALLET.toLowerCase());
+    service.broadcastToAddress(WALLET, 'chain:changed', {});
+    expect(dead.sent).toEqual([]);
+  });
+
+  test('every identified connection for the wallet gets it, not just the first', () => {
+    // One member, several devices — the whole point.
+    const phone = fakeSocket('sock-2');
+    service = install([socket, phone]);
+    service.connectionAddress.set('sock-1', WALLET.toLowerCase());
+    service.connectionAddress.set('sock-2', WALLET.toLowerCase());
+    service.broadcastToAddress(WALLET, 'chain:changed', {});
+    expect([socket.sent.length, phone.sent.length]).toEqual([1, 1]);
+  });
+});
+
+describe('the registry outlives a subscription', () => {
+  const SOURCE = readFileSync(join(import.meta.dirname, 'websocketService.ts'), 'utf8');
+
+  function handler(name: string): string {
+    const start = SOURCE.indexOf(`socket.on('${name}'`);
+    expect(start).toBeGreaterThan(-1);
+    return SOURCE.slice(start, SOURCE.indexOf("socket.on('", start + 20));
+  }
+
+  test('unsubscribe drops the polling entry and nothing else', () => {
+    const body = handler('unsubscribe');
+    expect(body).toContain('this.clients.delete(socket.id)');
+    expect(body).not.toContain('connectionAddress');
+  });
+
+  test('disconnect is the only thing that forgets a connection', () => {
+    expect(handler('disconnect')).toContain('this.connectionAddress.delete(socket.id)');
+  });
+
+  test('the client says who it is before it decides whether to poll', () => {
+    const hook = readFileSync(join(import.meta.dirname, '../../../src/hooks/useWebSocket.ts'), 'utf8');
+    const onConnect = hook.slice(hook.indexOf("socket.on('connect'"), hook.indexOf('const handleVisibility'));
+    expect(onConnect.indexOf("emit('identify'")).toBeGreaterThan(-1);
+    // Unconditional: the guard below it is what gates polling, and identify must sit above it.
+    expect(onConnect.indexOf("emit('identify'")).toBeLessThan(onConnect.indexOf('document.hidden'));
+  });
+});

--- a/app/server/src/services/websocketService.ts
+++ b/app/server/src/services/websocketService.ts
@@ -17,6 +17,20 @@ interface ClientSubscription {
 class WebSocketService {
   private io: SocketIOServer | null = null;
   private clients: Map<string, ClientSubscription> = new Map();
+  /*
+   * Who is on the other end of each live connection, for pushes.
+   *
+   * Deliberately NOT `clients`. That map is the POLLING registry: a tab that goes to the
+   * background emits `unsubscribe` so the server stops burning Alchemy calls on it, and that
+   * deletes its entry. Broadcasts used to read the same map, so the cost optimisation silently
+   * made every backgrounded tab unreachable — which is exactly the phone the push existed to
+   * reach. A member would deposit on a desktop and the phone in their pocket, having correctly
+   * stopped polling, would also have stopped listening.
+   *
+   * This one is keyed to the CONNECTION, not the subscription: set when a socket says who it is,
+   * cleared only when the socket actually goes away. Polling stays gated; delivery does not.
+   */
+  private connectionAddress: Map<string, string> = new Map();
   private priceUpdateInterval: number | null = null;
 
   /**
@@ -35,6 +49,20 @@ class WebSocketService {
     this.io.on('connection', (socket: Socket) => {
       console.log(`[WebSocket] Client connected: ${socket.id}`);
 
+      /*
+       * "This connection belongs to this wallet" — and nothing more.
+       *
+       * A hidden tab must not be polled, but it must still be reachable, so this is separate from
+       * `subscribe` on purpose. The client emits it on every connect regardless of visibility;
+       * `subscribe` remains the thing that costs money.
+       */
+      socket.on('identify', (data: { address?: string }) => {
+        const address = data?.address;
+        if (typeof address === 'string' && address) {
+          this.connectionAddress.set(socket.id, address.toLowerCase());
+        }
+      });
+
       // Subscribe to updates
       socket.on('subscribe', async (data: { address: string; chainIds?: number[]; subscriptions?: string[] }) => {
         // 'nfts' is NOT a default. The Deed views that consumed it are archived and the client
@@ -46,6 +74,8 @@ class WebSocketService {
         // how T-Deeds and bonds will ask once there is a surface for them.
         const { address, chainIds = [], subscriptions = ['balances', 'transactions'] } = data;
         
+        // Also identify, so a client from before `identify` existed is still reachable while visible.
+        this.connectionAddress.set(socket.id, address.toLowerCase());
         this.clients.set(socket.id, {
           address: address.toLowerCase(),
           chainIds: chainIds.length > 0 ? chainIds : [1, 8453, 100, 11155111], // Default chains
@@ -86,6 +116,8 @@ class WebSocketService {
 
       // Handle disconnection
       socket.on('disconnect', () => {
+        // Only here — an `unsubscribe` means "stop polling me", not "stop talking to me".
+        this.connectionAddress.delete(socket.id);
         const subscription = this.clients.get(socket.id);
         if (subscription) {
           // Check if any other clients are monitoring this address
@@ -473,12 +505,14 @@ class WebSocketService {
   async broadcastToAddress(address: string, event: string, data: any) {
     if (!this.io) return;
 
-    for (const [socketId, subscription] of this.clients.entries()) {
-      if (subscription.address.toLowerCase() === address.toLowerCase()) {
-        const socket = this.io.sockets.sockets.get(socketId);
-        if (socket && socket.connected) {
-          socket.emit(event, data);
-        }
+    // connectionAddress, not clients: see the field comment. Reading the polling registry here is
+    // what made a backgrounded phone unreachable.
+    const wanted = address.toLowerCase();
+    for (const [socketId, connectionWallet] of this.connectionAddress.entries()) {
+      if (connectionWallet !== wanted) continue;
+      const socket = this.io.sockets.sockets.get(socketId);
+      if (socket && socket.connected) {
+        socket.emit(event, data);
       }
     }
   }

--- a/app/src/hooks/useWebSocket.ts
+++ b/app/src/hooks/useWebSocket.ts
@@ -62,6 +62,15 @@ export function useWebSocket(
       console.log('[WebSocket] Connected');
       setIsConnected(true);
       isConnectedRef.current = true;
+      /*
+       * Say who we are on every connect, hidden or not.
+       *
+       * `identify` costs nothing — it registers this connection's wallet so the server can PUSH to
+       * it. `subscribe` is the expensive half (balance/transaction polling) and stays gated below.
+       * Conflating the two is what made a backgrounded phone miss the very updates the push was
+       * built to deliver: it unsubscribed to save Alchemy calls and stopped being reachable.
+       */
+      socket.emit('identify', { address });
       // Don't start polling for a tab that's already in the background; visibilitychange resumes it.
       if (!document.hidden) socket.emit('subscribe', subPayload);
     });


### PR DESCRIPTION
You were right that something was missed, and it was mine.

## The bug

`clients` is the **polling** registry. A backgrounded tab emits `unsubscribe` so the server stops spending Alchemy calls on it — and that deletes its entry:

```ts
this.clients.delete(socket.id);
```

`broadcastToAddress` iterated that same map. So the cost optimisation quietly made every backgrounded tab unreachable — which is precisely the phone in your pocket the push was built to reach.

I shipped the push on top of that and told you it would reach every device. It couldn't. A deposit on a desktop broadcast into a map the phone had correctly removed itself from the moment it stopped being looked at.

## Two registries, because there are two questions

| map | question | gated by visibility? |
|---|---|---|
| `clients` | may I poll you? | **yes** — Alchemy savings untouched |
| `connectionAddress` | who are you? | no — cleared only on real disconnect |

The client emits `identify` on every connect, hidden or not, **above** the visibility check that gates `subscribe`. Identifying costs nothing; subscribing is the half that costs money. `subscribe` also identifies, so a client running older JS stays reachable while visible.

## The tests actually run the code this time

They drive the real singleton with fake sockets rather than asserting that files mention the wiring. That distinction matters here — the previous guards for this feature were text matches, and they stayed green for the entire time it didn't work.

Reverting the one line in `broadcastToAddress` makes **4 of the 9 fail**.

479 app tests, 149 server tests, server typechecks clean.

## What this does and does not explain

This certainly fixes cross-device — the desktop → phone case. Whether it also fixes the same-tab credit/vesting lag depends on whether your tab was ever hidden between the deposit and looking (a wallet prompt, an app switch, the phone locking). If it still lags on a tab that never left the foreground, there's a second cause and this narrows where to look.