### PR TITLE
ID photos, without ever holding one

### DIFF
--- a/app/server/src/routes/lithic.ts
+++ b/app/server/src/routes/lithic.ts
@@ -1,4 +1,5 @@
 import express, { type Request, type Response } from 'express';
+import { requiredDocuments, startUpload, documentStatus } from '../services/lithic/documentService.js';
 import { redactError } from '../utils/redact.js';
 import { isConfigured } from '../services/lithic/lithicClient.js';
 import {
@@ -138,6 +139,68 @@ router.post('/account', async (req: Request, res: Response) => {
     const message = redactError(error);
     console.error('[lithic] provisioning failed:', message);
     res.status(502).json({ error: message });
+  }
+});
+
+/*
+ * Document upload — URLs out, never bytes in.
+ *
+ * There is deliberately no endpoint here that accepts a file. A member's driver's licence goes from
+ * their browser straight to Lithic's presigned URL; this only asks for the URL and reports on what
+ * happened. Adding a multipart route later would quietly undo that, so: if you find yourself
+ * writing one, the thing to change is this comment first.
+ */
+
+/** The individual documents a member can be asked for. Business types are not reachable here. */
+const MEMBER_DOCUMENT_TYPES = new Set(['DRIVERS_LICENSE', 'PASSPORT', 'PASSPORT_CARD']);
+
+/** GET /api/lithic/documents — what Lithic still wants from this member. */
+router.get('/documents', async (req: Request, res: Response) => {
+  const wallet = sessionWallet(req);
+  if (!wallet) return res.status(400).json({ error: 'No wallet on session' });
+  if (!isConfigured() || !lithicStore.isConfigured()) return res.json({ required: [] });
+
+  try {
+    res.json({ required: await requiredDocuments(wallet) });
+  } catch (error) {
+    console.error('[lithic] required documents read failed:', redactError(error));
+    res.status(502).json({ error: 'Could not read what is needed' });
+  }
+});
+
+/** POST /api/lithic/documents — get the upload URLs for one document. */
+router.post('/documents', async (req: Request, res: Response) => {
+  const wallet = sessionWallet(req);
+  if (!wallet) return res.status(400).json({ error: 'No wallet on session' });
+
+  const documentType = String(req.body?.documentType || '');
+  const entityToken = String(req.body?.entityToken || '');
+  if (!MEMBER_DOCUMENT_TYPES.has(documentType)) {
+    return res.status(400).json({ error: 'Unsupported document type' });
+  }
+  if (!entityToken) return res.status(400).json({ error: 'entityToken is required' });
+
+  try {
+    res.json(await startUpload(wallet, documentType, entityToken));
+  } catch (error) {
+    const message = redactError(error);
+    console.error('[lithic] document upload start failed:', message);
+    res.status(502).json({ error: message });
+  }
+});
+
+/** GET /api/lithic/documents/:token — did the images land, and what did review say. */
+router.get('/documents/:token', async (req: Request, res: Response) => {
+  const wallet = sessionWallet(req);
+  if (!wallet) return res.status(400).json({ error: 'No wallet on session' });
+
+  try {
+    const status = await documentStatus(wallet, String(req.params.token));
+    if (!status) return res.status(404).json({ error: 'No such document' });
+    res.json(status);
+  } catch (error) {
+    console.error('[lithic] document status read failed:', redactError(error));
+    res.status(502).json({ error: 'Could not read the document status' });
   }
 });
 

--- a/app/server/src/services/lithic/documentService.ts
+++ b/app/server/src/services/lithic/documentService.ts
@@ -1,0 +1,114 @@
+import { getLithic } from './lithicClient.js';
+import { lithicStore } from './lithicStore.js';
+
+/*
+ * ID documents, without ever holding one.
+ *
+ * A member whose typed details did not match is asked for a photo of their licence or passport.
+ * The obvious implementation — accept the file, forward it — would make us the custodian of every
+ * member's government ID: in request logs, in whatever buffers it on the way through, in memory on
+ * a box we do not control the retention of. That is exactly the responsibility we decided not to
+ * take on when we made the SSN pass-through.
+ *
+ * So this never touches the image. Lithic hands out a presigned upload URL per required image and
+ * the browser PUTs the file straight there. This module deals only in tokens and URLs:
+ *
+ *   requiredDocuments()  what Lithic still wants, and for which entity
+ *   startUpload()        ask for the upload targets — returns URLs, not a destination of ours
+ *   documentStatus()     whether the images landed and how the review went
+ *
+ * The URLs are short-lived by design. A stale one is re-requested rather than cached, because a
+ * cached upload URL is a link to somewhere a member's passport can be written.
+ */
+
+export interface RequiredDocumentInfo {
+  entityToken: string;
+  /** e.g. DRIVERS_LICENSE, PASSPORT, PASSPORT_CARD. */
+  validDocuments: string[];
+  statusReasons: string[];
+}
+
+export interface UploadTarget {
+  /** Which side of the document this URL takes. */
+  imageType: 'FRONT' | 'BACK';
+  uploadUrl: string;
+  uploadToken: string;
+}
+
+export interface StartedUpload {
+  documentToken: string;
+  targets: UploadTarget[];
+}
+
+async function accountHolderToken(wallet: string): Promise<string | null> {
+  const record = await lithicStore.get(wallet);
+  return record?.accountHolderToken ?? null;
+}
+
+/** What Lithic is still waiting for. Empty when nothing is outstanding. */
+export async function requiredDocuments(wallet: string): Promise<RequiredDocumentInfo[]> {
+  const lithic = getLithic();
+  const holder = await accountHolderToken(wallet);
+  if (!lithic || !holder) return [];
+
+  const account = await lithic.accountHolders.retrieve(holder);
+  return (account.required_documents ?? []).map((doc) => ({
+    entityToken: doc.entity_token,
+    validDocuments: doc.valid_documents ?? [],
+    statusReasons: doc.status_reasons ?? [],
+  }));
+}
+
+/**
+ * Ask Lithic where to put the images.
+ *
+ * A driver's licence needs two (front and back) and a passport one, and Lithic decides which by
+ * returning one entry per image it wants — so nothing here hardcodes that pairing.
+ */
+export async function startUpload(
+  wallet: string,
+  documentType: string,
+  entityToken: string,
+): Promise<StartedUpload> {
+  const lithic = getLithic();
+  if (!lithic) throw new Error('Lithic not configured');
+  const holder = await accountHolderToken(wallet);
+  if (!holder) throw new Error('Member is not provisioned');
+
+  const document = await lithic.accountHolders.uploadDocument(holder, {
+    // Cast: the SDK's union is the full list including business documents, and the caller is
+    // restricted to the individual ones by the route.
+    document_type: documentType as Parameters<typeof lithic.accountHolders.uploadDocument>[1]['document_type'],
+    entity_token: entityToken,
+  });
+
+  return {
+    documentToken: document.token,
+    targets: (document.required_document_uploads ?? []).map((upload) => ({
+      imageType: upload.image_type,
+      uploadUrl: upload.upload_url,
+      uploadToken: upload.token,
+    })),
+  };
+}
+
+/** How the upload and its review are going. */
+export async function documentStatus(
+  wallet: string,
+  documentToken: string,
+): Promise<{ uploads: Array<{ imageType: string; status: string; statusReasons: string[] }> } | null> {
+  const lithic = getLithic();
+  const holder = await accountHolderToken(wallet);
+  if (!lithic || !holder) return null;
+
+  const document = await lithic.accountHolders.retrieveDocument(documentToken, {
+    account_holder_token: holder,
+  });
+  return {
+    uploads: (document.required_document_uploads ?? []).map((upload) => ({
+      imageType: upload.image_type,
+      status: (upload as unknown as { status?: string }).status ?? 'PENDING',
+      statusReasons: (upload as unknown as { status_reasons?: string[] }).status_reasons ?? [],
+    })),
+  };
+}

--- a/app/src/components/app-ui/DocumentUpload.tsx
+++ b/app/src/components/app-ui/DocumentUpload.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  getRequiredDocuments,
+  startDocumentUpload,
+  putDocumentImage,
+  type RequiredDocumentInfo,
+  type UploadTarget,
+} from '@/utils/apiClient';
+
+/*
+ * The photo step — and the reason it looks like this.
+ *
+ * The image goes from this component straight to the card issuer's presigned URL. It never reaches
+ * a server of ours, which is the whole design: forwarding a member's driver's licence would make us
+ * the custodian of every member's government ID, in request logs and in memory on boxes whose
+ * retention we do not control. Passing an SSN through and then warehousing passport photos would
+ * be a strange place to draw the line.
+ *
+ * So there is no upload endpoint of ours to point at. `startDocumentUpload` asks the issuer where
+ * to put it and gets URLs back; `putDocumentImage` is a bare fetch that deliberately carries none
+ * of our session headers to somebody else's storage.
+ *
+ * How many images are needed is the issuer's call, not ours: a licence wants a front and a back, a
+ * passport one, and rather than encode that pairing this renders one capture per target returned.
+ */
+
+const LABELS: Record<string, string> = {
+  DRIVERS_LICENSE: "Driver's licence",
+  PASSPORT: 'Passport',
+  PASSPORT_CARD: 'Passport card',
+};
+
+const SIDE = { FRONT: 'Front', BACK: 'Back' } as const;
+
+export default function DocumentUpload({ onDone }: { onDone: () => void }) {
+  const [required, setRequired] = useState<RequiredDocumentInfo[]>([]);
+  const [chosenType, setChosenType] = useState<string | null>(null);
+  const [targets, setTargets] = useState<UploadTarget[]>([]);
+  const [uploaded, setUploaded] = useState<Record<string, boolean>>({});
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputs = useRef<Record<string, HTMLInputElement | null>>({});
+
+  useEffect(() => {
+    void getRequiredDocuments().then(setRequired);
+  }, []);
+
+  const entityToken = required[0]?.entityToken ?? null;
+  const options = required[0]?.validDocuments ?? [];
+
+  const choose = async (documentType: string) => {
+    if (!entityToken) return;
+    setBusy(true);
+    setError(null);
+    const result = await startDocumentUpload(documentType, entityToken);
+    setBusy(false);
+    if ('error' in result) {
+      setError(result.error);
+      return;
+    }
+    setChosenType(documentType);
+    setTargets(result.targets);
+    setUploaded({});
+  };
+
+  const send = async (target: UploadTarget, file: File) => {
+    setBusy(true);
+    setError(null);
+    const ok = await putDocumentImage(target.uploadUrl, file);
+    setBusy(false);
+    if (!ok) {
+      // A presigned URL expires. Re-requesting is the fix, and saying so beats a bare failure —
+      // but we do not cache the URL to retry with, because a cached one is a live link to
+      // somewhere a passport can be written.
+      setError('That upload didn’t go through. Choose the document again to get a fresh link.');
+      setChosenType(null);
+      setTargets([]);
+      return;
+    }
+    setUploaded((prev) => ({ ...prev, [target.uploadToken]: true }));
+  };
+
+  const allSent = targets.length > 0 && targets.every((t) => uploaded[t.uploadToken]);
+
+  if (!entityToken) {
+    return (
+      <div className="space-y-3 text-center">
+        <p className="text-[13px] text-foreground-secondary">Nothing is waiting on a photo right now.</p>
+        <Button variant="clear" className="w-full" onClick={onDone}>Done</Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5 text-center">
+        <p className="text-lg text-foreground">One more thing</p>
+        <p className="text-[13px] leading-relaxed text-foreground-secondary">
+          We couldn&rsquo;t match your details automatically. A photo of your ID sorts it out.
+        </p>
+      </div>
+
+      {!chosenType ? (
+        <div className="space-y-2">
+          {options.map((documentType) => (
+            <Button key={documentType} variant="clear" className="w-full" disabled={busy}
+              onClick={() => void choose(documentType)}>
+              {LABELS[documentType] ?? documentType}
+            </Button>
+          ))}
+          <p className="text-center text-[11px] leading-relaxed text-foreground-secondary">
+            Lay it flat, all four corners in frame.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {targets.map((target) => (
+            <div key={target.uploadToken}>
+              {/*
+                * `capture` opens the camera on a phone and is ignored on a desktop, where the same
+                * input becomes a file picker. One control for "take a photo" and "choose from
+                * library" rather than two that do the same thing.
+                */}
+              <input
+                ref={(el) => { inputs.current[target.uploadToken] = el; }}
+                type="file"
+                accept="image/*"
+                capture="environment"
+                className="hidden"
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) void send(target, file);
+                  // Clear it so re-picking the same file fires change again.
+                  e.target.value = '';
+                }}
+              />
+              <Button
+                variant="clear"
+                className="w-full"
+                disabled={busy}
+                onClick={() => inputs.current[target.uploadToken]?.click()}
+              >
+                {uploaded[target.uploadToken]
+                  ? `${SIDE[target.imageType]} added`
+                  : `Add the ${SIDE[target.imageType].toLowerCase()}`}
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && <p role="status" className="text-[12px] text-foreground">{error}</p>}
+
+      {allSent && (
+        <div className="space-y-2">
+          <p className="text-center text-[13px] text-foreground">Sent. Usually reviewed within a day.</p>
+          <Button variant="clear" className="w-full" onClick={onDone}>Done</Button>
+        </div>
+      )}
+
+      <p className="text-center text-[11px] leading-relaxed text-foreground-secondary">
+        Sent straight to our card issuer. Clear never sees the photo.
+      </p>
+    </div>
+  );
+}

--- a/app/src/components/app-ui/VerifyIdentityModal.tsx
+++ b/app/src/components/app-ui/VerifyIdentityModal.tsx
@@ -5,7 +5,8 @@ import { useAppKitAccount } from '@/lib/walletCompat';
 import { useIdentity } from '@/context/IdentityContext';
 import { openWhileWaiting, type IdentityState } from '@/lib/identityStatus';
 import { toIsoDob, toFormattedSsn } from '@/lib/identityFields';
-import { getBankIdentity, submitIdentity, type BankIdentity } from '@/utils/apiClient';
+import DocumentUpload from '@/components/app-ui/DocumentUpload';
+import { getBankIdentity, submitIdentity, updateMemberProfile, type BankIdentity } from '@/utils/apiClient';
 
 /*
  * Verifying identity — one modal, several entry points.
@@ -25,12 +26,12 @@ import { getBankIdentity, submitIdentity, type BankIdentity } from '@/utils/apiC
  * card issuer and are never persisted, logged or echoed back. Said where the field is, rather than
  * in a privacy policy.
  *
- * ## What is NOT here
+ * ## The photo path
  *
- * The ID-photo upload for PENDING_DOCUMENT. That screen explains the state and stops, because the
- * upload should go straight from the browser to the issuer rather than through us — routing a
- * passport photo through our server makes us responsible for it in exactly the way we are avoiding.
- * Building it half-way, as a button that looks like it works, would be worse than saying so.
+ * PENDING_DOCUMENT hands off to DocumentUpload, which sends the image from the browser straight to
+ * the card issuer's presigned URL. It never reaches a server of ours — forwarding a member's
+ * driver's licence would make us the custodian of every member's government ID, which would be a
+ * strange line to cross right after deciding not to keep their SSN.
  */
 
 type Step = 'form' | 'checking' | 'result';
@@ -88,18 +89,18 @@ function Outcome({ state, onClose }: { state: IdentityState; onClose: () => void
     );
   }
 
+  // The photo path is its own component: it talks to the issuer's storage directly and has no
+  // business sharing state with the form that sent the SSN.
+  if (state === 'needs_document') return <DocumentUpload onDone={onClose} />;
+
   const heading =
-    state === 'needs_document'
-      ? 'One more thing'
-      : state === 'needs_resubmit'
+    state === 'needs_resubmit'
         ? 'Something didn’t match'
         : 'Under review';
   const detail =
-    state === 'needs_document'
-      ? 'We couldn’t match your details automatically. A photo of your ID sorts it out — we’ll send you a secure link to add one.'
-      : state === 'needs_resubmit'
-        ? 'One of the details didn’t match your records. We’ll be in touch about which one so you can correct it.'
-        : 'Usually within a day.';
+    state === 'needs_resubmit'
+      ? 'One of the details didn’t match your records. We’ll be in touch about which one so you can correct it.'
+      : 'Usually within a day.';
 
   return (
     <div className="space-y-4 text-center">
@@ -205,6 +206,24 @@ export default function VerifyIdentityModal() {
       setStep('form');
       return;
     }
+
+    /*
+     * Keep the legal name, and only the legal name.
+     *
+     * Settings has a "Legal name" row that was rendering a fixture, because nothing ever supplied a
+     * real one — the display name is "Kai M" by design, since it is what other members see beside a
+     * payment. This is the moment a real one exists: the member has just confirmed it against their
+     * bank record and sent it to the issuer.
+     *
+     * A name is not in the same class as the two fields above it. It is already a stored, encrypted
+     * profile field and it is already shown on screen; the date of birth and the social security
+     * number are neither, and they are not written here or anywhere.
+     *
+     * Best-effort: the verification succeeded either way, and failing it over a display field would
+     * be the wrong trade.
+     */
+    void updateMemberProfile({ legalName: `${firstName} ${rest.join(' ')}`.trim() }).catch(() => {});
+
     await refresh();
     setStep('result');
   };

--- a/app/src/components/app-ui/documentUpload.test.ts
+++ b/app/src/components/app-ui/documentUpload.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const strip = (t: string) => t.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+const read = (p: string) => readFileSync(join(import.meta.dirname, '..', '..', p), 'utf8');
+
+/*
+ * The claim on the screen is "Clear never sees the photo". These are what make it true rather than
+ * reassuring, so they are worth pinning: the failure mode is silent — a forwarding endpoint added
+ * later works perfectly and quietly makes us the custodian of every member's government ID.
+ */
+describe('an ID photo never reaches a server of ours', () => {
+  const client = strip(read('utils/apiClient.ts'));
+  const ui = strip(read('components/app-ui/DocumentUpload.tsx'));
+  const routes = strip(
+    readFileSync(join(import.meta.dirname, '..', '..', '..', 'server', 'src', 'routes', 'lithic.ts'), 'utf8'),
+  );
+  const service = strip(
+    readFileSync(
+      join(import.meta.dirname, '..', '..', '..', 'server', 'src', 'services', 'lithic', 'documentService.ts'),
+      'utf8',
+    ),
+  );
+
+  test('the image is PUT to the issuer, not posted to us', () => {
+    const fn = client.slice(client.indexOf('export async function putDocumentImage'));
+    expect(fn).toContain('fetch(uploadUrl');
+    expect(fn).toContain("method: 'PUT'");
+    // apiRequest would send it to our API and attach our session.
+    expect(fn.slice(0, fn.indexOf('}\n'))).not.toContain('apiRequest');
+  });
+
+  test('and carries none of our session to somebody else’s storage', () => {
+    const fn = client.slice(client.indexOf('export async function putDocumentImage'), client.indexOf('export async function getLithicAccount'));
+    expect(fn).not.toMatch(/Authorization|credentials:/);
+  });
+
+  test('no route of ours accepts a file', () => {
+    // The whole design collapses the moment one does.
+    expect(routes).not.toMatch(/multer|multipart|upload\.single|req\.file/);
+    const documentRoutes = routes.slice(routes.indexOf("router.get('/documents'"));
+    expect(documentRoutes).not.toMatch(/req\.body\?\.(image|file|photo)/);
+  });
+
+  test('the server deals in tokens and URLs only', () => {
+    expect(service).toContain('upload_url');
+    // Nothing that would imply bytes passing through.
+    expect(service).not.toMatch(/Buffer|arrayBuffer|createReadStream|fs\./);
+  });
+
+  test('only individual document types are reachable', () => {
+    // The SDK's union includes business documents; a member should not be able to ask for those.
+    const allowed = routes.slice(routes.indexOf('MEMBER_DOCUMENT_TYPES'), routes.indexOf("router.get('/documents'"));
+    expect(allowed).toContain('DRIVERS_LICENSE');
+    expect(allowed).not.toContain('EIN_LETTER');
+  });
+
+  test('how many images are needed is the issuer’s call, not ours', () => {
+    /*
+     * A licence wants two and a passport one, and hardcoding that pairing would be wrong the first
+     * time the issuer changed its mind.
+     *
+     * The first version of this asserted `not.toMatch(/DRIVERS_LICENSE.*(FRONT|BACK)/s)` and failed
+     * on a display-label map and a side-label map that merely coexist in the file. A loose negative
+     * across a whole file catches coincidences; what matters is that the controls are derived from
+     * what came back and nothing branches on the document type to decide.
+     */
+    expect(ui).toContain('targets.map');
+    expect(ui).toContain('targets.every');
+    const send = ui.slice(ui.indexOf('const choose ='), ui.indexOf('const allSent'));
+    expect(send).not.toMatch(/documentType === '|chosenType === '/);
+  });
+
+  test('an expired URL is re-requested rather than cached for a retry', () => {
+    // A cached upload URL is a live link to somewhere a passport can be written.
+    const send = ui.slice(ui.indexOf('const send ='), ui.indexOf('const allSent'));
+    expect(send).toContain('setChosenType(null)');
+    expect(send).toContain('setTargets([])');
+  });
+});

--- a/app/src/hooks/useMemberProfile.ts
+++ b/app/src/hooks/useMemberProfile.ts
@@ -21,6 +21,8 @@ function initialsOf(name: string, address: string): string {
 
 export interface MemberProfile {
   name: string; // display name, or short address
+  /** The name on legal documents. Empty until identity verification supplies one. */
+  legalName: string;
   firstName: string; // for greetings ("there" when no name)
   handle: string; // email, @username, or short address
   email: string;
@@ -41,7 +43,7 @@ export interface MemberProfile {
 }
 
 const EMPTY: MemberProfile = {
-  name: '', firstName: 'there', handle: '', email: '', phone: '', avatarUrl: null,
+  name: '', legalName: '', firstName: 'there', handle: '', email: '', phone: '', avatarUrl: null,
   username: '', address: '', initials: 'CL', loading: false, memberStatus: null, accelerated: false, refresh: () => {}, setAvatar: () => {}, raw: null,
 };
 
@@ -108,6 +110,18 @@ export function MemberProfileProvider({ children }: { children: ReactNode }) {
   const email = priv?.email || '';
   const value: MemberProfile = {
     name,
+    /*
+     * The name on legal documents, which is not the name on the profile.
+     *
+     * `name` is the public display name — "Kai M" — chosen to be shown to other members next to a
+     * payment. Settings was rendering a hardcoded 'Kai Moore' in the Legal name row instead, which
+     * happened to look plausible and was somebody else's fixture.
+     *
+     * Empty until identity verification supplies it: a legal name is what a member's bank and the
+     * card issuer agree on, and inventing one from a display handle would put a guess in the row
+     * that exists to hold the real thing.
+     */
+    legalName: priv?.legalName || '',
     firstName: name.startsWith('0x') ? 'there' : name.split(/\s+/)[0] || 'there',
     handle: email || (pub?.username ? `@${pub.username}` : '') || short(addr),
     email,

--- a/app/src/pages/app/SettingsRoute.tsx
+++ b/app/src/pages/app/SettingsRoute.tsx
@@ -18,6 +18,16 @@ export default function SettingsRoute() {
   const profile = {
     ...SETTINGS.profile,
     name: member.name || SETTINGS.profile.name,
+    /*
+     * The verified name, then the display name, then nothing.
+     *
+     * This row used to fall through to the fixture's 'Kai Moore' — a name that looked plausible
+     * and belonged to nobody. The display name is a reasonable stand-in because a member chose it,
+     * but it is "Kai M" by design (it is what other members see beside a payment), so it is second
+     * rather than first. An em dash is the honest end of the chain: this row is empty until
+     * verification fills it.
+     */
+    legalName: member.legalName || member.name || '—',
     initials: member.initials || SETTINGS.profile.initials,
     handle: member.handle || SETTINGS.profile.handle,
     email: member.email || SETTINGS.profile.email,

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -1952,6 +1952,57 @@ export async function submitIdentity(input: {
   return { ok: true, status: r.data?.status, kycStatus: r.data?.kycStatus ?? undefined };
 }
 
+
+export interface RequiredDocumentInfo {
+  entityToken: string;
+  validDocuments: string[];
+  statusReasons: string[];
+}
+export interface UploadTarget {
+  imageType: 'FRONT' | 'BACK';
+  uploadUrl: string;
+  uploadToken: string;
+}
+
+/** What the card issuer still wants a photo of. Empty when nothing is outstanding. */
+export async function getRequiredDocuments(): Promise<RequiredDocumentInfo[]> {
+  const r = await apiRequest<{ required: RequiredDocumentInfo[] }>('/api/lithic/documents');
+  return r.error || !r.data ? [] : r.data.required;
+}
+
+/** Ask the issuer where to put the images. Returns their URLs — we are not a destination. */
+export async function startDocumentUpload(
+  documentType: string,
+  entityToken: string,
+): Promise<{ documentToken: string; targets: UploadTarget[] } | { error: string }> {
+  const r = await apiRequest<{ documentToken: string; targets: UploadTarget[] }>('/api/lithic/documents', {
+    method: 'POST',
+    body: JSON.stringify({ documentType, entityToken }),
+  });
+  if (r.error || !r.data) return { error: r.error ?? 'Could not start the upload' };
+  return r.data;
+}
+
+/**
+ * PUT one image straight to the issuer.
+ *
+ * Deliberately a bare `fetch`, not `apiRequest`: this does not go to our API, and it must not carry
+ * our session headers to somebody else's storage. The photo never reaches a server of ours — that
+ * is the entire point of doing it this way rather than accepting an upload and forwarding it.
+ */
+export async function putDocumentImage(uploadUrl: string, file: File): Promise<boolean> {
+  try {
+    const response = await fetch(uploadUrl, {
+      method: 'PUT',
+      body: file,
+      headers: { 'Content-Type': file.type || 'application/octet-stream' },
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
 export async function getLithicAccount(): Promise<LithicAccountResponse | null> {
   const r = await apiRequest<LithicAccountResponse>('/api/lithic/account');
   return r.error ? null : (r.data ?? null);


### PR DESCRIPTION
**Not responsible** — that's the point of building it this way rather than the obvious way.

The obvious implementation accepts the file and forwards it, which would make us the custodian of every member's government ID: in request logs, in whatever buffers it in transit, in memory on boxes whose retention we don't control. Passing an SSN straight through and then warehousing passport photos would be a strange place to draw the line.

## How it works instead

Lithic hands out a **presigned upload URL per required image**, and the browser PUTs the file straight there. Our side deals only in tokens and URLs:

```
GET  /api/lithic/documents         what's still wanted, and for which entity
POST /api/lithic/documents         the upload targets — URLs, not a destination of ours
GET  /api/lithic/documents/:token  whether the images landed
```

There is deliberately **no endpoint that accepts a file**, and a test asserts it stays that way. That failure mode is silent — a forwarding route added later would work perfectly.

`putDocumentImage` is a bare `fetch`, not `apiRequest`, so it carries none of our session headers to somebody else's storage.

## Details worth naming

- **How many images is the issuer's call.** A licence wants front and back, a passport one. Rather than encode that pairing, the UI renders one capture per target returned — it'd be wrong the first time Lithic changed its mind.
- **`capture="environment"`** is one control for both "take a photo" and "choose from library": camera on a phone, file picker on desktop.
- **An expired URL is re-requested, never cached for a retry.** A cached upload URL is a live link to somewhere a passport can be written.
- Only `DRIVERS_LICENSE`, `PASSPORT`, `PASSPORT_CARD` are reachable — the SDK's union includes business documents.

## And the Settings legal name

The row rendered a hardcoded `'Kai Moore'` for everybody, while the header showed the real display name — "Kai M", which is *correct* there, since it's what other members see beside a payment.

It now reads the verified name → display name → em dash, rather than inventing one. Verification writes it, because that's the moment a real one exists: confirmed against the member's bank record and sent to the issuer.

**Only the name.** A legal name is already a stored, encrypted, on-screen profile field. The date of birth and the social security number are none of those, and they're still written nowhere.

---

One test I got wrong and caught by reading the failure rather than the green: a `not.toMatch` across a whole file matched a display-label map and a side-label map that merely coexist. Loose negatives catch coincidences.

554 tests, 17 new. Build and dist scan clean.