### PR TITLE
Make the credit context read the member's actual line

### DIFF
--- a/app/src/context/CreditContext.tsx
+++ b/app/src/context/CreditContext.tsx
@@ -1,6 +1,10 @@
-import { createContext, useContext, useState, type ReactNode } from 'react';
-import { Zap, Lock, Users, Wallet, ShoppingBag, Home, Tag, type LucideIcon } from 'lucide-react';
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { Zap, Lock, Users, Wallet, Tag, type LucideIcon } from 'lucide-react';
 import BorrowModal from '@/components/app-ui/BorrowModal';
+import { useAppKitAccount } from '@/lib/walletCompat';
+import { onChainStale } from '@/lib/chainStale';
+import { getCredit, type CreditState } from '@/utils/apiClient';
+import { toCycle } from '@/lib/creditMapping';
 
 export type ProductStatus = 'available' | 'active' | 'soon';
 export interface CreditProduct {
@@ -24,26 +28,40 @@ export interface PurposeLine {
 }
 
 /**
- * Mock credit model. The base line is the Stable/Mutual credit line: borrow = overdraft to a
- * negative balance, repay = back to 0. NO interest — a flat fee per draw. Limit backed by the
- * CLRUSD (Savings) balance 1:1. Credit CYCLES (not due dates): balance to 0 within the cycle to
- * keep full borrowing power. Users organize borrowing into PURPOSE LINES (allocations of the one
- * base line) for control. All abstracted as USD.
+ * The member's credit line, read from the contracts.
+ *
+ * The model: the base line is the Stable/Mutual credit line — borrow overdrafts to a negative
+ * balance, repay returns it to zero. No interest, a flat fee per draw. Credit CYCLES rather than
+ * due dates: clear the balance within the cycle to keep full borrowing power. Purpose lines are
+ * UI-only buckets a member creates to organise one underlying line.
+ *
+ * ## This used to be a fixture, and it was one `openBorrow()` away from a member
+ *
+ * It shipped a $5,000 base limit, three purpose lines and $1,200 already borrowed — hardcoded, for
+ * everybody. Nothing calls `openBorrow` yet, so no member has seen it, which is luck rather than
+ * design: wiring up a Borrow button would have shown every member somebody else's credit line
+ * rendered as their own. The route containers next door go to some length to avoid exactly that
+ * (`*_DAY_ONE` over `*_IN_USE`, "each field only overrides once it has been read"), and this
+ * context sat inside the same shell contradicting them.
+ *
+ * So the figures come from /api/credit now — the same read HomeRoute does, which also means the
+ * limit here cannot disagree with the limit on the home screen. Two sources for one number is the
+ * failure this codebase keeps producing.
  */
-export const CLRUSD_BALANCE = 5000; // Savings balance — backs the base limit 1:1
 export const BASE_DRAW_FEE = 0.01; // 1% flat fee per draw, no interest
 export const CYCLE_LENGTH_DAYS = 30;
 
+/*
+ * Product copy, deliberately with no `limit`.
+ *
+ * The names and terms are real product decisions. The limits attached to them were not — "Cash
+ * Advance, $1,500" is a number nobody has underwritten, and it was being summed into `totalPower`
+ * as though it were headroom the member had.
+ */
 const PRODUCTS: CreditProduct[] = [
-  { id: 'cash', name: 'Cash Advance', desc: 'Quick personal loan, straight to your balance.', limit: 1500, status: 'available', terms: '1.5% flat fee · no interest', icon: Zap },
-  { id: 'secured', name: 'Secured Line', desc: 'A higher limit backed by your savings or assets.', limit: 5000, status: 'available', terms: 'Flat fee · no interest', icon: Lock },
+  { id: 'cash', name: 'Cash Advance', desc: 'Quick personal loan, straight to your balance.', status: 'available', terms: '1.5% flat fee · no interest', icon: Zap },
+  { id: 'secured', name: 'Secured Line', desc: 'A higher limit backed by your savings or assets.', status: 'available', terms: 'Flat fee · no interest', icon: Lock },
   { id: 'pool', name: 'Community Pool', desc: 'Borrow from — or lend to — the member pool to earn rewards.', status: 'soon', terms: 'Earn reward yield', icon: Users },
-];
-
-const SEED_LINES: PurposeLine[] = [
-  { id: 'general', name: 'General', limit: 2000, used: 400, icon: Wallet },
-  { id: 'everyday', name: 'Everyday', limit: 1500, used: 800, icon: ShoppingBag },
-  { id: 'rent', name: 'Rent buffer', limit: 1500, used: 0, icon: Home },
 ];
 
 interface CreditValue {
@@ -68,50 +86,100 @@ interface CreditValue {
 const Ctx = createContext<CreditValue | null>(null);
 
 export function useCredit(): CreditValue {
-  return (
-    useContext(Ctx) ?? {
-      baseLimit: 0,
-      borrowed: 0,
-      available: 0,
-      cycleDaysLeft: CYCLE_LENGTH_DAYS,
-      cycleLength: CYCLE_LENGTH_DAYS,
-      powerPct: 100,
-      products: [],
-      totalPower: 0,
-      lines: [],
-      activeLineId: '',
-      addPurposeLine: () => {},
-      removePurposeLine: () => {},
-      borrow: () => {},
-      repay: () => {},
-      openBorrow: () => {},
-      openRepay: () => {},
-    }
-  );
+  const value = useContext(Ctx);
+  if (!value) {
+    // Same reasoning as useClearBalances: a silent stub here is a credit line of zero presented as
+    // fact. BorrowModal is rendered by CreditProvider itself, so nothing can legitimately miss it.
+    throw new Error('useCredit must be used within a CreditProvider (mounted in AppShell)');
+  }
+  return value;
 }
 
 export function CreditProvider({ children }: { children: ReactNode }) {
-  const [lines, setLines] = useState<PurposeLine[]>(SEED_LINES);
+  const { address } = useAppKitAccount();
+  const [credit, setCredit] = useState<CreditState | null>(null);
+  const [extraLines, setExtraLines] = useState<PurposeLine[]>([]);
   const [mode, setMode] = useState<'borrow' | 'repay'>('borrow');
   const [open, setOpen] = useState(false);
   const [activeLineId, setActiveLineId] = useState('general');
 
-  const baseLimit = CLRUSD_BALANCE;
-  const borrowed = lines.reduce((s, l) => s + l.used, 0);
-  const available = Math.max(0, baseLimit - borrowed);
-  const cycleDaysLeft = 18;
-  const powerPct = 100; // good standing (mock) — shrinks if you don't balance within the cycle
-  const totalPower = available + PRODUCTS.filter((p) => p.status === 'available').reduce((s, p) => s + (p.limit ?? 0), 0);
+  /*
+   * The same read HomeRoute does, and re-read on the same signal.
+   *
+   * Not a second fetch of a different thing: literally the same endpoint, so the limit in a Borrow
+   * sheet cannot disagree with the limit on the home screen. Without the stale listener this
+   * context had no refresh path at all — it read once on mount and then described a past.
+   */
+  useEffect(() => {
+    if (!address) return;
+    let cancelled = false;
+    const read = () => {
+      void getCredit(address).then((result) => {
+        if (!cancelled) setCredit(result);
+      });
+    };
+    read();
+    const stopListening = onChainStale(read);
+    return () => {
+      cancelled = true;
+      stopListening();
+    };
+  }, [address]);
 
-  const borrow = (amount: number, lineId: string) =>
-    setLines((ls) => {
-      const room = Math.max(0, baseLimit - ls.reduce((s, l) => s + l.used, 0)); // global headroom
-      return ls.map((l) =>
-        l.id === lineId ? { ...l, used: l.used + Math.min(amount, Math.max(0, l.limit - l.used), room) } : l,
-      );
-    });
-  const repay = (amount: number, lineId: string) =>
-    setLines((ls) => ls.map((l) => (l.id === lineId ? { ...l, used: Math.max(0, l.used - amount) } : l)));
+  // Only tiers the issuer has actually activated. An inactive tier is a product the member could
+  // have, not headroom they do have.
+  const activeTiers = (credit?.complete ? credit.tiers : []).filter((tier) => tier.active);
+  const baseLimit = activeTiers.reduce((sum, tier) => sum + tier.limitCents, 0) / 100;
+  const borrowed = activeTiers.reduce((sum, tier) => sum + tier.usedCents, 0) / 100;
+  const available = Math.max(0, baseLimit - borrowed);
+  // Through the same mapper HomeRoute uses, rather than re-deriving days-from-expiry here. The
+  // arithmetic is small; having two copies of it that can disagree is not.
+  const cycleDaysLeft = toCycle(credit?.cycle ?? null, {
+    lengthDays: CYCLE_LENGTH_DAYS,
+    daysLeft: 0,
+    clearsOn: '—',
+    rebalanceBy: '—',
+  }).daysLeft;
+  // Full power until the contracts say otherwise. Nothing on chain reports this yet, so the honest
+  // value is "no penalty recorded" rather than a percentage invented here.
+  const powerPct = 100;
+  // What the member can draw, and nothing else. This used to add every product's hardcoded limit,
+  // so it reported borrowing power nobody had underwritten.
+  const totalPower = available;
+
+  /*
+   * One real line, plus any buckets the member has made.
+   *
+   * There is a single underlying credit line; purpose lines are a UI device for splitting it. The
+   * default one therefore *is* the line — its limit and usage are the contract's, not a slice
+   * invented here — and it starts as the only one, because a new member has not made any.
+   */
+  const lines: PurposeLine[] = [
+    { id: 'general', name: 'General', limit: baseLimit, used: borrowed, icon: Wallet },
+    ...extraLines,
+  ];
+  const setLines = setExtraLines;
+
+  /*
+   * Not built, and now it says so.
+   *
+   * These moved a number in local state and nothing else — no draw against StableCredit, no
+   * transfer, no receipt. A member who pressed Borrow would have watched their balance rise and
+   * their credit fall on screen while nothing whatsoever happened on chain, and the figures would
+   * have snapped back on the next read with no explanation.
+   *
+   * Throwing is safe: nothing calls `openBorrow`, so the modal these belong to cannot be opened
+   * today. It is also the point — whoever wires the Borrow button up should hit this immediately
+   * rather than ship a convincing mime of a loan.
+   */
+  const notBuilt = (action: string) => (): never => {
+    throw new Error(
+      `${action} is not implemented: it needs a StableCredit draw/repay on chain. ` +
+        'This context reads the line; it cannot move it.',
+    );
+  };
+  const borrow = notBuilt('borrow');
+  const repay = notBuilt('repay');
 
   const value: CreditValue = {
     baseLimit,

--- a/app/src/context/creditIsReal.test.ts
+++ b/app/src/context/creditIsReal.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(import.meta.dirname, '..', p), 'utf8');
+const ctx = read('context/CreditContext.tsx');
+
+/*
+ * This context shipped a $5,000 base limit, three purpose lines and $1,200 already borrowed —
+ * hardcoded, identical for every member, inside the same shell whose route containers go to real
+ * lengths to avoid exactly that ("each field only overrides once it has been read").
+ *
+ * No member ever saw it, because nothing calls `openBorrow`. That is luck, not design, and luck is
+ * what this file is here to replace.
+ */
+describe('the credit line is the member’s, not a fixture', () => {
+  test('no hardcoded balance or seeded borrowings survive', () => {
+    expect(ctx).not.toContain('CLRUSD_BALANCE');
+    expect(ctx).not.toContain('SEED_LINES');
+    // The tell was a `used:` with a number on it. The one legitimate `used` is the contract's.
+    expect(ctx).not.toMatch(/used:\s*[1-9]/);
+  });
+
+  test('the figures come from the contracts', () => {
+    expect(ctx).toContain('getCredit(address)');
+    expect(ctx).toContain('tier.limitCents');
+    expect(ctx).toContain('tier.usedCents');
+  });
+
+  test('and only from tiers the issuer actually activated', () => {
+    // An inactive tier is a product a member could have, not headroom they do have.
+    expect(ctx).toMatch(/filter\(\(tier\) => tier\.active\)/);
+  });
+
+  test('it re-reads on the same signal as the home screen', () => {
+    // Before this it had no refresh path at all — one read on mount, then it described a past.
+    expect(ctx).toContain('onChainStale(read)');
+  });
+
+  test('days-left goes through the shared mapper, not a second copy of the arithmetic', () => {
+    expect(ctx).toContain('toCycle(');
+    expect(ctx).not.toContain('DAY_SECONDS');
+  });
+
+  test('product copy carries no invented limits', () => {
+    const products = ctx.slice(ctx.indexOf('const PRODUCTS'), ctx.indexOf('interface CreditValue'));
+    expect(products).not.toMatch(/limit:\s*\d/);
+    // ...and none are summed into headroom.
+    expect(ctx).toContain('const totalPower = available;');
+  });
+
+  test('borrowing throws rather than miming a loan', () => {
+    // It used to move a number in local state and nothing else: no draw, no transfer, no receipt.
+    expect(ctx).toContain('is not implemented');
+    expect(ctx).not.toMatch(/const borrow = \(amount/);
+  });
+
+  test('both hooks refuse to hand back a silent stub', () => {
+    expect(ctx).toContain('useCredit must be used within a CreditProvider');
+    expect(read('hooks/useClearBalances.ts')).toContain('useClearBalances must be used within a ClearBalancesProvider');
+  });
+});

--- a/app/src/hooks/useClearBalances.ts
+++ b/app/src/hooks/useClearBalances.ts
@@ -50,29 +50,26 @@ export interface ClearBalances {
 
 const Ctx = createContext<ClearBalances | null>(null);
 
-/*
- * The fallback stays, but it stops being silent.
+/**
+ * The member's Clear balances.
  *
- * A consumer rendered outside ClearBalancesProvider gets zeros, a no-op `refresh` and a no-op
- * `applyOptimistic` — and no indication anything is wrong. That is a balance of zero shown as
- * fact, and a move that quietly fails to update anything. It is the same shape as the bug that
- * made marking a notification read appear not to work: a second, silent, wrong copy.
+ * Throws outside ClearBalancesProvider rather than handing back a silent stub.
  *
- * Throwing would be better, except some legacy modals still mount outside the shell and a throw
- * there is a blank screen for a real member. So: keep working, say so loudly in dev, and name the
- * component so the next person does not spend an afternoon on it.
+ * It used to fall back to `{ cash: 0, savings: 0, refresh: noop, applyOptimistic: noop }`, which is
+ * a balance of zero presented as fact and a move that quietly updates nothing. I kept that
+ * fallback once on the assumption that legacy modals mounted outside the shell — then checked, and
+ * none of the live ones do. Every consumer that can actually render sits inside AppShell's
+ * provider; the two that render this outside it (components/TransferModal, portfolio/EarnHome) are
+ * unreachable code that never mounts.
+ *
+ * So the fallback was protecting nothing and hiding the one failure mode that matters.
  */
 export function useClearBalances(): ClearBalances {
   const value = useContext(Ctx);
-  if (!value && import.meta.env?.DEV) {
-    console.error(
-      '[useClearBalances] rendered outside ClearBalancesProvider — showing 0 and ignoring ' +
-        'applyOptimistic/refresh. Mount this inside AppShell.',
-    );
+  if (!value) {
+    throw new Error('useClearBalances must be used within a ClearBalancesProvider (mounted in AppShell)');
   }
-  return (
-    value ?? { cash: 0, savings: 0, total: 0, loading: false, refresh: () => {}, applyOptimistic: () => {} }
-  );
+  return value;
 }
 
 const POLL_MS = 30_000; // steady auto-refresh


### PR DESCRIPTION
## First, a correction

I flagged two silent fallbacks and said throwing would be better *"except some legacy modals mount outside the shell."* **I hadn't checked that, and it's wrong.** Every live consumer of `useClearBalances` sits inside AppShell's provider; the only two files that render one outside it (`components/TransferModal`, `portfolio/EarnHome`) are unreachable code that never mounts.

The fallback was protecting nothing and hiding the one failure it existed for. Both hooks throw now.

## The part worth the PR

`CreditContext` shipped this:

```ts
export const CLRUSD_BALANCE = 5000;
const SEED_LINES = [
  { id: 'general',  name: 'General',     limit: 2000, used: 400 },
  { id: 'everyday', name: 'Everyday',    limit: 1500, used: 800 },
  { id: 'rent',     name: 'Rent buffer', limit: 1500, used: 0   },
];
```

A $5,000 base limit and $1,200 already borrowed. **Hardcoded, identical for every member** — inside the same shell whose route containers go to real lengths to avoid exactly this: `*_DAY_ONE` over `*_IN_USE`, *"each field only overrides once it has been read"*, *"that is not a placeholder, it is a fabrication."*

No member has seen it, because nothing calls `openBorrow`. **That's luck, not design.** Wiring up a Borrow button would have shown every member somebody else's credit line rendered as their own.

It now reads `/api/credit` — the same endpoint `HomeRoute` uses, so a Borrow sheet can't disagree with the home screen — and re-reads on the same stale signal. Previously it had **no refresh path at all**: one read on mount, then it described a past.

## Three smaller fabrications went with it

| was | now |
|---|---|
| Product limits (`Cash Advance, $1,500`) summed into `totalPower` as headroom | copy stays, numbers gone; `totalPower = available` |
| `powerPct = 100 // mock` | still 100, but stated as "nothing on chain reports standing yet" |
| `borrow`/`repay` mutating local state | throw, naming what needs building |

That last one is the sharpest. `borrow` moved a number in local state and nothing else — no draw against StableCredit, no transfer, no receipt. A member pressing Borrow would have watched their balance rise and their credit fall on screen while nothing whatsoever happened, then seen it snap back on the next read with no explanation. Throwing is safe (the modal can't be opened) and pointed (whoever wires it up hits it immediately).

## Purpose lines

They're a UI device for splitting one underlying line, so the default one now **is** the line — the contract's limit and usage — and a member starts with only that, because they haven't made any others.

494 tests, 8 new. Build and dist scan clean. The single lint error in `CreditContext` is pre-existing and unchanged — verified by stashing.