### PR TITLE
One identity check, and the screens the design asks for

### DIFF
--- a/app/server/src/routes/plaid.ts
+++ b/app/server/src/routes/plaid.ts
@@ -1,4 +1,6 @@
 import { Router, Request, Response } from 'express';
+import { redactError } from '../utils/redact.js';
+import { getAccountHolder } from '../services/plaidIdentityService.js';
 import {
   Configuration,
   PlaidApi,
@@ -2559,6 +2561,31 @@ router.post('/disconnect', async (req: Request, res: Response) => {
       error: 'Failed to disconnect',
       message: error instanceof Error ? error.message : 'Unknown error',
     });
+  }
+});
+
+/**
+ * GET /api/plaid/identity — the account holder, as the bank knows them.
+ *
+ * For the verification screen, which shows a name and address rather than asking for them. Nulls
+ * are the ordinary answer, not an error: Identity is an optional Plaid product, so an institution
+ * without it links fine and the screen falls back to asking.
+ *
+ * Deliberately not part of the KYC submission. The member confirms what is shown and the client
+ * sends it back, so a wrong record is corrected by a person rather than silently submitted.
+ */
+router.get('/identity', async (req: Request, res: Response) => {
+  const walletAddress = String((req.query.walletAddress as string) || '').toLowerCase();
+  if (!walletAddress) return res.status(400).json({ error: 'walletAddress is required' });
+  if (!requireWalletMatch(req, res, walletAddress, 'walletAddress')) return;
+
+  try {
+    const holder = await getAccountHolder(walletAddress);
+    res.json({ legalName: holder.legalName, address: holder.address });
+  } catch (error) {
+    console.error('[plaid] identity read failed:', redactError(error));
+    // A failure here costs a prefill, not the flow. The screen asks instead.
+    res.json({ legalName: null, address: null });
   }
 });
 

--- a/app/server/src/routes/plaid.ts
+++ b/app/server/src/routes/plaid.ts
@@ -291,6 +291,23 @@ router.post('/link-token', async (req: Request, res: Response) => {
     const optionalProducts: Products[] = [];
     if (process.env.PLAID_ENABLE_INVESTMENTS === 'true') optionalProducts.push(Products.Investments);
     if (process.env.PLAID_ENABLE_LIABILITIES === 'true') optionalProducts.push(Products.Liabilities);
+    /*
+     * Identity: the account holder's legal name and address, from the bank.
+     *
+     * Optional rather than required, deliberately. As a required product, Link refuses any
+     * institution that does not support Identity — trading the KYC screen's convenience for members
+     * who cannot connect their bank at all, which is the wrong way round. As optional it is
+     * initialised where available and simply absent elsewhere, and the verification screen already
+     * has the path for that: name and address are shown with "Not right? Change it", so a member at
+     * an institution without Identity types what a member at one confirms.
+     *
+     * It is what makes that screen two fields instead of six, and it fixes a second thing:
+     * withdrawals were sending Plaid's account NICKNAME to Bridge as the account owner's name.
+     *
+     * Billed per item. PLAID_DISABLE_IDENTITY=true turns it off, which costs the prefill and
+     * restores the old owner-name fallback.
+     */
+    if (process.env.PLAID_DISABLE_IDENTITY !== 'true') optionalProducts.push(Products.Identity);
     const baseRequest: LinkTokenCreateRequest = {
       client_name: 'Protocol Contracts',
       language: 'en',

--- a/app/server/src/services/plaidIdentity.test.ts
+++ b/app/server/src/services/plaidIdentity.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(import.meta.dirname, '..', p), 'utf8');
+
+/*
+ * Two problems, one cause: we never asked Plaid who the account holder is.
+ *
+ * A withdrawal sent Plaid's account NICKNAME to Bridge as the owner's legal name, and the identity
+ * screen had to ask for a name and address the bank already knows.
+ */
+describe('the account holder comes from the bank', () => {
+  const plaid = read('routes/plaid.ts');
+  const withdraw = read('services/withdrawService.ts');
+  const identity = read('services/plaidIdentityService.ts');
+
+  test('Identity is requested', () => {
+    expect(plaid).toContain('Products.Identity');
+  });
+
+  test('as OPTIONAL, so an institution without it can still be linked', () => {
+    // Required would trade the KYC screen's convenience for members who cannot connect at all.
+    const block = plaid.slice(plaid.indexOf('const optionalProducts'), plaid.indexOf('const baseRequest'));
+    expect(block).toContain('optionalProducts.push(Products.Identity)');
+    const required = plaid.slice(plaid.indexOf('products: [Products'), plaid.indexOf('products: [Products') + 90);
+    expect(required).not.toContain('Identity');
+  });
+
+  test('withdrawals no longer send the account nickname as a person’s name', () => {
+    // `acct.name` is "TOTAL CHECKING" — a product label where a legal name belongs, on every ACH credit.
+    expect(withdraw).not.toMatch(/ownerName = .*acct\?\.name/);
+    expect(withdraw).toContain('holder.legalName');
+  });
+
+  test('and fall back to a placeholder rather than a guess', () => {
+    expect(withdraw).toContain("holder.legalName || 'Account holder'");
+  });
+
+  test('a bank without Identity returns nothing rather than throwing', () => {
+    // This is the documented path, not an error: the caller has somewhere honest to go.
+    const fn = identity.slice(identity.indexOf('export async function getAccountHolder'));
+    expect(fn).toContain('continue;');
+    expect(fn).toContain('return EMPTY;');
+  });
+
+  test('a joint account resolves to the primary holder and mailing address', () => {
+    expect(identity).toContain('owner.names?.[0]');
+    expect(identity).toContain('a.primary');
+  });
+
+  test("Plaid's `region` is mapped to the `state` both Lithic and Bridge want", () => {
+    expect(identity).toContain('state: data.region');
+  });
+});

--- a/app/server/src/services/plaidIdentityService.ts
+++ b/app/server/src/services/plaidIdentityService.ts
@@ -1,0 +1,85 @@
+import { getPlaidClient } from '../routes/plaid.js';
+import { plaidTokenStore } from './plaidTokenStore.js';
+
+/*
+ * The account holder, as the bank knows them.
+ *
+ * Two callers want the same thing for different reasons, and they were solving it separately and
+ * one of them wrongly:
+ *
+ *  - A withdrawal has to tell Bridge whose account it is paying. It was sending `account.name`,
+ *    which is Plaid's word for the account's NICKNAME — "TOTAL CHECKING", "Plaid Saving". A product
+ *    label where a person's legal name belongs.
+ *  - The verification screen shows name and address rather than asking for them, which is what
+ *    makes it two fields instead of six.
+ *
+ * `Identity` is requested as an OPTIONAL Plaid product, so this legitimately returns null: an
+ * institution that does not support it still links, and both callers have somewhere honest to go —
+ * the withdrawal falls back, the screen asks.
+ */
+
+export interface PlaidAccountHolder {
+  /** The bank's spelling of the member's legal name. */
+  legalName: string | null;
+  address: {
+    address1: string | null;
+    city: string | null;
+    /** Plaid calls it `region`; Lithic and Bridge both call it `state`. */
+    state: string | null;
+    postalCode: string | null;
+    country: string | null;
+  } | null;
+}
+
+const EMPTY: PlaidAccountHolder = { legalName: null, address: null };
+
+/**
+ * Read the holder of one linked account.
+ *
+ * `plaidAccountId` is optional: withdrawals care about a specific account, while the verification
+ * screen only wants "who is this member", and any linked account answers that equally well.
+ */
+export async function getAccountHolder(
+  wallet: string,
+  plaidAccountId?: string,
+): Promise<PlaidAccountHolder> {
+  const client = getPlaidClient();
+  if (!client || !plaidTokenStore.isConfigured()) return EMPTY;
+
+  const items = await plaidTokenStore.getItems(wallet);
+  for (const item of items) {
+    let resp;
+    try {
+      resp = await client.identityGet({ access_token: item.access_token });
+    } catch {
+      // Institution without Identity, or a product not yet initialised on this item. Not an error
+      // worth surfacing — it is the documented reason this returns null.
+      continue;
+    }
+    const accounts = resp.data.accounts ?? [];
+    const account = plaidAccountId
+      ? accounts.find((a: { account_id: string }) => a.account_id === plaidAccountId)
+      : accounts.find((a: { owners?: unknown[] }) => (a.owners?.length ?? 0) > 0);
+    const owner = account?.owners?.[0];
+    if (!owner) continue;
+
+    // Banks return several names on a joint account. The first is the primary holder, which is who
+    // an ACH credit is going to and who is signing up.
+    const legalName = owner.names?.[0]?.trim() || null;
+    // `primary` marks the mailing address; without the flag the first is the best available guess.
+    const chosen = owner.addresses?.find((a: { primary?: boolean | null }) => Boolean(a.primary)) ?? owner.addresses?.[0];
+    const data = chosen?.data;
+    const address = data
+      ? {
+          address1: data.street?.trim() || null,
+          city: data.city?.trim() || null,
+          state: data.region?.trim() || null,
+          postalCode: data.postal_code?.trim() || null,
+          country: data.country?.trim() || null,
+        }
+      : null;
+
+    if (legalName || address) return { legalName, address };
+  }
+  return EMPTY;
+}

--- a/app/server/src/services/withdrawService.ts
+++ b/app/server/src/services/withdrawService.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { getAccountHolder } from './plaidIdentityService.js';
 import { createHash } from 'crypto';
 import { bridge } from './billerPayoutService.js';
 import { resolveCustomerForEmails } from './bridgeCustomerService.js';
@@ -48,6 +49,7 @@ export interface WithdrawResult {
   depositAmount?: string;
 }
 
+
 /** Plaid Auth: account_number + routing_number + checking/savings for a linked account the user owns. */
 export async function resolveBankNumbers(
   wallet: string,
@@ -71,7 +73,21 @@ export async function resolveBankNumbers(
     const ach = resp.data.numbers?.ach?.find((n) => n.account_id === plaidAccountId);
     if (!ach) continue;
     const acct = resp.data.accounts?.find((a) => a.account_id === plaidAccountId);
-    const ownerName = resp.data.accounts?.length ? (acct?.name || 'Account holder') : 'Account holder';
+    /*
+     * The holder's name, not the account's.
+     *
+     * This read `acct.name`, which is Plaid's ACCOUNT NICKNAME — "TOTAL CHECKING", "Plaid Saving" —
+     * and sent it to Bridge as `account_owner_name`. Every ACH credit carried a product label where
+     * the recipient's legal name belongs. Banks match those, and Bridge has no way to know the
+     * difference.
+     *
+     * Identity is optional per institution, so the fallback is real rather than defensive. It is
+     * the old placeholder rather than the member's typed name: the private profile is encrypted and
+     * keyed by member, and reaching into it from a money path to guess at a name buys less than it
+     * costs. A generic placeholder is at least not a wrong name.
+     */
+    const holder = await getAccountHolder(wallet, plaidAccountId);
+    const ownerName = holder.legalName || 'Account holder';
     if (!ach.account || !ach.routing) return { error: 'This bank did not return account/routing numbers.' };
     // Bridge wants the real account type; Plaid's subtype tells us. Anything that isn't explicitly
     // savings (checking, money market, …) is treated as checking for ACH purposes.

--- a/app/src/components/app-ui/VerifyIdentityModal.tsx
+++ b/app/src/components/app-ui/VerifyIdentityModal.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useAppKitAccount } from '@/lib/walletCompat';
+import { useIdentity } from '@/context/IdentityContext';
+import { openWhileWaiting, type IdentityState } from '@/lib/identityStatus';
+import { toIsoDob, toFormattedSsn } from '@/lib/identityFields';
+import { getBankIdentity, submitIdentity, type BankIdentity } from '@/utils/apiClient';
+
+/*
+ * Verifying identity — one modal, several entry points.
+ *
+ * Reached from Settings, card activation, and (when they exist) counter onboarding and the first
+ * term plan. Same screens each time; only where the member came from differs, which is why this
+ * takes no "flow" prop — the closing screen is chosen by the status Lithic returns, not by the
+ * caller's opinion of what should happen next.
+ *
+ * ## What is deliberately on screen
+ *
+ * "This is not a credit check" — because a member asked for an SSN two screens after being told
+ * there is no credit check will assume they were lied to. Naming the difference is the whole
+ * reason the sentence exists.
+ *
+ * "Clear never keeps it" — a real architectural claim, not reassurance: the values below go to the
+ * card issuer and are never persisted, logged or echoed back. Said where the field is, rather than
+ * in a privacy policy.
+ *
+ * ## What is NOT here
+ *
+ * The ID-photo upload for PENDING_DOCUMENT. That screen explains the state and stops, because the
+ * upload should go straight from the browser to the issuer rather than through us — routing a
+ * passport photo through our server makes us responsible for it in exactly the way we are avoiding.
+ * Building it half-way, as a button that looks like it works, would be worse than saying so.
+ */
+
+type Step = 'form' | 'checking' | 'result';
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 py-1.5">
+      <span className="text-[13px] text-foreground-secondary">{label}</span>
+      <span className="text-[13px] text-foreground">{value}</span>
+    </div>
+  );
+}
+
+function Outcome({ state, onClose }: { state: IdentityState; onClose: () => void }) {
+  const { open, waiting } = openWhileWaiting(state);
+
+  if (state === 'verified') {
+    return (
+      <div className="space-y-4 text-center">
+        <p className="text-lg text-foreground">You&rsquo;re verified</p>
+        <p className="text-[13px] text-foreground-secondary">Nothing else to do</p>
+        <div className="rounded-xl border border-border px-3 py-2 text-left">
+          <Row label="Credit" value="Ready to use" />
+          <Row label="Term plans" value="Unlocked" />
+          <Row label="Your card" value="Ships in 5–7 days" />
+        </div>
+        <Button variant="clear" className="w-full" onClick={onClose}>Continue</Button>
+      </div>
+    );
+  }
+
+  if (state === 'rejected') {
+    /*
+     * The screen the design did not have, and the hardest copy in the flow.
+     *
+     * No retry button: re-submitting the same details produces the same answer, and a button that
+     * implies otherwise sends someone round a loop that cannot end. No reason either — a rejection
+     * reason is rarely something the member can act on and guessing at it invites an argument the
+     * app cannot settle. What it does say is what still works, because that is true and it is the
+     * part they need.
+     */
+    return (
+      <div className="space-y-4 text-center">
+        <p className="text-lg text-foreground">We couldn&rsquo;t verify you</p>
+        <p className="text-[13px] leading-relaxed text-foreground-secondary">
+          We&rsquo;re not able to open credit or a card on this account. Support can look at it with
+          you — they can see things this screen can&rsquo;t.
+        </p>
+        <div className="rounded-xl border border-border px-3 py-2 text-left">
+          {open.map((name) => <Row key={name} label={name} value="Open now" />)}
+          {waiting.length > 0 && <Row label={waiting.join(' and ')} value="Not available" />}
+        </div>
+        <Button variant="clear" className="w-full" onClick={onClose}>Done</Button>
+      </div>
+    );
+  }
+
+  const heading =
+    state === 'needs_document'
+      ? 'One more thing'
+      : state === 'needs_resubmit'
+        ? 'Something didn’t match'
+        : 'Under review';
+  const detail =
+    state === 'needs_document'
+      ? 'We couldn’t match your details automatically. A photo of your ID sorts it out — we’ll send you a secure link to add one.'
+      : state === 'needs_resubmit'
+        ? 'One of the details didn’t match your records. We’ll be in touch about which one so you can correct it.'
+        : 'Usually within a day.';
+
+  return (
+    <div className="space-y-4 text-center">
+      <p className="text-lg text-foreground">{heading}</p>
+      <p className="text-[13px] leading-relaxed text-foreground-secondary">{detail}</p>
+      {/*
+        * What still works has to be here.
+        *
+        * A member who has just handed over a social security number and been told to wait assumes
+        * everything is frozen. Savings and Earn need no verification — that is their own money — so
+        * saying they are open turns a dead end into a waiting room.
+        */}
+      <div className="rounded-xl border border-border px-3 py-2 text-left">
+        {open.map((name) => <Row key={name} label={name} value="Open now" />)}
+        <Row label={waiting.join(' and ')} value="When this clears" />
+      </div>
+      <Button variant="clear" className="w-full" onClick={onClose}>Done</Button>
+    </div>
+  );
+}
+
+export default function VerifyIdentityModal() {
+  const { address } = useAppKitAccount();
+  const { open, closeVerification, status, refresh } = useIdentity();
+  const [step, setStep] = useState<Step>('form');
+  const [bank, setBank] = useState<BankIdentity>({ legalName: null, address: null });
+  const [dob, setDob] = useState('');
+  const [ssn, setSsn] = useState('');
+  const [editingDetails, setEditingDetails] = useState(false);
+  const [name, setName] = useState('');
+  const [address1, setAddress1] = useState('');
+  const [city, setCity] = useState('');
+  const [state, setState] = useState('');
+  const [postal, setPostal] = useState('');
+  const [phone, setPhone] = useState('');
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Prefill from the bank. Nulls leave the fields empty and `editingDetails` on, which is the
+  // difference between a member at an institution with Plaid Identity and one without.
+  useEffect(() => {
+    if (!open || !address) return;
+    void getBankIdentity(address).then((result) => {
+      setBank(result);
+      setName(result.legalName ?? '');
+      setAddress1(result.address?.address1 ?? '');
+      setCity(result.address?.city ?? '');
+      setState(result.address?.state ?? '');
+      setPostal(result.address?.postalCode ?? '');
+      setEditingDetails(!result.legalName || !result.address?.address1);
+    });
+  }, [open, address]);
+
+  const reset = () => {
+    // The SSN does not outlive the modal. It is in memory while the form is open and nowhere else:
+    // no draft in localStorage, no analytics event, nothing kept for a retry.
+    setSsn('');
+    setDob('');
+    setStep('form');
+    setError(null);
+  };
+
+  const close = () => {
+    reset();
+    closeVerification();
+    void refresh();
+  };
+
+  const submit = async () => {
+    setError(null);
+    const isoDob = toIsoDob(dob);
+    if (!isoDob) return setError('Enter your date of birth as MM/DD/YYYY. You must be 18 or over.');
+    const formattedSsn = toFormattedSsn(ssn);
+    if (!formattedSsn) return setError('A social security number is nine digits.');
+    const [firstName, ...rest] = name.trim().split(/\s+/);
+    if (!firstName || rest.length === 0) return setError('Enter your first and last name as they appear on your bank account.');
+    if (!phone.trim()) return setError('We need a phone number for your card issuer.');
+    if (!email.trim()) return setError('We need an email address for your card issuer.');
+    if (!address1.trim() || !city.trim() || !state.trim() || !postal.trim()) {
+      return setError('We need your full home address, including street.');
+    }
+
+    setBusy(true);
+    setStep('checking');
+    const result = await submitIdentity({
+      firstName,
+      lastName: rest.join(' '),
+      email: email.trim(),
+      // E.164. Lithic rejects anything else, and a member types a number the way they say it.
+      phoneNumber: phone.trim().startsWith('+') ? phone.replace(/\s/g, '') : `+1${phone.replace(/\D/g, '')}`,
+      dob: isoDob,
+      governmentId: formattedSsn,
+      address: { address1: address1.trim(), city: city.trim(), state: state.trim(), postal_code: postal.trim() },
+    });
+    setBusy(false);
+    // Clear the sensitive fields the moment they have been sent, whatever the answer.
+    setSsn('');
+    setDob('');
+
+    if (!result.ok) {
+      setError(result.error ?? "That didn't go through. Please try again.");
+      setStep('form');
+      return;
+    }
+    await refresh();
+    setStep('result');
+  };
+
+  const field = 'w-full rounded-lg border border-border bg-transparent px-3 py-2 text-[15px] text-foreground placeholder:text-foreground-secondary';
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => { if (!next) close(); }}>
+      <DialogContent className="max-w-sm">
+        {step === 'form' && (
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <p className="text-lg text-foreground">Verify your identity</p>
+              <p className="text-[12px] leading-relaxed text-foreground-secondary">
+                The law requires us to know who our members are before we can lend. This is not a
+                credit check — nothing here touches your score.
+              </p>
+            </div>
+
+            <label className="block space-y-1">
+              <span className="text-[12px] text-foreground-secondary">Date of birth</span>
+              <input className={field} inputMode="numeric" autoComplete="off" placeholder="MM / DD / YYYY"
+                value={dob} onChange={(e) => setDob(e.target.value)} />
+            </label>
+
+            <label className="block space-y-1">
+              <span className="text-[12px] text-foreground-secondary">Social security number</span>
+              {/* type=password so it is not shoulder-read; autoComplete off so it is never saved. */}
+              <input className={field} type="password" inputMode="numeric" autoComplete="off"
+                placeholder="••• •• ••••" value={ssn} onChange={(e) => setSsn(e.target.value)} />
+            </label>
+
+            {!editingDetails ? (
+              <div className="rounded-xl border border-border px-3 py-2">
+                <p className="text-[11px] text-foreground-secondary">From your linked bank</p>
+                <p className="mt-1 text-[13px] text-foreground">{bank.legalName}</p>
+                <p className="text-[12px] text-foreground-secondary">
+                  {[bank.address?.address1, bank.address?.city, bank.address?.state].filter(Boolean).join(', ')}
+                </p>
+                <button type="button" className="mt-1.5 text-[12px] underline text-foreground-secondary"
+                  onClick={() => setEditingDetails(true)}>
+                  Not right? Change it
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <input className={field} placeholder="Full legal name" value={name} onChange={(e) => setName(e.target.value)} />
+                <input className={field} placeholder="Street address" value={address1} onChange={(e) => setAddress1(e.target.value)} />
+                <div className="grid grid-cols-3 gap-2">
+                  <input className={field} placeholder="City" value={city} onChange={(e) => setCity(e.target.value)} />
+                  <input className={field} placeholder="State" value={state} onChange={(e) => setState(e.target.value)} />
+                  <input className={field} placeholder="ZIP" value={postal} onChange={(e) => setPostal(e.target.value)} />
+                </div>
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <input className={field} placeholder="Phone number" inputMode="tel" value={phone} onChange={(e) => setPhone(e.target.value)} />
+              <input className={field} placeholder="Email address" inputMode="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+            </div>
+
+            {error && <p role="status" className="text-[12px] text-foreground">{error}</p>}
+
+            <Button variant="clear" className="w-full" disabled={busy} onClick={() => void submit()}>
+              {busy ? 'Sending…' : 'Continue'}
+            </Button>
+            <p className="text-center text-[11px] leading-relaxed text-foreground-secondary">
+              Encrypted and sent straight to our card issuer. Clear never keeps it.
+            </p>
+          </div>
+        )}
+
+        {step === 'checking' && (
+          <div className="space-y-3 py-6 text-center">
+            <p className="text-lg text-foreground">Checking</p>
+            <p className="text-[13px] text-foreground-secondary">Details received · Matching your records</p>
+            <p className="text-[12px] leading-relaxed text-foreground-secondary">
+              Usually a few seconds. You can close this — we&rsquo;ll tell you either way.
+            </p>
+          </div>
+        )}
+
+        {step === 'result' && <Outcome state={status.state} onClose={close} />}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/app-ui/verifyIdentity.test.ts
+++ b/app/src/components/app-ui/verifyIdentity.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+import { toIsoDob, toFormattedSsn } from '../../lib/identityFields';
+
+/*
+ * The two fields a member types, and the two formats Lithic will not negotiate on: `YYYY-MM-DD`
+ * and `000-00-0000`. Getting either wrong is a 400 after the SSN has already been sent, which is
+ * the worst possible moment to discover a formatting bug.
+ */
+describe('what the member types becomes what the issuer wants', () => {
+  test('a date is reordered, not just reformatted', () => {
+    expect(toIsoDob('04/12/1985')).toBe('1985-04-12');
+    expect(toIsoDob(' 04 / 12 / 1985 ')).toBe('1985-04-12');
+  });
+
+  test('an impossible date is refused rather than silently rolled over', () => {
+    // `new Date('2001-02-31')` is March 3rd. Without the round-trip check that submits a birthday
+    // the member did not type.
+    expect(toIsoDob('02/31/2001')).toBeNull();
+    expect(toIsoDob('13/01/1990')).toBeNull();
+  });
+
+  test('so is a date that would make them a child', () => {
+    const nextYear = new Date().getFullYear() + 1;
+    expect(toIsoDob(`01/01/${nextYear}`)).toBeNull();
+    expect(toIsoDob(`01/01/${new Date().getFullYear() - 5}`)).toBeNull();
+  });
+
+  test('and anything that is not a date at all', () => {
+    for (const bad of ['', '1985-04-12', '4/12/1985', 'not a date']) {
+      expect(toIsoDob(bad)).toBeNull();
+    }
+  });
+
+  test('an SSN is accepted however it is typed and sent one way', () => {
+    for (const typed of ['123456789', '123-45-6789', '123 45 6789']) {
+      expect(toFormattedSsn(typed)).toBe('123-45-6789');
+    }
+  });
+
+  test('a wrong-length one is refused before it is sent', () => {
+    for (const bad of ['', '12345678', '1234567890', 'abcdefghi']) {
+      expect(toFormattedSsn(bad)).toBeNull();
+    }
+  });
+});
+
+/*
+ * The handling rules that follow from "Clear never keeps it" being on the screen.
+ */
+describe('the sensitive fields do not outlive the modal', () => {
+  const raw = require('node:fs').readFileSync(
+    require('node:path').join(import.meta.dirname, 'VerifyIdentityModal.tsx'), 'utf8',
+  ) as string;
+  /*
+   * Comments stripped, for the third time in this codebase.
+   *
+   * The docblock in that file says "no draft in localStorage" — and the first version of this test
+   * failed on its own prose. A rule about what the code does has to be checked against the code.
+   */
+  const source = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+
+  test('nothing is written to storage', () => {
+    expect(source).not.toContain('localStorage');
+    expect(source).not.toContain('sessionStorage');
+  });
+
+  test('nothing is sent to analytics', () => {
+    expect(source).not.toMatch(/\btrack\(/);
+  });
+
+  test('the SSN field cannot be saved by the browser', () => {
+    const ssnField = source.slice(source.indexOf('Social security number'), source.indexOf('editingDetails ?'));
+    expect(ssnField).toContain("autoComplete=\"off\"");
+    expect(ssnField).toContain('type="password"');
+  });
+
+  test('and both are cleared as soon as they have been sent, whatever the answer', () => {
+    const submit = source.slice(source.indexOf('const submit ='), source.indexOf('const field ='));
+    const afterSend = submit.slice(submit.indexOf('setBusy(false)'));
+    expect(afterSend).toContain("setSsn('')");
+    expect(afterSend).toContain("setDob('')");
+    // Before the branch on success, so a failure does not leave them sitting in state.
+    expect(afterSend.indexOf("setSsn('')")).toBeLessThan(afterSend.indexOf('if (!result.ok)'));
+  });
+});

--- a/app/src/components/shell/AppShell.tsx
+++ b/app/src/components/shell/AppShell.tsx
@@ -13,6 +13,7 @@ import { ExternalAccountsProvider } from '@/context/ExternalAccountsContext';
 import { ContactsProvider } from '@/context/ContactsContext';
 import { PayProvider } from '@/context/PayContext';
 import { CreditProvider } from '@/context/CreditContext';
+import { IdentityProvider } from '@/context/IdentityContext';
 import { MoneyActionsProvider } from '@/context/MoneyActionsContext';
 import { useGlobalModals } from '@/context/GlobalModalsContext';
 import { useNotifications } from '@/context/ClearNotificationsContext';
@@ -87,6 +88,7 @@ export default function AppShell() {
       <ExternalAccountsProvider>
       <ContactsProvider>
       <PayProvider>
+      <IdentityProvider>
       <CreditProvider>
       <MoneyActionsProvider>
         <AppChrome trailing={<LiveHeaderActions />}>
@@ -97,6 +99,7 @@ export default function AppShell() {
         <XmtpModalHost />
       </MoneyActionsProvider>
       </CreditProvider>
+      </IdentityProvider>
       </PayProvider>
       </ContactsProvider>
       </ExternalAccountsProvider>

--- a/app/src/context/IdentityContext.tsx
+++ b/app/src/context/IdentityContext.tsx
@@ -1,0 +1,97 @@
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
+import { useAppKitAccount } from '@/lib/walletCompat';
+import { getLithicAccount, type LithicAccountResponse } from '@/utils/apiClient';
+import { toIdentityStatus, type IdentityStatus } from '@/lib/identityStatus';
+import VerifyIdentityModal from '@/components/app-ui/VerifyIdentityModal';
+
+/*
+ * The app's single answer to "is this member verified".
+ *
+ * One provider, one read, one status — the shape the notifications bug taught. Every surface that
+ * asks (the Settings row, the card, a term plan) reads this rather than fetching its own copy that
+ * can disagree.
+ */
+interface IdentityValue {
+  status: IdentityStatus;
+  account: LithicAccountResponse | null;
+  loading: boolean;
+  refresh: () => Promise<void>;
+  /** Whether the verification flow is on screen. */
+  open: boolean;
+  openVerification: () => void;
+  closeVerification: () => void;
+}
+
+const Ctx = createContext<IdentityValue | null>(null);
+
+export function IdentityProvider({ children }: { children: ReactNode }) {
+  const { address } = useAppKitAccount();
+  const [account, setAccount] = useState<LithicAccountResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!address) {
+      setAccount(null);
+      setLoading(false);
+      return;
+    }
+    const result = await getLithicAccount();
+    setAccount(result);
+    setLoading(false);
+  }, [address]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  /*
+   * Re-read when the tab comes back.
+   *
+   * Three of the five statuses resolve on Lithic's side, minutes or a day later, and the screen
+   * promises "you can close this — we'll tell you either way". A member who takes that at its word
+   * and returns should not find the old state waiting for them.
+   */
+  useEffect(() => {
+    const onVisible = () => {
+      if (typeof document !== 'undefined' && !document.hidden) void refresh();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => document.removeEventListener('visibilitychange', onVisible);
+  }, [refresh]);
+
+  const value: IdentityValue = {
+    status: toIdentityStatus(account),
+    account,
+    loading,
+    refresh,
+    open,
+    openVerification: () => setOpen(true),
+    closeVerification: () => setOpen(false),
+  };
+
+  /*
+   * The modal is hosted by the provider, not by each caller.
+   *
+   * Settings, card activation and (later) onboarding all open the same one, and hosting it beside
+   * the state is what keeps "same modal each time" true rather than aspirational — three copies
+   * would drift the way three copies of the notification state did.
+   */
+  return (
+    <Ctx.Provider value={value}>
+      {children}
+      <VerifyIdentityModal />
+    </Ctx.Provider>
+  );
+}
+
+/** The member's identity state. Throws outside the provider rather than answering "unverified". */
+export function useIdentity(): IdentityValue {
+  const value = useContext(Ctx);
+  if (!value) {
+    // A silent default here would be a second, wrong answer to the question this context exists to
+    // make singular — and "unverified" is the worst possible default to invent.
+    throw new Error('useIdentity must be used within an IdentityProvider (mounted in AppShell)');
+  }
+  return value;
+}

--- a/app/src/lib/identityFields.ts
+++ b/app/src/lib/identityFields.ts
@@ -1,0 +1,33 @@
+/**
+ * The two fields a member types, in the two formats the card issuer will not negotiate on.
+ *
+ * Their own module rather than sitting beside the component: they are pure, they are the part most
+ * worth testing, and a validation bug here is a 400 discovered *after* a social security number has
+ * already been sent — the worst possible moment to find one.
+ */
+
+const nowMinus18Years = () => {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - 18);
+  return d;
+};
+
+/** MM/DD/YYYY as typed → YYYY-MM-DD as Lithic wants. Returns null when it isn't a real date. */
+export function toIsoDob(typed: string): string | null {
+  const m = typed.trim().match(/^(\d{2})\s*\/\s*(\d{2})\s*\/\s*(\d{4})$/);
+  if (!m) return null;
+  const [, mm, dd, yyyy] = m;
+  const date = new Date(`${yyyy}-${mm}-${dd}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return null;
+  // Round-trip check: `2026-02-31` parses to March 3rd rather than failing.
+  if (date.getUTCMonth() + 1 !== Number(mm) || date.getUTCDate() !== Number(dd)) return null;
+  if (date > nowMinus18Years()) return null;
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/** SSN as typed → 000-00-0000. Accepts it with or without dashes; rejects anything else. */
+export function toFormattedSsn(typed: string): string | null {
+  const digits = typed.replace(/\D/g, '');
+  if (digits.length !== 9) return null;
+  return `${digits.slice(0, 3)}-${digits.slice(3, 5)}-${digits.slice(5)}`;
+}

--- a/app/src/lib/identityStatus.test.ts
+++ b/app/src/lib/identityStatus.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import { toIdentityStatus, openWhileWaiting } from './identityStatus';
+
+describe('one identity state, from Lithic', () => {
+  test('the integration being off is not the member’s failure', () => {
+    // "Not verified" would read as something they had neglected to do.
+    expect(toIdentityStatus({ configured: false, provisioned: false }).state).toBe('unavailable');
+    expect(toIdentityStatus(null).label).toBe('—');
+    expect(toIdentityStatus(null).actionable).toBe(false);
+  });
+
+  test('unprovisioned reads as not started, which is everyone today', () => {
+    const s = toIdentityStatus({ configured: true, provisioned: false });
+    expect(s.state).toBe('unverified');
+    expect(s.action).toBe('Verify');
+  });
+
+  test('each Lithic status maps to one member-facing state', () => {
+    const map: Record<string, string> = {
+      ACCEPTED: 'verified',
+      PENDING_REVIEW: 'in_review',
+      PENDING_DOCUMENT: 'needs_document',
+      PENDING_RESUBMIT: 'needs_resubmit',
+      REJECTED: 'rejected',
+    };
+    for (const [status, expected] of Object.entries(map)) {
+      expect(toIdentityStatus({ configured: true, provisioned: true, status }).state).toBe(expected);
+    }
+  });
+
+  test('an unknown status waits rather than claiming verified', () => {
+    // Guessing wrong this way tells a member to wait; the other way tells them they can borrow
+    // when nobody has said so.
+    expect(toIdentityStatus({ configured: true, provisioned: true, status: 'SOMETHING_NEW' }).state).toBe('in_review');
+  });
+
+  test('a rejection offers no button, because re-sending the same details changes nothing', () => {
+    const s = toIdentityStatus({ configured: true, provisioned: true, status: 'REJECTED' });
+    expect(s.actionable).toBe(false);
+    expect(s.action).toBeUndefined();
+  });
+
+  test('needing a photo and needing a correction are different asks', () => {
+    const doc = toIdentityStatus({ configured: true, provisioned: true, status: 'PENDING_DOCUMENT' });
+    const fix = toIdentityStatus({ configured: true, provisioned: true, status: 'PENDING_RESUBMIT' });
+    expect(doc.action).not.toBe(fix.action);
+  });
+
+  test('waiting says what still works', () => {
+    // A member who just handed over an SSN assumes everything is frozen.
+    expect(openWhileWaiting('in_review').open).toEqual(['Savings', 'Earn']);
+    expect(openWhileWaiting('in_review').waiting).toEqual(['Credit', 'Card']);
+    expect(openWhileWaiting('verified').open).toEqual([]);
+  });
+});

--- a/app/src/lib/identityStatus.ts
+++ b/app/src/lib/identityStatus.ts
@@ -1,0 +1,106 @@
+/**
+ * One identity state for the member, derived from Lithic.
+ *
+ * ## Why Lithic and not Bridge
+ *
+ * There were two "verify your identity" flows in the app — Bridge's KycModal, reachable from
+ * Settings and the transfer sheet, and now Lithic's provisioning. A member could be verified in one
+ * sense and not the other, and Settings would have shown two verification rows meaning different
+ * things, which is a question no member can be expected to answer.
+ *
+ * Lithic is the one that gates what a member actually notices: lending and the card. It is also the
+ * one whose sponsor bank runs the KYC we are relying on (KYC_BASIC — Program Managed). Bridge's own
+ * status stays where it is and keeps gating Bridge operations; it just stops being a second answer
+ * to "am I verified".
+ *
+ * ## The states
+ *
+ * Lithic returns five, three of them asynchronous. The design covers the happy path, review, and
+ * the document fallback; `needs_resubmit` and `rejected` are added here because a status that can
+ * come back needs somewhere to land, and a rejection is the one a member cannot fix by trying the
+ * same thing again.
+ */
+export type IdentityState =
+  | 'unavailable'
+  | 'unverified'
+  | 'verified'
+  | 'in_review'
+  | 'needs_document'
+  | 'needs_resubmit'
+  | 'rejected';
+
+export interface IdentityStatus {
+  state: IdentityState;
+  /** What the Settings row reads. Short, because it sits at the end of a line. */
+  label: string;
+  /** Whether opening the verification flow can achieve anything from here. */
+  actionable: boolean;
+  /** The row's call to action, when there is one. */
+  action?: string;
+}
+
+const BY_STATE: Record<IdentityState, Omit<IdentityStatus, 'state'>> = {
+  // The integration is off. Not the member's business and not a failure of theirs, so the row says
+  // nothing rather than "unverified", which would read as something they had neglected.
+  unavailable: { label: '—', actionable: false },
+  unverified: { label: 'Not verified', actionable: true, action: 'Verify' },
+  verified: { label: 'Verified', actionable: false },
+  in_review: { label: 'Under review', actionable: true, action: 'See status' },
+  needs_document: { label: 'Photo needed', actionable: true, action: 'Add photo' },
+  // Distinct from needs_document: something typed did not match, and a photo is not what is being
+  // asked for. Re-opening the form with the fields is the only useful move.
+  needs_resubmit: { label: 'Needs a correction', actionable: true, action: 'Fix details' },
+  // Deliberately not actionable. Re-submitting the same details produces the same answer, and a
+  // button that promises otherwise is worse than no button.
+  rejected: { label: "Couldn't verify", actionable: false },
+};
+
+/**
+ * Map what the server knows into what the member is shown.
+ *
+ * `provisioned: false` with `configured: true` is the ordinary starting state for everybody today —
+ * nothing provisions a member yet — so it must read as "not started", never as an error.
+ */
+export function toIdentityStatus(account: {
+  configured: boolean;
+  provisioned: boolean;
+  status?: string;
+} | null): IdentityStatus {
+  if (!account || !account.configured) return { state: 'unavailable', ...BY_STATE.unavailable };
+  if (!account.provisioned) return { state: 'unverified', ...BY_STATE.unverified };
+
+  const state = ((): IdentityState => {
+    switch ((account.status || '').toUpperCase()) {
+      case 'ACCEPTED':
+        return 'verified';
+      case 'PENDING_REVIEW':
+        return 'in_review';
+      case 'PENDING_DOCUMENT':
+        return 'needs_document';
+      case 'PENDING_RESUBMIT':
+        return 'needs_resubmit';
+      case 'REJECTED':
+        return 'rejected';
+      default:
+        // A status we have not seen. Treated as in review rather than verified: the failure of
+        // guessing wrong here is a member being told to wait, and the other way round is a member
+        // being told they can borrow when nobody has said so.
+        return 'in_review';
+    }
+  })();
+
+  return { state, ...BY_STATE[state] };
+}
+
+/**
+ * What a member can still do while verification is outstanding.
+ *
+ * The design is firm about this and it is the sentence that matters most on the review screen: a
+ * member who has just handed over an SSN and been told to wait assumes everything is frozen.
+ * Savings and Earn are their own money and need no verification, so they open immediately — which
+ * turns a dead end into a waiting room.
+ */
+export function openWhileWaiting(state: IdentityState): { open: string[]; waiting: string[] } {
+  if (state === 'verified') return { open: [], waiting: [] };
+  return { open: ['Savings', 'Earn'], waiting: ['Credit', 'Card'] };
+}

--- a/app/src/pages/app/CardRoute.tsx
+++ b/app/src/pages/app/CardRoute.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useIdentity } from '@/context/IdentityContext';
 import CardPage from './CardPage';
 import { CARD_DAY_ONE } from '@/data/clearPlaceholder';
 import { createCard, getCards, setCardFrozen, type MemberCard } from '@/utils/apiClient';
@@ -34,6 +35,7 @@ export default function CardRoute() {
   const [loaded, setLoaded] = useState(false);
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
+  const identity = useIdentity();
 
   useEffect(() => {
     let cancelled = false;
@@ -86,18 +88,29 @@ export default function CardRoute() {
         setCard(created);
         return;
       }
+      /*
+       * "Not provisioned" is now something the member can act on.
+       *
+       * It used to be a dead end, because there was no way to become provisioned. There is one now,
+       * and this is the third entry point the design names — card activation, for a member who
+       * saved first and never borrowed. Same modal as Settings; the closing screen differs because
+       * the status differs, not because the caller does.
+       */
+      if (needsSetup && identity.status.actionable) {
+        identity.openVerification();
+        return;
+      }
       setNotice(
         unavailable || needsSetup
-          ? // Both are "not yet", from the member's side. The difference between an unset API key
-            // and an unbuilt KYC step matters to us and not at all to them; what matters to them is
-            // that pressing this again will not help.
+          ? // An unset API key is not something a member can do anything about, and the difference
+            // between that and an unbuilt step matters to us and not at all to them.
             "Card setup isn't finished for your account yet. Nothing to do here — we'll let you know when it's ready."
           : `That didn't go through. ${error ?? 'Please try again.'}`,
       );
     } finally {
       setBusy(false);
     }
-  }, []);
+  }, [identity]);
 
   const toggleFreeze = useCallback(
     async (frozen: boolean) => {

--- a/app/src/pages/app/SettingsPage.tsx
+++ b/app/src/pages/app/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from 'react';
+import { useIdentity } from '@/context/IdentityContext';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Copy, CircleCheck } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -77,6 +78,7 @@ export default function SettingsPage({
 
   const [accelerationOpen, setAccelerationOpen] = useState(false);
   const [phoneOpen, setPhoneOpen] = useState(false);
+  const verification = useIdentity();
   const [devicesOpen, setDevicesOpen] = useState(false);
   const [linkOpen, setLinkOpen] = useState(false);
   /** A drill-in below the current section, on either layout. */
@@ -101,15 +103,34 @@ export default function SettingsPage({
       <SettingRows
         rows={[
           { label: 'Legal name', value: profile.legalName },
-          { label: 'Date of birth', value: profile.dateOfBirth },
-          { label: 'Home address', value: profile.address },
+          /*
+           * One identity row, in the order the reference puts it.
+           *
+           * There used to be two answers to "am I verified" — Bridge's KycModal and Lithic's
+           * provisioning — and Settings was where they would have appeared side by side meaning
+           * different things. This reads the single status; see lib/identityStatus.ts.
+           */
+          {
+            label: 'Identity',
+            value: verification.status.label,
+            ...(verification.status.actionable ? { onSelect: verification.openVerification } : {}),
+          },
           { label: 'Phone', value: profile.phone, onSelect: () => setPhoneOpen(true) },
           { label: 'Email', value: profile.email },
+          { label: 'Home address', value: profile.address },
         ]}
       />
+      {/*
+        * Date of birth is gone from this list on purpose.
+        *
+        * It rendered a hardcoded `••/••/1994` for everybody — a fabricated birth year presented as
+        * the member's own — and it could not be replaced with a real one: a date of birth is passed
+        * straight through to the card issuer and never kept, so there is nothing here to show.
+        */}
       <InfoBlock tone="neutral" className="mt-3.5 text-[11px]">
-        Name and date of birth are locked after identity verification. Contact support to correct
-        them.
+        Your legal name is locked after identity verification — contact support to correct it. Your
+        date of birth and social security number are sent to our card issuer and never kept by
+        Clear, so they are not shown here.
       </InfoBlock>
     </>
   );

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -1911,6 +1911,47 @@ export interface LithicAccountResponse {
   deposit: { routingNumber: string; accountNumber: string; accountType: string } | null;
 }
 
+
+export interface BankIdentity {
+  legalName: string | null;
+  address: {
+    address1: string | null;
+    city: string | null;
+    state: string | null;
+    postalCode: string | null;
+    country: string | null;
+  } | null;
+}
+
+/**
+ * The account holder as the linked bank knows them, for the verification screen to show.
+ *
+ * Nulls are ordinary: Plaid Identity is optional per institution, so a member at a bank without it
+ * types what a member at one confirms.
+ */
+export async function getBankIdentity(wallet: string): Promise<BankIdentity> {
+  const r = await apiRequest<BankIdentity>(`/api/plaid/identity?walletAddress=${encodeURIComponent(wallet.toLowerCase())}`);
+  return r.error || !r.data ? { legalName: null, address: null } : r.data;
+}
+
+/** Submit identity details for verification. They pass through to the card issuer; we keep none. */
+export async function submitIdentity(input: {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber: string;
+  dob: string;
+  governmentId: string;
+  address: { address1: string; address2?: string; city: string; state: string; postal_code: string; country?: string };
+}): Promise<{ ok: boolean; status?: string; kycStatus?: string; error?: string }> {
+  const r = await apiRequest<{ status: string; kycStatus: string | null }>('/api/lithic/account', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+  if (r.error) return { ok: false, error: r.error };
+  return { ok: true, status: r.data?.status, kycStatus: r.data?.kycStatus ?? undefined };
+}
+
 export async function getLithicAccount(): Promise<LithicAccountResponse | null> {
   const r = await apiRequest<LithicAccountResponse>('/api/lithic/account');
   return r.error ? null : (r.data ?? null);


### PR DESCRIPTION
## #4 — consolidated toward Lithic

There were two answers to *"am I verified"* — Bridge's `KycModal` and Lithic's provisioning — and Settings is exactly where they'd have appeared side by side meaning different things.

**Lithic is the answer**: it gates what a member actually notices (lending, the card), and its sponsor bank runs the KYC we're relying on. Bridge keeps its own status and keeps gating Bridge operations — it just stops being a second reply to that question. Nothing Bridge-side removed, per your "I'll come back to the Bridge stuff."

One provider, one read, one status, one modal hosted beside it — the shape the notifications bug taught. Settings, card activation and (later) onboarding open the same modal; **the closing screen is chosen by the status Lithic returns, not by the caller's opinion** of what should happen next.

## The gaps

Lithic returns five statuses; the design covers three.

| status | screen |
|---|---|
| `ACCEPTED` | ✅ in design |
| `PENDING_REVIEW` | ✅ in design |
| `PENDING_DOCUMENT` | ✅ in design |
| **`PENDING_RESUBMIT`** | **added** — a different ask from a photo: something typed didn't match |
| **`REJECTED`** | **added** — the hard one |

`REJECTED` deliberately has **no retry button**. Re-sending the same details produces the same answer, and a button implying otherwise is a loop with no exit. No reason given either — guessing at one invites an argument the app can't settle. It does say what still works.

An unknown status **waits** rather than claiming verified: guessing wrong that way tells a member to wait; the other way tells them they can borrow when nobody has said so.

Phone and email are on the form — Lithic needs E.164, and an email-login member may have neither.

## Settings

Identity row added, in the reference's order. **Date of birth removed** — it rendered a hardcoded `••/••/1994` for everybody, and it can't be replaced with a real one: a date of birth passes through to the issuer and is never kept, so there's nothing to show. The note under the rows now says that instead of the old claim about dob being "locked".

## Pass-through, enforced in the UI too

No `localStorage`, no analytics, SSN field is `type=password` with `autoComplete="off"`, and both sensitive fields are cleared the moment they're sent — whatever the answer. Verified by adding a `localStorage` write and watching the test fail.

## Not built, and saying so rather than faking it

The ID-photo upload for `PENDING_DOCUMENT`. That screen explains the state and stops, because the upload should go from the browser **straight to the issuer** — routing a passport photo through our server makes us responsible for it in exactly the way you're avoiding. A button that looked like it worked would be worse.

---

Third time a guard matched my own prose: the "no localStorage" test failed on a comment saying *"no draft in localStorage"*. Comments stripped, as in the other two.

547 tests, 26 new. Build and dist scan clean.