### PR TITLE
Tell an unprovisioned member something true

### DIFF
--- a/app/src/pages/app/CardRoute.tsx
+++ b/app/src/pages/app/CardRoute.tsx
@@ -81,14 +81,17 @@ export default function CardRoute() {
     setBusy(true);
     setNotice(null);
     try {
-      const { value: created, error, unavailable } = await createCard('Clear card');
+      const { value: created, error, unavailable, needsSetup } = await createCard('Clear card');
       if (created) {
         setCard(created);
         return;
       }
       setNotice(
-        unavailable
-          ? "Cards aren't switched on yet. Nothing to do — we'll enable this for your account."
+        unavailable || needsSetup
+          ? // Both are "not yet", from the member's side. The difference between an unset API key
+            // and an unbuilt KYC step matters to us and not at all to them; what matters to them is
+            // that pressing this again will not help.
+            "Card setup isn't finished for your account yet. Nothing to do here — we'll let you know when it's ready."
           : `That didn't go through. ${error ?? 'Please try again.'}`,
       );
     } finally {

--- a/app/src/pages/app/cardActivation.test.ts
+++ b/app/src/pages/app/cardActivation.test.ts
@@ -125,3 +125,35 @@ describe('no card path fails silently', () => {
     expect(portal).toContain('role="status"');
   });
 });
+
+/*
+ * "Member is not provisioned" is a third thing, and worth its own case.
+ *
+ * It is not an outage and not a retry: the key is set, Lithic is answering, and the member simply
+ * has no account holder. They cannot have one — `ensureProvisioned` is reached from exactly one
+ * route, POST /api/lithic/account, and nothing in the client calls it. No member is provisioned,
+ * old account or new.
+ *
+ * So the member-facing wording deliberately collapses it with `unavailable`: the distinction
+ * between an unset API key and an unbuilt setup step matters to us and not at all to them. What
+ * matters to them is that pressing the button again will not help.
+ */
+describe('an unprovisioned member is told something true', () => {
+  const client = read('utils/apiClient.ts');
+  const route = read('pages/app/CardRoute.tsx');
+
+  test('the server’s wording is matched, not shown', () => {
+    // "Member is not provisioned" is a sentence about our database, not about the person reading.
+    const shape = client.slice(client.indexOf('function cardFailure'), client.indexOf('export async function getCards'));
+    expect(shape).toMatch(/needsSetup: \/not provisioned\/i\.test\(error\)/);
+    expect(route).not.toContain('not provisioned');
+  });
+
+  test('and it does not invite a retry that cannot work', () => {
+    const activate = route.slice(route.indexOf('const activate'), route.indexOf('const toggleFreeze'));
+    expect(activate).toContain('unavailable || needsSetup');
+    const retry = activate.slice(activate.indexOf('unavailable || needsSetup'));
+    // The "try again" branch must be the other one.
+    expect(retry.indexOf("we'll let you know")).toBeLessThan(retry.indexOf('Please try again'));
+  });
+});

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -1945,11 +1945,28 @@ export interface MemberCard {
 export interface CardResult<T> {
   value: T | null;
   error?: string;
+  /** The integration is switched off (no LITHIC_API_KEY). Nothing the member can do. */
   unavailable?: boolean;
+  /**
+   * The member has no Lithic account holder yet, so there is nothing to issue a card against.
+   *
+   * Distinct from `unavailable` because the cause is different and so is the fix: the key is set
+   * and Lithic is answering, but provisioning needs KYC fields (date of birth, government id,
+   * street address) that no screen collects and no code path submits. Not a retry, and not an
+   * outage — a step that does not exist yet.
+   */
+  needsSetup?: boolean;
 }
 
 function cardFailure<T>(error: string): CardResult<T> {
-  return { value: null, error, unavailable: /unavailable/i.test(error) };
+  return {
+    value: null,
+    error,
+    unavailable: /unavailable/i.test(error),
+    // The server's exact words. Matched here rather than shown, because "Member is not
+    // provisioned" is a sentence about our database, not about the person reading it.
+    needsSetup: /not provisioned/i.test(error),
+  };
 }
 
 /**


### PR DESCRIPTION
**It isn't an old-account problem** — worth stating plainly, because that's the natural thing to assume.

The chain:

```
lithicStore.upsert        ← called only by provisioningService.ensureProvisioned
ensureProvisioned         ← called only by POST /api/lithic/account
POST /api/lithic/account  ← called by nothing
```

No screen calls it. No onboarding step calls it. No KYC hook calls it. No script writes that table. **So no member is provisioned** — not this account because it predates the integration, and not one created this morning either. Activate card cannot succeed for anybody.

## The message

It surfaced as:

> That didn't go through. Member is not provisioned

That's a sentence about our database handed to a person, and it invites a retry that cannot work. `needsSetup` carries the case now, and the member sees the same "not yet" wording as an unset API key — the difference between an unconfigured integration and an unbuilt step matters to us and not at all to them.

## What I deliberately did not do

Pick a provisioning workflow. `accountService`'s own docblock already settles why:

> KYC_BYO — we assert we verified them… Our Bridge flow does verify members, but claiming that satisfies Lithic's bank sponsor is **their sponsor's call to make, not an inference to encode. Available, never automatic.**

And `KYC_BASIC` needs date of birth and a government id, which no screen collects. Either way this is a compliance decision plus a screen, not a patch.

509 tests, 2 new. Build and dist scan clean.