### PR TITLE
Say something when activating a card fails, and stop the SW rejecting on routes

### DIFF
--- a/app/public/sw.js
+++ b/app/public/sw.js
@@ -90,15 +90,61 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Strategy 4: HTML - Network First with cache fallback
-  if (isHTML(url)) {
-    event.respondWith(networkFirst(request, STATIC_CACHE));
+  /*
+   * Strategy 4: page loads — network first, app shell as the fallback.
+   *
+   * Keyed on `request.mode === 'navigate'`, not on the path. `isHTML` only ever matched `/` and
+   * `*.html`, so every route this app actually has — /card, /savings, /earn, /send, /inbox — missed
+   * it and fell through to the bare `fetch(request)` below: no cache fallback, and no catch, so a
+   * failed navigation surfaced as
+   *
+   *   The FetchEvent for "/card" resulted in a network error response: the promise was rejected.
+   *
+   * An installed PWA that can only open its home page offline is not offline-capable, and a
+   * rejected navigation is a blank tab rather than a stale page.
+   *
+   * The shell is what gets served, because this is a single-page app: index.html boots the router
+   * and the router knows what /card is.
+   */
+  if (request.mode === 'navigate' || isHTML(url)) {
+    event.respondWith(navigation(request));
     return;
   }
 
-  // Default: Network only
-  event.respondWith(fetch(request));
+  // Default: network only — but never an unhandled rejection. A rejected respondWith is a network
+  // error page; an error Response at least says what happened.
+  event.respondWith(
+    fetch(request).catch(
+      () => new Response('Offline', { status: 503, statusText: 'Offline', headers: { 'Content-Type': 'text/plain' } }),
+    ),
+  );
 });
+
+/**
+ * A page load: the network's answer if there is one, otherwise the cached shell.
+ *
+ * Deliberately not `networkFirst`, whose offline fallback is a JSON 503 — correct for an API call
+ * and useless for a navigation, where the browser would render the JSON as the page.
+ */
+async function navigation(request) {
+  const cache = await caches.open(STATIC_CACHE);
+  try {
+    const response = await fetch(request);
+    // Only the shell is worth keeping. Caching every route under its own URL would fill the cache
+    // with copies of one document.
+    if (response.ok && new URL(request.url).pathname === '/') {
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch (error) {
+    const shell = (await cache.match('/index.html')) || (await cache.match('/'));
+    if (shell) return shell;
+    return new Response(
+      '<!doctype html><meta charset="utf-8"><title>Offline</title><p>You are offline.',
+      { status: 503, headers: { 'Content-Type': 'text/html; charset=utf-8' } },
+    );
+  }
+}
 
 // Cache First Strategy
 async function cacheFirst(request, cacheName) {
@@ -220,6 +266,11 @@ function isPlaidAPI(url) {
   return url.pathname.startsWith('/api/plaid/');
 }
 
+/*
+ * Only for requests that are not navigations — a navigation is caught by `request.mode` above,
+ * which is what a single-page app's routes actually look like. This stays for the handful of
+ * direct .html fetches.
+ */
 function isHTML(url) {
   return url.pathname.endsWith('.html') || url.pathname === '/';
 }

--- a/app/src/pages/app/CardPage.tsx
+++ b/app/src/pages/app/CardPage.tsx
@@ -26,12 +26,15 @@ export default function CardPage({
   onActivate,
   onToggleFreeze,
   busy = false,
+  notice = null,
 }: {
   data?: CardData;
   /** Issues the card. Absent in the preview harness, where the page stands alone. */
   onActivate?: () => void;
   onToggleFreeze?: (frozen: boolean) => void;
   busy?: boolean;
+  /** Why the last action did not do what it looked like it would. Absent when nothing went wrong. */
+  notice?: string | null;
 }) {
   const [frozen, setFrozen] = useState(data.frozen);
   const [variant, setVariant] = useState<CardData['variant']>(data.variant);
@@ -86,9 +89,17 @@ export default function CardPage({
       </Button>
     </div>
   ) : (
-    <Button variant="clear" size="xs" className="w-full" disabled={busy} onClick={onActivate}>
-      {busy ? 'Activating…' : 'Activate card'}
-    </Button>
+    <div className="space-y-2">
+      <Button variant="clear" size="xs" className="w-full" disabled={busy} onClick={onActivate}>
+        {busy ? 'Activating…' : 'Activate card'}
+      </Button>
+      {/* Sits under the button that failed, not in a toast — the member is looking here. */}
+      {notice && (
+        <p role="status" className="text-[11px] leading-relaxed text-muted-foreground">
+          {notice}
+        </p>
+      )}
+    </div>
   );
 
   const caption = (

--- a/app/src/pages/app/CardRoute.tsx
+++ b/app/src/pages/app/CardRoute.tsx
@@ -33,6 +33,7 @@ export default function CardRoute() {
   const [card, setCard] = useState<MemberCard | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -47,11 +48,31 @@ export default function CardRoute() {
     };
   }, []);
 
+  /*
+   * Activate, and say what happened either way.
+   *
+   * This used to be `if (created) setCard(created)` — so a failure was indistinguishable from not
+   * having pressed the button. The server was answering 503 'Cards unavailable' the whole time and
+   * the member saw a spinner stop and nothing change.
+   *
+   * The two failures read differently on purpose. Cards being switched off is not something a
+   * member can retry, and telling them to try again would be sending them round a loop that cannot
+   * end.
+   */
   const activate = useCallback(async () => {
     setBusy(true);
+    setNotice(null);
     try {
-      const created = await createCard('Clear card');
-      if (created) setCard(created);
+      const { card: created, error, unavailable } = await createCard('Clear card');
+      if (created) {
+        setCard(created);
+        return;
+      }
+      setNotice(
+        unavailable
+          ? "Cards aren't switched on yet. Nothing to do — we'll enable this for your account."
+          : `That didn't go through. ${error ?? 'Please try again.'}`,
+      );
     } finally {
       setBusy(false);
     }
@@ -91,5 +112,5 @@ export default function CardRoute() {
         periodTotal: card ? 0 : CARD_DAY_ONE.periodTotal,
       };
 
-  return <CardPage data={data} onActivate={activate} onToggleFreeze={toggleFreeze} busy={busy} />;
+  return <CardPage data={data} onActivate={activate} onToggleFreeze={toggleFreeze} busy={busy} notice={notice} />;
 }

--- a/app/src/pages/app/cardActivation.test.ts
+++ b/app/src/pages/app/cardActivation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(import.meta.dirname, '..', '..', p), 'utf8');
+
+/*
+ * Pressing Activate card did nothing at all.
+ *
+ * The server was answering `503 Cards unavailable` — LITHIC_API_KEY is not set — and the client
+ * turned that into `null`, which the route treated as "no card yet". A failure and a no-op were
+ * the same value, so the spinner stopped and the page did not change.
+ */
+describe('a failed activation says so', () => {
+  const client = read('utils/apiClient.ts');
+  const route = read('pages/app/CardRoute.tsx');
+  const page = read('pages/app/CardPage.tsx');
+
+  test('createCard returns the reason instead of collapsing to null', () => {
+    const fn = client.slice(client.indexOf('export async function createCard'), client.indexOf('export async function setCardFrozen'));
+    expect(fn).toContain('error?: string');
+    expect(fn).not.toMatch(/return r\.error \? null/);
+  });
+
+  test('and separates "not switched on" from "that failed"', () => {
+    // A member cannot retry their way out of an unconfigured integration, so telling them to try
+    // again would send them round a loop with no exit.
+    const fn = client.slice(client.indexOf('export async function createCard'), client.indexOf('export async function setCardFrozen'));
+    expect(fn).toContain('unavailable');
+  });
+
+  test('the route shows the outcome rather than discarding it', () => {
+    expect(route).toContain('setNotice(');
+    // The old shape: a failure fell off the end of the function.
+    expect(route).not.toMatch(/const created = await createCard\('Clear card'\);\s*if \(created\) setCard\(created\);/);
+  });
+
+  test('and the page has somewhere to put it', () => {
+    expect(page).toContain('notice?: string | null');
+    expect(page).toContain('role="status"');
+  });
+});
+
+/*
+ * The other half of that console paste: the service worker rejecting on /card.
+ */
+describe('the service worker can open a route offline', () => {
+  const sw = readFileSync(join(import.meta.dirname, '..', '..', '..', 'public', 'sw.js'), 'utf8');
+
+  test('navigations are matched by request mode, not by path', () => {
+    // isHTML only ever matched `/` and `*.html`, so /card, /savings, /earn and the rest fell
+    // through to a bare fetch with no fallback and no catch.
+    expect(sw).toContain("request.mode === 'navigate'");
+  });
+
+  test('a failed navigation serves the app shell', () => {
+    const nav = sw.slice(sw.indexOf('async function navigation'));
+    expect(nav).toContain("cache.match('/index.html')");
+  });
+
+  test('and never a JSON body, which the browser would render as the page', () => {
+    const nav = sw.slice(sw.indexOf('async function navigation'), sw.indexOf('// Cache First Strategy'));
+    expect(nav).not.toContain('JSON.stringify');
+    expect(nav).toContain('text/html');
+  });
+
+  test('the default branch cannot reject unhandled any more', () => {
+    const fetchHandler = sw.slice(sw.indexOf("self.addEventListener('fetch'"), sw.indexOf('async function navigation'));
+    expect(fetchHandler).toMatch(/fetch\(request\)\.catch\(/);
+  });
+});

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -1941,12 +1941,29 @@ export async function getCards(): Promise<MemberCard[]> {
 }
 
 /** Issue a virtual card — what "Activate card" does. */
-export async function createCard(memo?: string): Promise<MemberCard | null> {
+/**
+ * Issue a virtual card.
+ *
+ * Returns the reason on failure rather than collapsing to null. Null told the caller "no card" and
+ * nothing else, so a 503 from an unconfigured Lithic and a successful no-op were the same value —
+ * and pressing Activate produced no card, no error and no clue.
+ *
+ * `unavailable` separates "this isn't switched on yet" from "that didn't work", because a member
+ * should be told to wait in the first case and to try again in the second.
+ */
+export async function createCard(
+  memo?: string,
+): Promise<{ card: MemberCard | null; error?: string; unavailable?: boolean }> {
   const r = await apiRequest<{ card: MemberCard }>('/api/lithic/cards', {
     method: 'POST',
     body: JSON.stringify(memo ? { memo } : {}),
   });
-  return r.error ? null : (r.data?.card ?? null);
+  if (r.error) {
+    // 'Cards unavailable' is the server's word for LITHIC_API_KEY being unset — the integration is
+    // off, not broken, and the member has nothing to retry.
+    return { card: null, error: r.error, unavailable: /unavailable/i.test(r.error) };
+  }
+  return { card: r.data?.card ?? null };
 }
 
 export async function setCardFrozen(token: string, frozen: boolean): Promise<MemberCard | null> {


### PR DESCRIPTION
Two separate things in that console paste, and the cause of the first isn't in the code at all.

## Why nothing happened: the key isn't set

`isConfigured()` is only *"is `LITHIC_API_KEY` set"*, and on Railway dev it isn't:

```
$ railway variables --kv | cut -d= -f1 | grep -i lithic
LITHIC_ENV
```

`LITHIC_ENV` is there; the key is not. So every card call answers `503 Cards unavailable`. **Nothing to fix server-side — add your sandbox key to Railway and it works.**

## What *is* a bug: the button told you nothing

```ts
const created = await createCard('Clear card');
if (created) setCard(created);
```

`createCard` collapsed every failure to `null`, so a 503 and "no card yet" were the same value. The spinner stopped and the page didn't change.

It returns the reason now, and separates **"not switched on"** from **"that didn't work"** — a member can't retry their way out of an unconfigured integration, and telling them to try again would be a loop with no exit. The message renders under the button that failed rather than in a toast, because that's where they're looking.

## And the service worker couldn't open any route

```js
function isHTML(url) {
  return url.pathname.endsWith('.html') || url.pathname === '/';
}
```

Every route this app has — `/card`, `/savings`, `/earn`, `/send`, `/inbox` — missed that and fell through to a bare `fetch(request)` with **no cache fallback and no catch**. That's the other line in your paste:

> The FetchEvent for "https://demo.useclear.org/card" resulted in a network error response: the promise was rejected.

An installed PWA that can only open its home page offline isn't offline-capable, and a rejected navigation is a blank tab rather than a stale page.

Navigations are matched on `request.mode` now and fall back to the cached shell — the right answer for a single-page app, since `index.html` boots the router and the router knows what `/card` is. Deliberately **not** via `networkFirst`, whose offline fallback is a JSON 503: correct for an API call, and rendered *as the page* for a navigation. The default branch catches too, so a failure is an error Response instead of an unhandled rejection.

502 tests, 8 new. Build and dist scan clean. The 30 lint errors in `apiClient` are pre-existing and unchanged — verified by stashing.