### PR TITLE
Sweep the rest of the card paths, and find a worse one than activation

### DIFF
--- a/app/src/components/app-ui/BillPortalBrowser.tsx
+++ b/app/src/components/app-ui/BillPortalBrowser.tsx
@@ -95,7 +95,7 @@ function LaunchScreen({ portal, onOpen }: { portal: BillPortal; onOpen: () => vo
  */
 function CardOverlay() {
   const [open, setOpen] = useState(false);
-  const { configured, card, active, hasCard, activate, activating } = useClearCard();
+  const { configured, card, active, hasCard, activate, activating, error } = useClearCard();
 
   return (
     <div className="border-t border-border bg-card px-3 py-2">
@@ -134,6 +134,12 @@ function CardOverlay() {
               <ShieldCheck className="h-4 w-4 shrink-0 text-amber-500" />
               Your Clear card is activating — card details to copy will appear here once it’s live.
             </div>
+          )}
+          {/* After whichever of the three states is showing, under the button that failed. */}
+          {error && (
+            <p role="status" className="mt-2 text-xs leading-relaxed text-muted-foreground">
+              {error}
+            </p>
           )}
         </div>
       )}

--- a/app/src/hooks/useClearCard.ts
+++ b/app/src/hooks/useClearCard.ts
@@ -12,6 +12,7 @@ export function useClearCard() {
   const [configured, setConfigured] = useState(false);
   const [card, setCard] = useState<ClearCard | null>(null);
   const [activating, setActivating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     if (!isConnected) {
@@ -28,11 +29,30 @@ export function useClearCard() {
     void refresh();
   }, [refresh]);
 
+  /*
+   * Activate, and keep the reason if it did not.
+   *
+   * The result was discarded entirely: activation failed, `refresh()` found no card, the spinner
+   * stopped and the button sat there saying "Activate your Clear card" again. Identical to not
+   * having pressed it.
+   */
   const activate = useCallback(async () => {
     if (!address) return;
     setActivating(true);
+    setError(null);
     try {
-      await activateClearCard({ walletAddress: address, chainId: ACTIVE_CHAIN_ID });
+      const { value, error: reason, unavailable } = await activateClearCard({
+        walletAddress: address,
+        chainId: ACTIVE_CHAIN_ID,
+      });
+      if (!value) {
+        setError(
+          unavailable
+            ? "Cards aren't switched on yet. Nothing to do — we'll enable this for your account."
+            : `That didn't go through. ${reason ?? 'Please try again.'}`,
+        );
+        return;
+      }
       await refresh();
     } finally {
       setActivating(false);
@@ -43,6 +63,8 @@ export function useClearCard() {
     configured,
     card,
     activating,
+    /** Why the last activation did not happen. Null when nothing has gone wrong. */
+    error,
     activate,
     refresh,
     active: card?.status === 'active',

--- a/app/src/pages/app/CardRoute.tsx
+++ b/app/src/pages/app/CardRoute.tsx
@@ -37,10 +37,28 @@ export default function CardRoute() {
 
   useEffect(() => {
     let cancelled = false;
-    void getCards().then((cards) => {
+    void getCards().then(({ value, error, unavailable }) => {
       if (cancelled) return;
+      /*
+       * A failed read is not an empty account.
+       *
+       * This page renders "no cards" as an **Activate card** button, and getCards used to answer
+       * `[]` for both — so a member who has a card was invited to create one whenever the read
+       * hiccuped. That is not a missing message, it is the page asserting something false about
+       * their account, and it is the worse half of this bug.
+       *
+       * `loaded` therefore stays false on failure: the placeholder holds, and the notice explains.
+       */
+      if (error) {
+        setNotice(
+          unavailable
+            ? "Cards aren't switched on yet. Nothing to do — we'll enable this for your account."
+            : "Couldn't load your card just now. It hasn't changed — pull to refresh in a moment.",
+        );
+        return;
+      }
       // The newest card is the one on screen. Multiple cards are a later surface.
-      setCard(cards[0] ?? null);
+      setCard(value?.[0] ?? null);
       setLoaded(true);
     });
     return () => {
@@ -63,7 +81,7 @@ export default function CardRoute() {
     setBusy(true);
     setNotice(null);
     try {
-      const { card: created, error, unavailable } = await createCard('Clear card');
+      const { value: created, error, unavailable } = await createCard('Clear card');
       if (created) {
         setCard(created);
         return;
@@ -83,12 +101,27 @@ export default function CardRoute() {
       if (!card) return;
       setBusy(true);
       try {
-        const updated = await setCardFrozen(card.token, frozen);
-        // Only trust the server's answer. A freeze that failed must not leave the card looking
-        // frozen — a member who thinks their card is dead and it is not is worse off than one who
-        // can see it failed and tries again.
-        if (updated) setCard(updated);
-        else setCard({ ...card });
+        const { value: updated, error, unavailable } = await setCardFrozen(card.token, frozen);
+        /*
+         * Only trust the server's answer. A freeze that failed must not leave the card looking
+         * frozen — a member who believes their card is dead when it is not is worse off than one
+         * who can see it failed and tries again.
+         *
+         * Which is exactly why the revert now comes with words. `setCard({ ...card })` sprang the
+         * toggle back and said nothing, so the two possible readings — "it failed" and "I misclicked"
+         * — looked identical, and the safer state was communicated as an accident.
+         */
+        if (updated) {
+          setCard(updated);
+          setNotice(null);
+          return;
+        }
+        setCard({ ...card });
+        setNotice(
+          unavailable
+            ? "Cards aren't switched on yet, so there's nothing to freeze."
+            : `Couldn't ${frozen ? 'freeze' : 'unfreeze'} your card. ${error ?? 'Please try again.'}`,
+        );
       } finally {
         setBusy(false);
       }

--- a/app/src/pages/app/cardActivation.test.ts
+++ b/app/src/pages/app/cardActivation.test.ts
@@ -18,15 +18,18 @@ describe('a failed activation says so', () => {
 
   test('createCard returns the reason instead of collapsing to null', () => {
     const fn = client.slice(client.indexOf('export async function createCard'), client.indexOf('export async function setCardFrozen'));
-    expect(fn).toContain('error?: string');
+    expect(fn).toContain('CardResult<MemberCard>');
     expect(fn).not.toMatch(/return r\.error \? null/);
   });
 
   test('and separates "not switched on" from "that failed"', () => {
     // A member cannot retry their way out of an unconfigured integration, so telling them to try
-    // again would send them round a loop with no exit.
-    const fn = client.slice(client.indexOf('export async function createCard'), client.indexOf('export async function setCardFrozen'));
-    expect(fn).toContain('unavailable');
+    // again would send them round a loop with no exit. Now carried by the shared shape, so every
+    // card call gets the distinction rather than only the one that was reported.
+    const shape = client.slice(client.indexOf('export interface CardResult'), client.indexOf('export async function getCards'));
+    expect(shape).toContain('error?: string');
+    expect(shape).toContain('unavailable?: boolean');
+    expect(shape).toMatch(/unavailable: \/unavailable\/i\.test\(error\)/);
   });
 
   test('the route shows the outcome rather than discarding it', () => {
@@ -67,5 +70,58 @@ describe('the service worker can open a route offline', () => {
   test('the default branch cannot reject unhandled any more', () => {
     const fetchHandler = sw.slice(sw.indexOf("self.addEventListener('fetch'"), sw.indexOf('async function navigation'));
     expect(fetchHandler).toMatch(/fetch\(request\)\.catch\(/);
+  });
+});
+
+/*
+ * The sweep: every card call a member can trigger, held to the same contract.
+ *
+ * Activation was the one that got noticed, because it is the one with a button that visibly does
+ * nothing. The others fail the same way and are quieter about it.
+ */
+describe('no card path fails silently', () => {
+  const client = read('utils/apiClient.ts');
+  const route = read('pages/app/CardRoute.tsx');
+
+  function fn(name: string): string {
+    const start = client.indexOf(`export async function ${name}(`);
+    expect(start).toBeGreaterThan(-1);
+    return client.slice(start, client.indexOf('\nexport ', start + 10));
+  }
+
+  test('they all report through one shape, not four', () => {
+    for (const name of ['getCards', 'createCard', 'setCardFrozen', 'activateClearCard', 'freezeClearCard']) {
+      expect(fn(name)).toContain('CardResult<');
+    }
+  });
+
+  test('none of them collapse a failure into an empty success', () => {
+    for (const name of ['getCards', 'createCard', 'setCardFrozen', 'activateClearCard', 'freezeClearCard']) {
+      // `r.error ? [] :` and `r.error ? null :` are the two shapes that lost the reason.
+      expect(fn(name)).not.toMatch(/r\.error \?\s*(\[\]|null)/);
+    }
+  });
+
+  test('a failed read is not rendered as an empty account', () => {
+    // The page renders "no cards" as an Activate button, so `[]` on failure invited a member who
+    // has a card to create another one. `loaded` must stay false when the read failed.
+    const load = route.slice(route.indexOf('void getCards()'), route.indexOf('const activate'));
+    expect(load).toContain('if (error)');
+    expect(load.indexOf('if (error)')).toBeLessThan(load.indexOf('setLoaded(true)'));
+  });
+
+  test('a freeze that springs back explains itself', () => {
+    const toggle = route.slice(route.indexOf('const toggleFreeze'));
+    expect(toggle).toContain('setCard({ ...card })');
+    expect(toggle).toContain('setNotice(');
+  });
+
+  test('and the Bridge card activation keeps its reason too', () => {
+    const hook = readFileSync(join(import.meta.dirname, '..', '..', 'hooks', 'useClearCard.ts'), 'utf8');
+    expect(hook).toContain('setError(');
+    const portal = readFileSync(
+      join(import.meta.dirname, '..', '..', 'components', 'app-ui', 'BillPortalBrowser.tsx'), 'utf8',
+    );
+    expect(portal).toContain('role="status"');
   });
 });

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -1935,9 +1935,35 @@ export interface MemberCard {
   createdAt: string;
 }
 
-export async function getCards(): Promise<MemberCard[]> {
+/**
+ * How a card call reports failure.
+ *
+ * `unavailable` is the integration being switched off (LITHIC_API_KEY unset — the server says
+ * 'Cards unavailable'), which is not something a member can retry. Everything else is a failure
+ * they can. Collapsing both to `null` is what made pressing Activate look like pressing nothing.
+ */
+export interface CardResult<T> {
+  value: T | null;
+  error?: string;
+  unavailable?: boolean;
+}
+
+function cardFailure<T>(error: string): CardResult<T> {
+  return { value: null, error, unavailable: /unavailable/i.test(error) };
+}
+
+/**
+ * The member's cards.
+ *
+ * An empty list and a failed read used to be the same `[]`, and the card page renders "no cards"
+ * as **Activate card** — so a member who has a card was shown a button to create one whenever the
+ * read hiccuped. That is worse than the silent Activate failure: it does not merely fail to
+ * inform, it asserts something false about their account.
+ */
+export async function getCards(): Promise<CardResult<MemberCard[]>> {
   const r = await apiRequest<{ configured: boolean; cards: MemberCard[] }>('/api/lithic/cards');
-  return r.error ? [] : (r.data?.cards ?? []);
+  if (r.error) return cardFailure(r.error);
+  return { value: r.data?.cards ?? [] };
 }
 
 /** Issue a virtual card — what "Activate card" does. */
@@ -1951,27 +1977,23 @@ export async function getCards(): Promise<MemberCard[]> {
  * `unavailable` separates "this isn't switched on yet" from "that didn't work", because a member
  * should be told to wait in the first case and to try again in the second.
  */
-export async function createCard(
-  memo?: string,
-): Promise<{ card: MemberCard | null; error?: string; unavailable?: boolean }> {
+export async function createCard(memo?: string): Promise<CardResult<MemberCard>> {
   const r = await apiRequest<{ card: MemberCard }>('/api/lithic/cards', {
     method: 'POST',
     body: JSON.stringify(memo ? { memo } : {}),
   });
-  if (r.error) {
-    // 'Cards unavailable' is the server's word for LITHIC_API_KEY being unset — the integration is
-    // off, not broken, and the member has nothing to retry.
-    return { card: null, error: r.error, unavailable: /unavailable/i.test(r.error) };
-  }
-  return { card: r.data?.card ?? null };
+  if (r.error) return cardFailure(r.error);
+  return { value: r.data?.card ?? null };
 }
 
-export async function setCardFrozen(token: string, frozen: boolean): Promise<MemberCard | null> {
+/** Freeze or unfreeze. Reports why it failed — a toggle that springs back explains nothing. */
+export async function setCardFrozen(token: string, frozen: boolean): Promise<CardResult<MemberCard>> {
   const r = await apiRequest<{ card: MemberCard }>(
     `/api/lithic/cards/${encodeURIComponent(token)}/freeze`,
     { method: 'POST', body: JSON.stringify({ frozen }) },
   );
-  return r.error ? null : (r.data?.card ?? null);
+  if (r.error) return cardFailure(r.error);
+  return { value: r.data?.card ?? null };
 }
 
 export async function setCardSpendLimit(
@@ -2705,17 +2727,22 @@ export async function getClearCard(): Promise<{ configured: boolean; card: Clear
   const r = await apiRequest<{ configured: boolean; card: ClearCard | null }>('/api/cards');
   return r.error || !r.data ? { configured: false, card: null } : r.data;
 }
-export async function activateClearCard(input: { walletAddress: string; chainId: number }): Promise<{ status: string; card: ClearCard | null } | null> {
+/** The Bridge/Stripe card's own activation. Same contract as the Lithic one, for the same reason. */
+export async function activateClearCard(
+  input: { walletAddress: string; chainId: number },
+): Promise<CardResult<{ status: string; card: ClearCard | null }>> {
   const r = await apiRequest<{ status: string; card: ClearCard | null }>('/api/cards/activate', { method: 'POST', body: JSON.stringify(input) });
-  return r.error || !r.data ? null : r.data;
+  if (r.error) return cardFailure(r.error);
+  return { value: r.data ?? null };
 }
 export async function createCardEphemeralKey(input: { nonce: string; apiVersion: string }): Promise<{ secret: string; cardId: string } | null> {
   const r = await apiRequest<{ secret: string; cardId: string }>('/api/cards/ephemeral-key', { method: 'POST', body: JSON.stringify(input) });
   return r.error || !r.data ? null : r.data;
 }
-export async function freezeClearCard(active: boolean): Promise<ClearCard | null> {
+export async function freezeClearCard(active: boolean): Promise<CardResult<ClearCard>> {
   const r = await apiRequest<{ card: ClearCard }>('/api/cards/freeze', { method: 'POST', body: JSON.stringify({ active }) });
-  return r.error || !r.data ? null : r.data.card;
+  if (r.error) return cardFailure(r.error);
+  return { value: r.data?.card ?? null };
 }
 
 export async function getNotifications(wallet: string): Promise<{ notifications: ApiNotification[]; unreadCount: number }> {


### PR DESCRIPTION
Activation was the one that got noticed, because it has a button that visibly does nothing. The others fail the same way and are quieter about it.

## The worst one is the read, not any action

```ts
export async function getCards(): Promise<MemberCard[]> {
  return r.error ? [] : (r.data?.cards ?? []);
}
```

`[]` meant both *"no cards"* and *"couldn't load"* — and this page renders no-cards as an **Activate card** button.

So a member who **has** a card was invited to create one every time that read hiccuped. That isn't a missing message; it's the page asserting something false about their account, and unlike a dead button it looks completely normal. `loaded` now stays false on failure, so the placeholder holds and a notice explains.

## Freeze sprang back and said nothing

The existing comment was right — a failed freeze must not leave the card looking frozen, since a member who believes their card is dead when it isn't is worse off. But `setCard({ ...card })` made *"it failed"* and *"I misclicked"* look identical, so the safer state was communicated as an accident. It reverts **and** says why.

## The Bridge/Stripe card had the same hole one layer up

`useClearCard.activate` threw the result away entirely: activation failed, `refresh()` found no card, the spinner stopped, and the button offered to activate again.

## One shape, not four

| call | before | now |
|---|---|---|
| `getCards` | `[]` on failure | `CardResult<MemberCard[]>` |
| `createCard` | bespoke `{card, error, unavailable}` | `CardResult<MemberCard>` |
| `setCardFrozen` | `null` | `CardResult<MemberCard>` |
| `activateClearCard` | `null` | `CardResult<{status, card}>` |
| `freezeClearCard` | `null` | `CardResult<ClearCard>` |

`unavailable` separates an integration that's switched off from something a member can retry. `createCard` folded in too, so last PR's fix isn't a special case.

**Checked and left alone:** `StripeCardDetails` already sets an error state; `setCardSpendLimit`, `getCardEmbedUrl` and `freezeClearCard` have no call sites yet.

## One I broke and caught by reading, not by typechecking

Appending the error paragraph to `BillPortalBrowser`'s three-branch ternary first collapsed it to two — which would have shown *"your Clear card is activating"* underneath the live card details. It typechecked perfectly.

507 tests, 5 new. Build and dist scan clean. Reverting `getCards` to `[]` makes one fail.