### PR TITLE
Keep SSNs out of the logs, not just out of the database

### DIFF
--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { redactError } from './utils/redact.js';
 import { createServer } from 'http';
 import cors from 'cors';
 import compression from 'compression';
@@ -267,10 +268,18 @@ async function startServer() {
 
     // Error handler (must be after all routes and 404 handler)
     app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
-      console.error('Unhandled error:', err);
+      /*
+       * Redacted, because this handler sees requests it knows nothing about.
+       *
+       * Logging the Error whole is the natural thing to write and the reason it is worth changing:
+       * a provider SDK hangs the failed request off the error, so `console.error('...', err)` on
+       * the one route that carries an SSN would have written it to the log wholesale. The dev-only
+       * message goes through the same scrub — a laptop's console is still a place data ends up.
+       */
+      console.error('Unhandled error:', redactError(err));
       res.status(500).json({
         error: 'Internal server error',
-        message: process.env.NODE_ENV === 'development' ? err.message : 'An error occurred',
+        message: process.env.NODE_ENV === 'development' ? redactError(err) : 'An error occurred',
       });
     });
 

--- a/app/server/src/routes/lithic.ts
+++ b/app/server/src/routes/lithic.ts
@@ -1,4 +1,5 @@
 import express, { type Request, type Response } from 'express';
+import { redactError } from '../utils/redact.js';
 import { isConfigured } from '../services/lithic/lithicClient.js';
 import {
   ensureProvisioned,
@@ -55,7 +56,7 @@ router.get('/account', async (req: Request, res: Response) => {
       deposit,
     });
   } catch (error) {
-    console.error('[lithic] account read failed:', error);
+    console.error('[lithic] account read failed:', redactError(error));
     res.status(500).json({ error: 'Failed to read Lithic account' });
   }
 });
@@ -126,7 +127,15 @@ router.post('/account', async (req: Request, res: Response) => {
       awaitingFinancialAccounts: result.awaitingFinancialAccounts,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Provisioning failed';
+    /*
+     * Redacted on both exits.
+     *
+     * This is the only request in the app carrying an SSN and a date of birth, and a provider that
+     * rejects it commonly says which field was wrong by quoting it back. That message was going
+     * straight into Railway's logs and straight to the browser in a 502 — neither of which is
+     * "storing" it, and both of which outlive the request.
+     */
+    const message = redactError(error);
     console.error('[lithic] provisioning failed:', message);
     res.status(502).json({ error: message });
   }

--- a/app/server/src/routes/lithicNoStore.test.ts
+++ b/app/server/src/routes/lithicNoStore.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(import.meta.dirname, '..', p), 'utf8');
+
+/*
+ * The decision: a member's SSN, date of birth and government id pass through to Lithic and are
+ * never kept. These pin the parts of that which are easy to undo by accident.
+ */
+describe('identity data is passed through, never kept', () => {
+  test('the table has no column that could hold any of it', () => {
+    const store = read('services/lithic/lithicStore.ts');
+    const schema = store.slice(store.indexOf('CREATE TABLE'), store.indexOf('CREATE UNIQUE INDEX'));
+    for (const column of ['ssn', 'government', 'dob', 'birth', 'first_name', 'last_name', 'address']) {
+      expect(schema.toLowerCase()).not.toContain(column);
+    }
+    // What it does hold: provider tokens and a status, none of which identify anyone on their own.
+    expect(schema).toContain('account_token');
+    expect(schema).toContain('status');
+  });
+
+  test('nothing persists the request body', () => {
+    const route = read('routes/lithic.ts');
+    // The body is destructured into the provisioning call and goes nowhere else.
+    expect(route).not.toMatch(/upsert\([^)]*body/);
+    expect(route).not.toMatch(/INSERT|UPDATE\s+/i);
+  });
+
+  test('a provider error never reaches the log or the response unscrubbed', () => {
+    const route = read('routes/lithic.ts');
+    expect(route).toContain('redactError(error)');
+    // The shape that leaked: `error.message` straight into both.
+    expect(route).not.toMatch(/error instanceof Error \? error\.message/);
+  });
+
+  test('and the catch-all handler scrubs too, since it sees this route as well', () => {
+    const index = read('index.ts');
+    const handler = index.slice(index.indexOf("console.error('Unhandled error:'"));
+    expect(handler.slice(0, 200)).toContain('redactError(err)');
+    expect(handler.slice(0, 400)).not.toMatch(/message: process\.env\.NODE_ENV === 'development' \? err\.message/);
+  });
+
+  test('the field list the route validates is names only', () => {
+    // `missing` is returned to the client on a 400. Names are safe; values would not be.
+    const route = read('routes/lithic.ts');
+    const missing = route.slice(route.indexOf('const missing'), route.indexOf('const workflow'));
+    expect(missing).toMatch(/missing\.push\('[a-zA-Z.]+'\)/);
+    expect(missing).not.toMatch(/missing\.push\(body\./);
+  });
+});

--- a/app/server/src/utils/redact.test.ts
+++ b/app/server/src/utils/redact.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test';
+import { redactSensitive, redactError } from './redact.js';
+
+const SSN = '123-45-6789';
+
+describe('identity data does not reach a log or a response', () => {
+  test('an SSN in a provider error is scrubbed', () => {
+    const out = redactError(new Error(`400 Invalid government_id: ${SSN}`));
+    expect(out).not.toContain(SSN);
+    expect(out).toContain('[redacted]');
+  });
+
+  test('so is a bare one with no key next to it', () => {
+    expect(redactSensitive(`applicant ${SSN} rejected`)).not.toContain(SSN);
+  });
+
+  test('and a whole request body echoed back by an SDK', () => {
+    const body = JSON.stringify({
+      first_name: 'Ada',
+      dob: '1985-04-12',
+      government_id: SSN,
+      address: { address1: '1 Test Street' },
+    });
+    const out = redactSensitive(`Lithic rejected: ${body}`);
+    expect(out).not.toContain(SSN);
+    expect(out).not.toContain('1985-04-12');
+    // The parts that make an error useful survive.
+    expect(out).toContain('Ada');
+    expect(out).toContain('1 Test Street');
+  });
+
+  test('both key conventions, since the SDK uses one and our route the other', () => {
+    expect(redactSensitive(`governmentId=${SSN}`)).not.toContain(SSN);
+    expect(redactSensitive(`government_id: "${SSN}"`)).not.toContain(SSN);
+  });
+
+  test('an ISO timestamp is left alone', () => {
+    // tos_timestamp and created_at are in every one of these payloads; redacting them would make
+    // the logs useless and buy nothing.
+    const line = 'tos_timestamp 2026-08-26T14:00:00.000Z accepted';
+    expect(redactSensitive(line)).toContain('2026-08-26T14:00:00.000Z');
+  });
+
+  test('a date on its own is not, because here that means a birthday', () => {
+    expect(redactSensitive('dob 1985-04-12')).not.toContain('1985-04-12');
+  });
+
+  test('properties hung off an Error are searched too, not just its message', () => {
+    // JSON.stringify(error) is `{}` — a naive implementation stops working here and looks fine.
+    const err = Object.assign(new Error('Request failed'), { requestBody: { government_id: SSN } });
+    expect(redactError(err)).not.toContain(SSN);
+  });
+
+  test('nested context is redacted rather than silently dropped', () => {
+    // The first version used an array replacer, which filters keys at every level: the whole
+    // nested object disappeared. Safe, by accident, and useless for debugging — and it meant the
+    // redaction was never exercised on the shape a real SDK error actually has.
+    const err = Object.assign(new Error('400 Bad Request'), {
+      status: 400,
+      error: { message: 'invalid government_id', request: { individual: { dob: '1985-04-12', government_id: SSN, first_name: 'Ada' } } },
+    });
+    const out = redactError(err);
+    expect(out).not.toContain(SSN);
+    expect(out).not.toContain('1985-04-12');
+    // The context that makes it worth logging survives.
+    expect(out).toContain('invalid government_id');
+    expect(out).toContain('Ada');
+    expect(out).toContain('400');
+  });
+
+  test('and an unserialisable error still returns something', () => {
+    const circular: Record<string, unknown> = { government_id: SSN };
+    circular.self = circular;
+    expect(() => redactError(circular)).not.toThrow();
+    expect(redactError(circular)).not.toContain(SSN);
+  });
+});

--- a/app/server/src/utils/redact.ts
+++ b/app/server/src/utils/redact.ts
@@ -1,0 +1,95 @@
+/*
+ * Scrub identity data out of anything on its way to a log or a response.
+ *
+ * The decision this enforces: we pass a member's SSN, date of birth and government id straight
+ * through to Lithic and never store them. That is a decision about our database, and a database is
+ * not the only place data lands. A provider SDK that echoes the offending request in its error
+ * message, an unhandled throw logged whole, a 502 carrying the message to the browser — none of
+ * those are "storing" anything, and all of them end with an SSN somewhere it will outlive the
+ * request: Railway's log retention, a browser console, an error tracker.
+ *
+ * So this is applied at the two exits — what we log, and what we answer — rather than trusted to
+ * every future call site remembering.
+ *
+ * Deliberately conservative. Over-redacting a log costs someone one debugging round; under-
+ * redacting one costs a member their identity, and there is no round two.
+ */
+
+/** Keys whose values are identity data wherever they appear, in either casing convention. */
+const SENSITIVE_KEYS = [
+  'government_id',
+  'governmentId',
+  'ssn',
+  'itin',
+  'tax_id',
+  'taxId',
+  'dob',
+  'date_of_birth',
+  'dateOfBirth',
+];
+
+const KEY_VALUE = new RegExp(
+  `("?(?:${SENSITIVE_KEYS.join('|')})"?\\s*[:=]\\s*)("?)([^",}\\s]+)(\\2)`,
+  'gi',
+);
+
+/** SSN/ITIN as a bare string, with or without dashes — the backstop for an unkeyed leak. */
+const SSN_SHAPED = /\b\d{3}-\d{2}-\d{4}\b/g;
+
+/**
+ * A date on its own, which in this codebase's request bodies means a date of birth.
+ *
+ * Not applied to ISO timestamps: `2026-08-26T14:00:00Z` is a `tos_timestamp` or a `created_at` and
+ * redacting those makes logs unreadable for no gain. The lookahead is what tells them apart.
+ */
+const DATE_ONLY = /\b\d{4}-\d{2}-\d{2}\b(?!T)/g;
+
+/** Redact identity data from a string bound for a log or an HTTP response. */
+export function redactSensitive(input: string): string {
+  return input
+    .replace(KEY_VALUE, (_m, key: string, quote: string) => `${key}${quote}[redacted]${quote}`)
+    .replace(SSN_SHAPED, '[redacted]')
+    .replace(DATE_ONLY, '[redacted]');
+}
+
+/**
+ * The message from a thrown value, redacted — including anything an SDK attached to it.
+ *
+ * Errors are not always strings and not always shallow: a provider error can carry the request on
+ * `cause`, `response.data` or its own enumerable fields, so the whole object is serialised before
+ * scrubbing rather than only `.message`.
+ */
+export function redactError(error: unknown): string {
+  if (error instanceof Error) {
+    let extra = '';
+    try {
+      /*
+       * Copy the own properties, then stringify normally.
+       *
+       * Not `JSON.stringify(error, [...keys])`: an array replacer filters keys at EVERY level, so a
+       * nested `{ request: { individual: { dob, government_id } } }` came out with the whole
+       * `individual` object dropped. That happens to be safe and it is not the mechanism intended
+       * — it deleted the context that makes an error worth logging, and it meant the redaction was
+       * never actually exercised on nested data. Safety by accident stops being safe the moment the
+       * accident changes.
+       *
+       * A full JSON.stringify of an Error is `{}`, which is the other way this quietly does nothing.
+       */
+      const own: Record<string, unknown> = {};
+      for (const key of Object.getOwnPropertyNames(error)) {
+        if (key === 'stack' || key === 'message') continue;
+        own[key] = (error as unknown as Record<string, unknown>)[key];
+      }
+      const serialised = JSON.stringify(own);
+      if (serialised && serialised !== '{}') extra = ` ${serialised}`;
+    } catch {
+      // Circular or unserialisable. The message alone is still worth having.
+    }
+    return redactSensitive(`${error.message}${extra}`);
+  }
+  try {
+    return redactSensitive(typeof error === 'string' ? error : JSON.stringify(error) ?? 'Unknown error');
+  } catch {
+    return 'Unknown error';
+  }
+}


### PR DESCRIPTION
Agreed — and *"we don't store it"* is the easy half.

**Already true:** `lithic_accounts` holds nothing but provider tokens and a status. No name, no address, no dob, no government id. The route hands the body to Lithic and keeps none of it.

**Not true:** a body leaks without anyone storing it.

| exit | what it did |
|---|---|
| provisioning `catch` | `error.message` → `console.error` **and** → a 502 to the browser |
| global error handler | `console.error('Unhandled error:', err)` — the Error whole |

Providers commonly reject a KYC submission by quoting the offending field back. So the one request in this app carrying an SSN had a failure path that wrote it to Railway's logs *and* returned it to the client. And an SDK hangs the failed request off the error object, so the catch-all handler is the same leak by a different route for any unhandled throw.

Neither is storage. Both outlive the request — log retention, a browser console, an error tracker.

## Redaction at the two exits

Not trusted to every future call site: applied to **what we log** and **what we answer**.

- Sensitive keys in both casing conventions (`government_id` / `governmentId`, `dob` / `dateOfBirth`, `ssn`, `itin`, `tax_id`)
- Bare SSN shape as a backstop for an unkeyed leak
- Date-only, which here means a birthday — but **not** ISO timestamps, since `tos_timestamp` is in every one of these payloads and scrubbing it buys nothing

## One I got wrong, and caught by reading the output rather than the green test

The first version serialised the error with an array replacer — which filters keys at **every** level. The nested request object wasn't redacted, it was **deleted**. Safe by accident, useless for debugging, and it meant the redaction was never exercised on the shape a real SDK error actually has.

Own properties are copied and stringified normally now, so nesting survives *and* gets scrubbed:

```json
{"status":400,"error":{"message":"invalid government_id",
 "request":{"individual":{"dob":"[redacted]",
 "government_id":"[redacted]","first_name":"Ada"}}}}
```

The context that makes an error worth logging is still there.

163 server tests (10 new), 523 app tests. Reverting the route's redaction makes one fail.