### PR TITLE
One notification state instead of three

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "@/context/ThemeContext";
 import { DeedNFTProvider } from "@/context/DeedNFTContext";
 import { XMTPProvider } from "@/context/XMTPContext";
 import { NotificationProvider } from "@/context/NotificationContext";
+import { ClearNotificationsProvider } from "@/context/ClearNotificationsContext";
 import { ModalProvider } from "@/context/ModalContext";
 import { PortfolioProvider } from "@/context/PortfolioContext";
 import { GlobalModalsProvider } from "@/context/GlobalModalsContext";
@@ -81,6 +82,7 @@ function App() {
       <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
         <PortfolioProvider>
           <NotificationProvider>
+            <ClearNotificationsProvider>
             <DeedNFTProvider>
               <XMTPProvider>
                 <ModalProvider>
@@ -154,6 +156,7 @@ function App() {
                 </ModalProvider>
               </XMTPProvider>
             </DeedNFTProvider>
+            </ClearNotificationsProvider>
           </NotificationProvider>
         </PortfolioProvider>
       </ThemeProvider>

--- a/app/src/components/app-ui/NotificationsMenu.tsx
+++ b/app/src/components/app-ui/NotificationsMenu.tsx
@@ -4,7 +4,7 @@ import {
   Bell, ArrowDownLeft, ArrowUpRight, Receipt, Sparkles, CreditCard, Clock, HandCoins, Trash2, ShieldCheck, type LucideIcon,
 } from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
-import { useNotifications } from '@/hooks/useNotifications';
+import { useNotifications } from '@/context/ClearNotificationsContext';
 import { useXMTP } from '@/context/XMTPContext';
 import { IS_LIVE_APP } from '@/lib/clearNetwork';
 import { cn } from '@/lib/utils';

--- a/app/src/components/shell/AppShell.tsx
+++ b/app/src/components/shell/AppShell.tsx
@@ -15,7 +15,7 @@ import { PayProvider } from '@/context/PayContext';
 import { CreditProvider } from '@/context/CreditContext';
 import { MoneyActionsProvider } from '@/context/MoneyActionsContext';
 import { useGlobalModals } from '@/context/GlobalModalsContext';
-import { useNotifications } from '@/hooks/useNotifications';
+import { useNotifications } from '@/context/ClearNotificationsContext';
 import { SETTINGS } from '@/data/clearPlaceholder';
 import XMTPMessaging from '@/components/XMTPMessaging';
 

--- a/app/src/context/ClearNotificationsContext.tsx
+++ b/app/src/context/ClearNotificationsContext.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import { useNotificationsState } from '@/hooks/useNotifications';
+
+/*
+ * One notification state for the whole app.
+ *
+ * `useNotificationsState` was called directly by three surfaces — the bell menu, the inbox page and
+ * the shell's badge. A hook is not shared state: each got its own rows, its own optimistic
+ * `readIds` ref, and its own WebSocket. Marking a row read in the bell updated the bell, while the
+ * badge kept showing the old count until its own 20-second poll came round. That is why marking a
+ * notification read appeared not to take, and why doing it twice "worked" — the second click
+ * landed on whichever copy you were looking at.
+ *
+ * It was also most of the seven sockets one tab was opening against the server.
+ *
+ * So the hook is called exactly once, here, and everything else reads this context. Same public
+ * API, so call sites did not change.
+ */
+type NotificationsValue = ReturnType<typeof useNotificationsState>;
+
+const ClearNotificationsContext = createContext<NotificationsValue | null>(null);
+
+export function ClearNotificationsProvider({ children }: { children: ReactNode }) {
+  const value = useNotificationsState();
+  return <ClearNotificationsContext.Provider value={value}>{children}</ClearNotificationsContext.Provider>;
+}
+
+/**
+ * The app's notifications: rows, unread count, and the read/dismiss actions.
+ *
+ * Throws outside the provider rather than quietly handing back an empty second copy — a silent
+ * fallback here would reproduce exactly the bug this context exists to fix.
+ */
+export function useNotifications(): NotificationsValue {
+  const value = useContext(ClearNotificationsContext);
+  if (!value) throw new Error('useNotifications must be used within a ClearNotificationsProvider');
+  return value;
+}

--- a/app/src/context/notificationsSingleInstance.test.ts
+++ b/app/src/context/notificationsSingleInstance.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC = join(import.meta.dirname, '..');
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === '_archive' || entry === 'node_modules') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...sourceFiles(full));
+    else if (/\.(ts|tsx)$/.test(entry) && !entry.endsWith('.test.ts')) out.push(full);
+  }
+  return out;
+}
+
+const FILES = sourceFiles(SRC).map((path) => ({
+  path: path.slice(SRC.length + 1),
+  text: readFileSync(path, 'utf8'),
+}));
+
+/*
+ * Why this is worth a test at all.
+ *
+ * `useNotificationsState` holds rows, an optimistic `readIds` ref and a WebSocket. A hook is not
+ * shared state, so every extra caller is a second, silently divergent copy. Three surfaces called
+ * it — the bell, the inbox page, the shell badge — and marking a row read in one left the others
+ * showing it unread until their own 20-second poll. Clicking twice "worked" because the second
+ * click landed on the copy being looked at.
+ *
+ * Nothing about that is visible in a type error or a render. The only durable guard is the count
+ * of callers, so that is what this asserts.
+ */
+describe('notifications have exactly one state', () => {
+  test('only the provider calls the stateful hook', () => {
+    // Skip the file that declares it — `function useNotificationsState(` is a definition, not a call.
+    const callers = FILES.filter(
+      (f) => f.path !== 'hooks/useNotifications.ts' && /(?<!function )useNotificationsState\s*\(/.test(f.text),
+    ).map((f) => f.path);
+    expect(callers).toEqual(['context/ClearNotificationsContext.tsx']);
+  });
+
+  test('and only the provider imports it', () => {
+    const importers = FILES.filter((f) => /import[^;]*useNotificationsState[^;]*from/.test(f.text)).map((f) => f.path);
+    expect(importers).toEqual(['context/ClearNotificationsContext.tsx']);
+  });
+
+  test('every surface reads the shared context instead', () => {
+    for (const path of [
+      'components/app-ui/NotificationsMenu.tsx',
+      'pages/app/InboxRoute.tsx',
+      'components/shell/AppShell.tsx',
+    ]) {
+      const file = FILES.find((f) => f.path === path)!;
+      expect(file.text).toContain("from '@/context/ClearNotificationsContext'");
+      expect(file.text).not.toContain("useNotifications } from '@/hooks/useNotifications'");
+    }
+  });
+
+  test('the provider is mounted, or every consumer throws', () => {
+    const app = FILES.find((f) => f.path === 'App.tsx')!;
+    expect(app.text).toContain('<ClearNotificationsProvider>');
+    expect(app.text).toContain('</ClearNotificationsProvider>');
+  });
+
+  test('missing the provider fails loudly rather than handing back a second copy', () => {
+    // A null-object fallback here would restore the exact bug, quietly.
+    const ctx = FILES.find((f) => f.path === 'context/ClearNotificationsContext.tsx')!;
+    expect(ctx.text).toContain('throw new Error');
+  });
+
+  test('the unread count is derived from the rows, not tracked alongside them', () => {
+    const hook = FILES.find((f) => f.path === 'hooks/useNotifications.ts')!;
+    // Four hand-maintained adjustments were four chances to disagree with the list. One of them
+    // did: `notification:new` incremented even when the row was already present.
+    expect(hook.text).not.toContain('setUnreadCount');
+    expect(hook.text).toMatch(/const unreadCount = notifications\.reduce/);
+  });
+});

--- a/app/src/hooks/useNotifications.ts
+++ b/app/src/hooks/useNotifications.ts
@@ -14,13 +14,30 @@ import { usePushRegistration } from '@/hooks/usePushRegistration';
 /**
  * Persistent in-app notifications from the backend (wallet-scoped). Fetches on mount + focus, receives
  * new ones live over the WebSocket (`notification:new`), and applies read/dismiss optimistically.
+ *
+ * **Call this once, from the provider.** Everything else uses `useNotifications` from
+ * `@/context/ClearNotificationsContext`, which shares this one instance.
+ *
+ * It used to be called directly by the bell, the inbox page and the shell's badge — three
+ * independent copies of the state, each with its own `readIds` ref and its own socket. Marking a
+ * row read in the bell updated the bell; the badge went on showing the old count until its own
+ * 20-second poll came round, which is why it took two goes to make a notification look read. The
+ * three sockets were also most of the "seven connections from one tab" in the server logs.
  */
-export function useNotifications() {
+export function useNotificationsState() {
   const { address, isConnected } = useAppKitAccount();
   const { socket } = useWebSocket(address, isConnected);
   const { enablePush } = usePushRegistration();
   const [notifications, setNotifications] = useState<ApiNotification[]>([]);
-  const [unreadCount, setUnreadCount] = useState(0);
+  /*
+   * Derived, never stored.
+   *
+   * As its own state it had to be adjusted by hand at four sites, and each was a chance to drift
+   * from the list: `notification:new` incremented even when the row was already present, so a
+   * repeat event bumped a badge that described nothing on screen. A count of unread rows is a fact
+   * about the rows — computing it cannot disagree with them.
+   */
+  const unreadCount = notifications.reduce((count, n) => count + (n.read ? 0 : 1), 0);
   // Ids the user just dismissed/read locally. A poll or focus refetch can start BEFORE the archive/read
   // commits server-side and then clobber the optimistic update (the row reappears / un-reads). These sets
   // guard every refresh + live socket event so that never happens. Cleared on wallet change.
@@ -30,7 +47,6 @@ export function useNotifications() {
   const refresh = useCallback(async () => {
     if (!address || !isConnected) {
       setNotifications([]);
-      setUnreadCount(0);
       return;
     }
     const res = await getNotifications(address);
@@ -38,7 +54,6 @@ export function useNotifications() {
       .filter((n) => !dismissedIds.current.has(n.id))
       .map((n) => (readIds.current.has(n.id) ? { ...n, read: true } : n));
     setNotifications(list);
-    setUnreadCount(list.reduce((c, n) => c + (n.read ? 0 : 1), 0));
   }, [address, isConnected]);
 
   // Drop the optimistic-action guards when the connected wallet changes.
@@ -96,8 +111,11 @@ export function useNotifications() {
     if (!socket) return;
     const onNew = (n: ApiNotification) => {
       if (dismissedIds.current.has(n.id)) return; // don't resurrect a just-dismissed row
+      if (readIds.current.has(n.id)) return; // nor un-read one the user just read
+      // Count only what was actually added. This used to increment unconditionally, so a repeated
+      // `notification:new` for a row already in the list left the list alone and still bumped the
+      // badge — a count that no longer described anything on screen.
       setNotifications((prev) => (prev.some((x) => x.id === n.id) ? prev : [n, ...prev].slice(0, 40)));
-      setUnreadCount((c) => c + 1);
       // Money moved (deposit landed / cash-out sent) → refresh balances + activity right away.
       if (n.kind === 'received' || n.kind === 'sent') window.dispatchEvent(new Event('clear:activity'));
     };
@@ -110,11 +128,7 @@ export function useNotifications() {
   const markRead = useCallback(
     (id: string) => {
       readIds.current.add(id);
-      setNotifications((prev) => {
-        const was = prev.find((n) => n.id === id && !n.read);
-        if (was) setUnreadCount((c) => Math.max(0, c - 1));
-        return prev.map((n) => (n.id === id ? { ...n, read: true } : n));
-      });
+      setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
       if (address) void markNotificationRead(address, id).catch(() => {});
     },
     [address],
@@ -125,18 +139,13 @@ export function useNotifications() {
       prev.forEach((n) => readIds.current.add(n.id));
       return prev.map((n) => ({ ...n, read: true }));
     });
-    setUnreadCount(0);
     if (address) void markAllNotificationsRead(address).catch(() => {});
   }, [address]);
 
   const dismiss = useCallback(
     (id: string) => {
       dismissedIds.current.add(id);
-      setNotifications((prev) => {
-        const was = prev.find((n) => n.id === id && !n.read);
-        if (was) setUnreadCount((c) => Math.max(0, c - 1));
-        return prev.filter((n) => n.id !== id);
-      });
+      setNotifications((prev) => prev.filter((n) => n.id !== id));
       if (address) void archiveNotificationApi(address, id).catch(() => {});
     },
     [address],

--- a/app/src/pages/app/InboxRoute.tsx
+++ b/app/src/pages/app/InboxRoute.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import InboxPage from './InboxPage';
-import { useNotifications } from '@/hooks/useNotifications';
+import { useNotifications } from '@/context/ClearNotificationsContext';
 import { INBOX } from '@/data/clearPlaceholder';
 import { toAlerts } from '@/lib/notificationsAdapter';
 


### PR DESCRIPTION
Marking a notification read didn't take because there was nothing shared to mark.

`useNotifications` was a plain hook, and **a hook is not shared state** — every caller got its own rows, its own optimistic `readIds` ref, and its own WebSocket. Three surfaces called it:

| caller | held |
|---|---|
| `NotificationsMenu` (the bell) | rows + `markRead` |
| `InboxRoute` | rows + `markRead` |
| `AppShell` | the unread badge |

So clicking read in the bell updated the bell. The badge kept the old count until its own 20-second poll came round, and the inbox held a third copy besides. Clicking twice "worked" because the second click landed on whichever copy you happened to be looking at.

Those three sockets were also most of the **seven connections one tab was opening** — which I saw in the Railway logs days ago and wrote off as untidy rather than as the symptom it was.

## The fix

The hook is `useNotificationsState`, called exactly once by `ClearNotificationsProvider`. Every surface reads that context. Same public API, so call sites only changed their import. Missing the provider **throws** — a null-object fallback would restore this bug silently.

## Two more things in the same area

**`unreadCount` is derived now**, not kept beside the rows. As its own state it needed adjusting by hand at four sites, and one was wrong:

```ts
setNotifications((prev) => (prev.some((x) => x.id === n.id) ? prev : [n, ...prev]));
setUnreadCount((c) => c + 1);   // ← ran even when the row was already there
```

A repeated `notification:new` bumped a badge that described nothing on screen. A count of unread rows is a fact about the rows; computing it can't disagree with them.

**`notification:new` now ignores an id already in `readIds`**, so a late duplicate can't un-read a row.

## On the test

It asserts how many callers the stateful hook has, because nothing about three copies shows up in a type error or a render. Repointing one surface back makes **2 of 6 fail**.

485 tests, build clean, dist scan clean. One new lint warning — `react-refresh/only-export-components`, which all 22 existing contexts in this codebase share; I kept the file consistent with them rather than special-casing it.

## Worth knowing

There are now two different `useNotifications` exports: this one, and the older localStorage/T-Deed one in `@/context/NotificationContext` used by `UserMenu`/`ProfileMenu`. Same name, different systems. The test pins the import path for the three Clear surfaces, but that pairing is a trap worth collapsing later.