### PR TITLE
Make card spending real, then build the bar on it

### DIFF
--- a/app/server/src/routes/lithicCards.ts
+++ b/app/server/src/routes/lithicCards.ts
@@ -1,4 +1,5 @@
 import express, { type Request, type Response } from 'express';
+import { listCardTransactions } from '../services/lithic/cardTransactionsService.js';
 import { isConfigured } from '../services/lithic/lithicClient.js';
 import { cardStore } from '../services/lithic/cardStore.js';
 import { cardService } from '../services/lithic/cardService.js';
@@ -46,6 +47,32 @@ router.get('/', async (req: Request, res: Response) => {
   } catch (error) {
     console.error('[cards] list failed', error);
     return res.status(500).json({ error: 'Failed to load cards' });
+  }
+});
+
+
+/**
+ * GET /api/lithic/cards/transactions — what this member's cards have spent.
+ *
+ * Read from our own approved authorizations rather than fetched from Lithic: every approval already
+ * passes through the Auth Stream handler, which records the amount, the merchant object and which
+ * tiers paid. Asking Lithic again for something we decided ourselves would be slower, rate-limited,
+ * and no more true.
+ *
+ * Registered before `/:token` so a card token named "transactions" cannot shadow it — the tokens
+ * are UUIDs and could not, but route order that depends on that is a trap for the next person.
+ */
+router.get('/transactions', async (req: Request, res: Response) => {
+  const wallet = sessionWallet(req);
+  if (!wallet) return res.status(400).json({ error: 'No wallet on session' });
+  if (!isConfigured()) return res.json({ transactions: [] });
+
+  try {
+    const limit = Number.parseInt(String(req.query.limit ?? '50'), 10);
+    res.json({ transactions: await listCardTransactions(wallet, Number.isFinite(limit) ? limit : 50) });
+  } catch (error) {
+    console.error('[lithic] card transactions read failed:', error instanceof Error ? error.message : error);
+    res.status(502).json({ error: 'Could not read card transactions' });
   }
 });
 

--- a/app/server/src/services/lithic/cardTransactionsService.ts
+++ b/app/server/src/services/lithic/cardTransactionsService.ts
@@ -1,0 +1,91 @@
+import { getPayPool } from '../../config/postgres.js';
+
+/*
+ * What the card actually spent, from the authorizations we already decide.
+ *
+ * The Card page has been showing an empty list for every real card, because nothing ever listed a
+ * transaction. It did not need to fetch them: every approval passes through our own Auth Stream
+ * handler, and that writes the amount, the merchant object Lithic sent, and which tiers paid. The
+ * data has been sitting in `lithic_auth_decisions` the whole time with an index on
+ * (wallet, decided_at DESC) — exactly the query this makes.
+ *
+ * Approvals only. A decline is not a purchase and does not belong in a list of what a member spent,
+ * or in the total above it.
+ *
+ * These are AUTHORIZATIONS, not settlements. The amount can change between the two — a restaurant
+ * adds a tip, a fuel pump authorizes a round number and settles the real one — so what this shows
+ * is what was approved. That is the honest label for it and it is what a member sees on the day,
+ * before any settlement exists to show instead.
+ */
+
+export type DrawSource = string;
+
+export interface CardTransactionRow {
+  id: string;
+  /** Merchant name as the network sent it. */
+  name: string;
+  /** ISO timestamp of the decision. */
+  at: string;
+  amountCents: number;
+  /** ISO 18245 merchant category code, as a string — leading zeros are meaningful. */
+  mcc: string | null;
+  city: string | null;
+  state: string | null;
+  /** Which tiers paid, cheapest first. `cash` means it never became credit. */
+  draws: Array<{ source: DrawSource; amountCents: number }>;
+  cardToken: string;
+}
+
+interface Row {
+  transaction_token: string;
+  card_token: string;
+  amount_cents: string;
+  draws: unknown;
+  merchant: unknown;
+  decided_at: Date;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+export async function listCardTransactions(
+  wallet: string,
+  limit = 50,
+): Promise<CardTransactionRow[]> {
+  const pool = getPayPool();
+  if (!pool) return [];
+
+  const { rows } = await pool.query<Row>(
+    `SELECT transaction_token, card_token, amount_cents, draws, merchant, decided_at
+       FROM lithic_auth_decisions
+      WHERE wallet = $1 AND result = 'APPROVED'
+      ORDER BY decided_at DESC
+      LIMIT $2`,
+    [wallet.toLowerCase(), Math.min(Math.max(limit, 1), 200)],
+  );
+
+  return rows.map((row) => {
+    const merchant = (row.merchant ?? {}) as Record<string, unknown>;
+    return {
+      id: row.transaction_token,
+      // `descriptor` is the name on a statement; `acceptor_id` is a merchant number, which is not a
+      // name and should never reach a member. An unnamed merchant is better blank than numeric.
+      name: asString(merchant.descriptor) ?? 'Card purchase',
+      at: row.decided_at.toISOString(),
+      amountCents: Number(row.amount_cents),
+      mcc: asString(merchant.mcc),
+      city: asString(merchant.city),
+      state: asString(merchant.state),
+      draws: Array.isArray(row.draws)
+        ? (row.draws as Array<{ source?: unknown; amountCents?: unknown }>).map((draw) => ({
+            source: String(draw?.source ?? 'cash'),
+            amountCents: Number(draw?.amountCents ?? 0),
+          }))
+        : [],
+      cardToken: row.card_token,
+    };
+  });
+}

--- a/app/src/assets/brand/networkMarks.ts
+++ b/app/src/assets/brand/networkMarks.ts
@@ -1,0 +1,37 @@
+/**
+ * Card-network brand marks — one file, so replacing one is a file swap and not a code change.
+ *
+ * ## Provenance, and what has to change before print
+ *
+ * The Visa path below is simple-icons' (CC0). The mark it draws is Visa's registered trademark, and
+ * simple-icons is explicit that its licence covers the file and not the trademark.
+ *
+ * That is the correct asset for what this app does: render a picture of a member's card on screen.
+ * It is NOT the asset for card art. Manufactured plastic has to carry Visa's official Brand Mark at
+ * their specified clear space, minimum size and approved colourway, and that file comes from the
+ * issuer program — Lithic — not from npm.
+ *
+ * Nothing in this repo produces print artwork, so the two do not currently meet. The reason this is
+ * one exported constant rather than a path inlined in a component is so that when they do, the
+ * licensed file replaces this value and every surface picks it up at once.
+ */
+
+export interface NetworkMark {
+  /** SVG path data, drawn against `viewBox`. */
+  path: string;
+  viewBox: string;
+  label: string;
+}
+
+export const VISA: NetworkMark = {
+  path: 'M9.112 8.262L5.97 15.758H3.92L2.374 9.775c-.094-.368-.175-.503-.461-.658C1.447 8.864.677 8.627 0 8.479l.046-.217h3.3a.904.904 0 01.894.764l.817 4.338 2.018-5.102zm8.033 5.049c.008-1.979-2.736-2.088-2.717-2.972.006-.269.262-.555.822-.628a3.66 3.66 0 011.913.336l.34-1.59a5.207 5.207 0 00-1.814-.333c-1.917 0-3.266 1.02-3.278 2.479-.012 1.079.963 1.68 1.698 2.04.756.367 1.01.603 1.006.931-.005.504-.602.725-1.16.734-.975.015-1.54-.263-1.992-.473l-.351 1.642c.453.208 1.289.39 2.156.398 2.037 0 3.37-1.006 3.377-2.564m5.061 2.447H24l-1.565-7.496h-1.656a.883.883 0 00-.826.55l-2.909 6.946h2.036l.405-1.12h2.488zm-2.163-2.656l1.02-2.815.588 2.815zm-8.16-4.84l-1.603 7.496H8.34l1.605-7.496z',
+  viewBox: '0 0 24 24',
+  label: 'Visa',
+};
+
+/** By the network name our card records use. Unknown networks render no mark rather than a wrong one. */
+export const NETWORK_MARKS: Record<string, NetworkMark> = {
+  VISA,
+  Visa: VISA,
+  visa: VISA,
+};

--- a/app/src/components/clear/ClearCardFace.tsx
+++ b/app/src/components/clear/ClearCardFace.tsx
@@ -1,5 +1,6 @@
 import { useId } from 'react';
 import type { CardData } from '@/lib/clearModel';
+import { NETWORK_MARKS } from '@/assets/brand/networkMarks';
 
 /*
  * The card face.
@@ -15,20 +16,24 @@ import type { CardData } from '@/lib/clearModel';
  * Deliberately plain CSS values rather than theme tokens: this is a physical object, not a surface
  * of the page, and it must look identical in light and dark. A card that changes colour with the
  * app's theme is not a card.
+ *
+ * The network mark and the rules about which asset is licensed for what live in
+ * assets/brand/networkMarks.ts.
  */
 
 /**
- * The Visa Brand Mark.
+ * The network mark for this card.
  *
- * The path is simple-icons' (CC0); the mark itself is Visa's trademark. Fine for a UI
- * representation of a member's card, and NOT sufficient for production card art — the plastic that
- * gets manufactured has to carry Visa's official asset at their specified clear space and minimum
- * size, supplied through the issuer program. That is a file from Lithic, not a path from npm.
+ * The asset and its provenance live in assets/brand/networkMarks.ts, deliberately: replacing it
+ * with the licensed file the issuer program supplies should be a file swap, not a hunt through
+ * components. An unrecognised network renders nothing rather than the wrong network's mark.
  */
-function VisaMark({ className }: { className?: string }) {
+function NetworkMark({ network, className }: { network: string; className?: string }) {
+  const mark = NETWORK_MARKS[network] ?? NETWORK_MARKS[network?.toUpperCase?.() ?? ''];
+  if (!mark) return null;
   return (
-    <svg viewBox="0 0 24 24" className={className} role="img" aria-label="Visa" focusable="false">
-      <path fill="currentColor" d="M9.112 8.262L5.97 15.758H3.92L2.374 9.775c-.094-.368-.175-.503-.461-.658C1.447 8.864.677 8.627 0 8.479l.046-.217h3.3a.904.904 0 01.894.764l.817 4.338 2.018-5.102zm8.033 5.049c.008-1.979-2.736-2.088-2.717-2.972.006-.269.262-.555.822-.628a3.66 3.66 0 011.913.336l.34-1.59a5.207 5.207 0 00-1.814-.333c-1.917 0-3.266 1.02-3.278 2.479-.012 1.079.963 1.68 1.698 2.04.756.367 1.01.603 1.006.931-.005.504-.602.725-1.16.734-.975.015-1.54-.263-1.992-.473l-.351 1.642c.453.208 1.289.39 2.156.398 2.037 0 3.37-1.006 3.377-2.564m5.061 2.447H24l-1.565-7.496h-1.656a.883.883 0 00-.826.55l-2.909 6.946h2.036l.405-1.12h2.488zm-2.163-2.656l1.02-2.815.588 2.815zm-8.16-4.84l-1.603 7.496H8.34l1.605-7.496z" />
+    <svg viewBox={mark.viewBox} className={className} role="img" aria-label={mark.label} focusable="false">
+      <path fill="currentColor" d={mark.path} />
     </svg>
   );
 }
@@ -219,7 +224,7 @@ export default function ClearCardFace({
                   <p className="m-0 text-[10px] uppercase tracking-[.8px] opacity-95">{cardholder}</p>
                 </div>
               )}
-              <VisaMark className="h-[18px] w-[27px] opacity-95" />
+              <NetworkMark network={card.network} className="h-[18px] w-[27px] opacity-95" />
             </div>
           </div>
         )}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -218,6 +218,17 @@
      member's own money is the cheapest thing there is. Reading the bar left to right is reading the
      order it spends in, without a word of explanation. */
   --tier-cash: 10 79 62; /* #0A4F3E — the member's own money */
+
+  /* Merchant categories, for the Card page's month bar and its transaction avatars. A different
+     scale from the tiers on purpose: a tier is what PAID, a category is what it was FOR, and
+     sharing a palette between them would suggest a relationship that does not exist. */
+  --cat-grocery: 63 125 107; /* #3F7D6B */
+  --cat-fuel: 168 118 44; /* #A8762C */
+  --cat-dining: 127 119 221; /* #7F77DD */
+  --cat-bills: 138 135 128; /* #8A8780 */
+  --cat-shopping: 90 110 150; /* #5A6E96 */
+  --cat-transport: 120 90 140; /* #785A8C */
+  --cat-other: 180 178 169; /* #B4B2A9 */
   --tier-savings: 15 110 86; /* #0F6E56 — savings-backed, free */
   --tier-asset: 29 158 117; /* #1D9E75 — asset-backed */
   --tier-income: 186 117 23; /* #BA7517 — income-backed */

--- a/app/src/lib/cardSpend.test.ts
+++ b/app/src/lib/cardSpend.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const strip = (t: string) => t.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+const read = (p: string) => strip(readFileSync(join(import.meta.dirname, '..', p), 'utf8'));
+
+/*
+ * The category bar is only honest if every segment came from a merchant category code the network
+ * actually sent. These pin the path from that code to the bar.
+ */
+describe('the month bar is made of real categories', () => {
+  const route = read('pages/app/CardRoute.tsx');
+  const page = read('pages/app/CardPage.tsx');
+  const service = strip(
+    readFileSync(
+      join(import.meta.dirname, '..', '..', 'server', 'src', 'services', 'lithic', 'cardTransactionsService.ts'),
+      'utf8',
+    ),
+  );
+
+  test('card spending is read, not hardcoded empty', () => {
+    // Every real card showed "no card spending yet" forever, because this was literally `[]`.
+    expect(route).toContain('getCardTransactions()');
+    expect(route).not.toMatch(/transactions: card \? \[\] :/);
+  });
+
+  test('it comes from our own approved authorizations', () => {
+    expect(service).toContain("result = 'APPROVED'");
+    // A decline is not a purchase and does not belong in a list of what was spent.
+    expect(service).not.toMatch(/result IN|result != /);
+  });
+
+  test('the category comes from the MCC the network sent', () => {
+    expect(service).toContain('merchant.mcc');
+    expect(route).toContain('categoryForMcc(tx.mcc)');
+  });
+
+  test('a merchant number is never shown as a name', () => {
+    // `acceptor_id` is a merchant id, not a name. Blank beats numeric.
+    expect(service).toContain('merchant.descriptor');
+    expect(service).not.toMatch(/name:.*acceptor_id/);
+  });
+
+  test('the source chip is the tier that actually paid', () => {
+    expect(route).toContain("credited.length === 0 ? 'cash' : 'credit'");
+  });
+
+  test('the month total is the rows, not a second figure that could disagree', () => {
+    expect(route).toMatch(/periodTotal: cardRows\.reduce/);
+  });
+
+  test('the bar is skipped when the rows carry no category', () => {
+    // Placeholder rows and non-card activity have no MCC; a bar built from them would be a picture
+    // of our ignorance rather than of a member's month.
+    expect(page).toContain('row.category != null');
+    expect(page).toContain('categoryTotals.length > 1');
+  });
+});
+
+describe('the network mark is swappable', () => {
+  const face = read('components/clear/ClearCardFace.tsx');
+  const marks = readFileSync(join(import.meta.dirname, '..', 'assets', 'brand', 'networkMarks.ts'), 'utf8');
+
+  test('the asset lives in one file, not inlined in a component', () => {
+    // Replacing it with the licensed file the issuer program supplies should be a file swap.
+    expect(face).toContain('NETWORK_MARKS');
+    expect(face).not.toMatch(/d="M9\.112/);
+  });
+
+  test('and that file says which asset is licensed for what', () => {
+    expect(marks).toContain('trademark');
+    expect(marks).toContain('Lithic');
+  });
+
+  test('an unknown network renders nothing rather than the wrong mark', () => {
+    expect(face).toContain('if (!mark) return null;');
+  });
+});

--- a/app/src/lib/clearModel.ts
+++ b/app/src/lib/clearModel.ts
@@ -1,3 +1,4 @@
+import type { MerchantCategory } from './mccCategory';
 /**
  * The member app's money model — design spec §3, "Core display rules".
  *
@@ -303,6 +304,14 @@ export interface ActivityRow {
   rate?: string;
   cardLast4?: string;
   status?: string;
+  /*
+   * What kind of purchase this was, from the merchant category code the network sent.
+   *
+   * Optional because most rows do not have one and never will: a transfer, a savings deposit and a
+   * bond purchase have no merchant. Only card spending carries an MCC, which is why the category
+   * bar lives on the Card page and not on Activity.
+   */
+  category?: MerchantCategory;
 }
 
 /** Where a flow draws the money from, and what's in it. */

--- a/app/src/lib/mccCategory.test.ts
+++ b/app/src/lib/mccCategory.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+import { categoryForMcc, totalsByCategory, CATEGORY_LABEL } from './mccCategory';
+
+describe('merchant category codes become categories a member recognises', () => {
+  test('the codes are the real assignments', () => {
+    expect(categoryForMcc(5411)).toBe('grocery'); // grocery stores & supermarkets
+    expect(categoryForMcc(5541)).toBe('fuel'); // service stations
+    expect(categoryForMcc(5812)).toBe('dining'); // eating places
+    expect(categoryForMcc(4814)).toBe('bills'); // telecom
+    expect(categoryForMcc(5732)).toBe('shopping'); // electronics
+    expect(categoryForMcc(4121)).toBe('transport'); // taxis & rideshare
+  });
+
+  test('ranges the standard defines as ranges are handled as ranges', () => {
+    expect(categoryForMcc(3007)).toBe('transport'); // an airline
+    expect(categoryForMcc(3509)).toBe('transport'); // a hotel
+    expect(categoryForMcc(2999)).toBe('other'); // just below the airline range
+    expect(categoryForMcc(4000)).toBe('other'); // just above lodging
+  });
+
+  test('MCCs travel as strings, because leading zeros are meaningful', () => {
+    expect(categoryForMcc('5411')).toBe('grocery');
+    expect(categoryForMcc(' 5811 ')).toBe('dining');
+  });
+
+  test('an unknown or missing code is Other, not the biggest bucket', () => {
+    // Filing an unmapped merchant under Shopping would quietly distort the bar.
+    expect(categoryForMcc(null)).toBe('other');
+    expect(categoryForMcc(undefined)).toBe('other');
+    expect(categoryForMcc('')).toBe('other');
+    expect(categoryForMcc('not-a-code')).toBe('other');
+    expect(categoryForMcc(9999)).toBe('other');
+  });
+
+  test('every category has a label', () => {
+    for (const key of ['grocery', 'fuel', 'dining', 'bills', 'shopping', 'transport', 'other'] as const) {
+      expect(CATEGORY_LABEL[key]).toBeTruthy();
+    }
+  });
+});
+
+describe('totals for the bar', () => {
+  test('largest first, because the bar is about what the month was mostly made of', () => {
+    const totals = totalsByCategory([
+      { category: 'dining', amount: -20 },
+      { category: 'grocery', amount: -100 },
+      { category: 'fuel', amount: -50 },
+    ]);
+    expect(totals.map((t) => t.category)).toEqual(['grocery', 'fuel', 'dining']);
+  });
+
+  test('debits are summed by magnitude', () => {
+    expect(totalsByCategory([{ category: 'fuel', amount: -52.1 }])[0].total).toBeCloseTo(52.1, 5);
+  });
+
+  test('a refund does not shrink a slice', () => {
+    // Netting a credit against spending would make the month look smaller than it was, and the bar
+    // is a picture of what went out.
+    const totals = totalsByCategory([
+      { category: 'grocery', amount: -100 },
+      { category: 'grocery', amount: 30 },
+    ]);
+    expect(totals[0].total).toBe(100);
+  });
+
+  test('a category with nothing spent does not appear at all', () => {
+    expect(totalsByCategory([{ category: 'bills', amount: 0 }])).toEqual([]);
+  });
+});

--- a/app/src/lib/mccCategory.ts
+++ b/app/src/lib/mccCategory.ts
@@ -1,0 +1,106 @@
+/**
+ * Merchant category codes to the handful of categories a member recognises.
+ *
+ * ISO 18245 defines several hundred MCCs. Showing them raw would be showing a member the payment
+ * network's filing system; showing four or five is showing them their month. So this is a
+ * deliberate flattening, and the losses are on purpose — a hardware shop and a bookshop are both
+ * Shopping here, and nobody is worse off for it.
+ *
+ * The codes below are the real assignments, not a guess at them. Where a range is contiguous in the
+ * standard it is expressed as a range; where the standard scatters related merchants across
+ * unrelated numbers, they are listed. That is the standard's shape, not an inconsistency here.
+ *
+ * `other` is a real answer rather than a failure. An unmapped MCC is a merchant type nobody has
+ * decided how to file yet, and putting it in the largest bucket would quietly distort the bar.
+ */
+/*
+ * `MerchantCategory`, not `SpendCategory` — clearModel already has one of those, and it is a
+ * different thing: a label and an amount for the Activity page's breakdown. This is the kind of
+ * merchant. Two meanings behind one name is the shape of bug that made marking a notification read
+ * take two goes.
+ */
+export type MerchantCategory = 'grocery' | 'fuel' | 'dining' | 'bills' | 'shopping' | 'transport' | 'other';
+
+export const CATEGORY_LABEL: Record<MerchantCategory, string> = {
+  grocery: 'Groceries',
+  fuel: 'Fuel',
+  dining: 'Dining',
+  bills: 'Bills',
+  shopping: 'Shopping',
+  transport: 'Transport',
+  other: 'Other',
+};
+
+/** Discrete codes, by category. */
+const EXACT: Record<number, MerchantCategory> = {
+  // Food retail
+  5411: 'grocery', 5412: 'grocery', 5422: 'grocery', 5441: 'grocery',
+  5451: 'grocery', 5462: 'grocery', 5499: 'grocery',
+  // Fuel and vehicle energy. 5983 is fuel dealers (heating oil, propane) — a bill in spirit, but
+  // the standard files it with fuel and a member reading "Fuel" will not be surprised.
+  5541: 'fuel', 5542: 'fuel', 5983: 'fuel',
+  // Eating and drinking
+  5811: 'dining', 5812: 'dining', 5813: 'dining', 5814: 'dining',
+  // Utilities and telecoms
+  4812: 'bills', 4814: 'bills', 4815: 'bills', 4816: 'bills', 4821: 'bills',
+  4899: 'bills', 4900: 'bills', 6300: 'bills', 5968: 'bills',
+  // Retail
+  5311: 'shopping', 5310: 'shopping', 5331: 'shopping', 5399: 'shopping',
+  5651: 'shopping', 5691: 'shopping', 5732: 'shopping', 5734: 'shopping',
+  5912: 'shopping', 5942: 'shopping', 5943: 'shopping', 5999: 'shopping',
+  5200: 'shopping', 5211: 'shopping', 5251: 'shopping', 5261: 'shopping',
+  // Getting about
+  4111: 'transport', 4112: 'transport', 4121: 'transport', 4131: 'transport',
+  4784: 'transport', 4789: 'transport', 7523: 'transport',
+};
+
+/** Contiguous ranges the standard actually defines as ranges. */
+const RANGES: Array<[number, number, MerchantCategory]> = [
+  // Airlines occupy 3000–3299 and car rental 3351–3441 — travel, which nobody has asked for a
+  // bucket for, so they read as Transport rather than inventing a seventh slice.
+  [3000, 3299, 'transport'],
+  [3351, 3441, 'transport'],
+  // Lodging, 3501–3999. Same reasoning.
+  [3501, 3999, 'transport'],
+];
+
+/**
+ * The category for an MCC, or `other`.
+ *
+ * Accepts the string Lithic sends as well as a number: MCCs are four digits and leading zeros are
+ * meaningful, so they travel as strings and coercing them early loses that.
+ */
+export function categoryForMcc(mcc: string | number | null | undefined): MerchantCategory {
+  if (mcc == null) return 'other';
+  const code = typeof mcc === 'number' ? mcc : Number.parseInt(String(mcc).trim(), 10);
+  if (!Number.isFinite(code)) return 'other';
+  const exact = EXACT[code];
+  if (exact) return exact;
+  for (const [from, to, category] of RANGES) {
+    if (code >= from && code <= to) return category;
+  }
+  return 'other';
+}
+
+/**
+ * Sum by category, largest first, for the composition bar.
+ *
+ * Sorted by size rather than by a fixed category order, because the bar's job is to show what the
+ * month was mostly made of — and a fixed order would bury that under whichever category happens to
+ * be listed first.
+ */
+export function totalsByCategory(
+  rows: Array<{ category: MerchantCategory; amount: number }>,
+): Array<{ category: MerchantCategory; total: number }> {
+  const sums = new Map<MerchantCategory, number>();
+  for (const row of rows) {
+    // Debits are negative; the bar is about what was spent, so magnitude is what matters. A refund
+    // must not subtract from a slice and make the month look smaller than it was.
+    const spent = row.amount < 0 ? -row.amount : 0;
+    if (spent === 0) continue;
+    sums.set(row.category, (sums.get(row.category) ?? 0) + spent);
+  }
+  return [...sums.entries()]
+    .map(([category, total]) => ({ category, total }))
+    .sort((a, b) => b.total - a.total);
+}

--- a/app/src/pages/app/CardPage.tsx
+++ b/app/src/pages/app/CardPage.tsx
@@ -3,6 +3,7 @@ import { Snowflake, Sun } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import ClearCardFace from '@/components/clear/ClearCardFace';
 import { CompositionBar, LegendRow } from '@/components/clear/CompositionBar';
+import { totalsByCategory, CATEGORY_LABEL, type MerchantCategory } from '@/lib/mccCategory';
 import CardControlsCard from '@/components/clear/CardControlsCard';
 import CardDetailsDialog from '@/components/clear/CardDetailsDialog';
 import TransactionRows from '@/components/clear/TransactionRows';
@@ -163,6 +164,45 @@ export default function CardPage({
     </p>
   );
 
+
+  /*
+   * The same bar as Spending from, doing a different job.
+   *
+   * Above it splits what a member CAN spend; here what they DID. One visual idea reused rather than
+   * two invented, and the second reads instantly because they learned it on the first.
+   *
+   * Only rendered when the rows carry a category. A card transaction gets one from the merchant
+   * category code the network sent; nothing else does, and a bar assembled from rows without one
+   * would be a picture of our ignorance.
+   */
+  const categorised = card.transactions.filter((row): row is typeof row & { category: MerchantCategory } =>
+    row.category != null,
+  );
+  const categoryTotals = totalsByCategory(categorised);
+  const categoryBar = categoryTotals.length > 1 && (
+    <>
+      <CompositionBar
+        className="mb-2"
+        segments={categoryTotals.map(({ category, total }) => ({
+          value: total,
+          color: `rgb(var(--cat-${category}))`,
+          label: CATEGORY_LABEL[category],
+        }))}
+      />
+      <div className="mb-3 flex flex-wrap gap-x-4 gap-y-1.5 text-[11.5px] text-foreground-secondary">
+        {categoryTotals.map(({ category, total }) => (
+          <span key={category} className="flex items-center gap-1.5">
+            <i
+              className="inline-block h-[7px] w-[7px] rounded-full"
+              style={{ background: `rgb(var(--cat-${category}))` }}
+            />
+            {CATEGORY_LABEL[category]} {money(total)}
+          </span>
+        ))}
+      </div>
+    </>
+  );
+
   const transactions = (
     <>
       <div className="mb-2.5 flex items-baseline justify-between gap-3">
@@ -180,6 +220,7 @@ export default function CardPage({
           </p>
         )}
       </div>
+      {categoryBar}
       <TransactionRows
         showDate
         onSelect={setSelected}

--- a/app/src/pages/app/CardRoute.tsx
+++ b/app/src/pages/app/CardRoute.tsx
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useState } from 'react';
 import { useIdentity } from '@/context/IdentityContext';
 import CardPage from './CardPage';
 import { CARD_DAY_ONE } from '@/data/clearPlaceholder';
-import { createCard, getCards, setCardFrozen, getCredit, type CreditState, type MemberCard } from '@/utils/apiClient';
+import { createCard, getCards, setCardFrozen, getCredit, getCardTransactions, type CardTransaction, type CreditState, type MemberCard } from '@/utils/apiClient';
+import { categoryForMcc } from '@/lib/mccCategory';
+import type { ActivityRow } from '@/lib/clearModel';
 import { onChainStale } from '@/lib/chainStale';
 import { toCreditTiers } from '@/lib/creditMapping';
 import { useAppKitAccount } from '@/lib/walletCompat';
@@ -41,6 +43,24 @@ export default function CardRoute() {
   const identity = useIdentity();
   const { address } = useAppKitAccount();
   const [credit, setCredit] = useState<CreditState | null>(null);
+  const [spend, setSpend] = useState<CardTransaction[] | null>(null);
+
+  /*
+   * What the card spent, from our own approved authorizations.
+   *
+   * The list was hardcoded to `[]` for every real card, so a member with a card saw "no card
+   * spending yet" forever. Nothing needed fetching from Lithic: every approval already passes
+   * through our Auth Stream handler, which writes the amount, the merchant and which tiers paid.
+   */
+  useEffect(() => {
+    let cancelled = false;
+    void getCardTransactions().then(({ value }) => {
+      if (!cancelled) setSpend(value ?? []);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   /*
    * The tiers behind "Spending from", read the same way Home reads them and re-read on the same
@@ -170,6 +190,35 @@ export default function CardRoute() {
     [card],
   );
 
+
+  /*
+   * An authorization becomes a row.
+   *
+   * `paidFromLabel` comes from the draws the waterfall actually made, so the source shown beside a
+   * purchase is the tier that paid it rather than a guess: one draw means one tier, several means
+   * it crossed from cash into credit and the credit half is what a member needs to see.
+   */
+  const cardRows: ActivityRow[] = (spend ?? []).map((tx) => {
+    const credited = tx.draws.filter((draw) => draw.source !== 'cash');
+    return {
+      id: tx.id,
+      name: tx.name,
+      date: new Date(tx.at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+      datetime: new Date(tx.at).toLocaleString(undefined, {
+        month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit',
+      }),
+      // The source IS the funding, which is what the row's chip reads — cash or the credit it
+      // crossed into. Not 'card': every row on this page came from a card, so it would say nothing.
+      source: credited.length === 0 ? 'cash' : 'credit',
+      kind: 'spending',
+      amount: -tx.amountCents / 100,
+      category: categoryForMcc(tx.mcc),
+      location: [tx.city, tx.state].filter(Boolean).join(', ') || undefined,
+      paidFromLabel: credited.length === 0 ? 'Cash' : 'Credit',
+      cardLast4: card?.lastFour ?? undefined,
+    };
+  });
+
   // Until the first load returns, show the placeholder rather than an un-activated card: flashing
   // "Activate card" at someone who already has one reads as their card having vanished.
   const data = !loaded
@@ -182,8 +231,13 @@ export default function CardRoute() {
         variant: (card?.type === 'PHYSICAL' ? 'physical' : 'virtual') as 'physical' | 'virtual',
         // Real once the card can settle. Showing placeholder spending against a real card would be
         // inventing transactions that never happened.
-        transactions: card ? [] : CARD_DAY_ONE.transactions,
-        periodTotal: card ? 0 : CARD_DAY_ONE.periodTotal,
+        ...(card
+          ? {
+              transactions: cardRows,
+              // The total is the rows, not a separate figure that could disagree with them.
+              periodTotal: cardRows.reduce((sum, row) => sum + (row.amount < 0 ? -row.amount : 0), 0),
+            }
+          : { transactions: CARD_DAY_ONE.transactions, periodTotal: CARD_DAY_ONE.periodTotal }),
         /*
          * The credit half of "Spending from", from the contracts.
          *

--- a/app/src/utils/apiClient.ts
+++ b/app/src/utils/apiClient.ts
@@ -2086,6 +2086,32 @@ export async function getCards(): Promise<CardResult<MemberCard[]>> {
  * `unavailable` separates "this isn't switched on yet" from "that didn't work", because a member
  * should be told to wait in the first case and to try again in the second.
  */
+
+export interface CardTransaction {
+  id: string;
+  name: string;
+  at: string;
+  amountCents: number;
+  mcc: string | null;
+  city: string | null;
+  state: string | null;
+  draws: Array<{ source: string; amountCents: number }>;
+  cardToken: string;
+}
+
+/**
+ * What the member's cards have spent.
+ *
+ * These are approved AUTHORIZATIONS. The amount can move before settlement — a tip added, a fuel
+ * pump authorizing a round number — so this is what was approved, which is also what a member sees
+ * on the day.
+ */
+export async function getCardTransactions(limit = 50): Promise<CardResult<CardTransaction[]>> {
+  const r = await apiRequest<{ transactions: CardTransaction[] }>(`/api/lithic/cards/transactions?limit=${limit}`);
+  if (r.error) return cardFailure(r.error);
+  return { value: r.data?.transactions ?? [] };
+}
+
 export async function createCard(memo?: string): Promise<CardResult<MemberCard>> {
   const r = await apiRequest<{ card: MemberCard }>('/api/lithic/cards', {
     method: 'POST',


### PR DESCRIPTION
I said MCC first, bar second. Doing it in that order turned up that the problem was larger than the MCC.

## There were no card transactions at all

```ts
transactions: card ? [] : CARD_DAY_ONE.transactions,
```

Every member with a real card saw *"no card spending yet"* forever. Only the placeholder had anything in it. The MCC was the second missing thing, not the first.

**And nothing needed fetching from Lithic.** Every approval already passes through our own Auth Stream handler, which has been writing the amount, the merchant object Lithic sent, and which tiers paid into `lithic_auth_decisions` — with an index on `(wallet, decided_at DESC)`, which is exactly the query this makes. The data was there; nobody had read it.

So: a service over our own approvals, a route, and rows built from them. The **source chip is the tier that actually paid**, and the **month total is the sum of the rows** rather than a second figure that can disagree with them.

## The mapping

Real ISO 18245 assignments, not a guess — ranges expressed as ranges where the standard defines them that way (airlines `3000–3299`, lodging `3501–3999`), discrete codes listed where the standard scatters them.

- **`other` is a real answer.** Filing an unmapped merchant under the biggest bucket would quietly distort the bar.
- **Refunds don't shrink a slice.** The bar is a picture of what went *out*; netting a credit against it would make the month look smaller than it was.
- **MCCs travel as strings** — leading zeros are meaningful.

The bar renders **only when the rows carry a category**. Placeholder rows and non-card activity have no MCC, and a bar built from them would be a picture of our ignorance.

## The Visa caveat is now structural, not a comment

The mark moved to `assets/brand/networkMarks.ts`, so replacing it with the licensed file the issuer program supplies is a **file swap, not a hunt through components**. That file carries the provenance and the rule:

> simple-icons' path is right for rendering a member's card on screen. Manufactured plastic needs Visa's official Brand Mark at their clear space and minimum size, from Lithic.

An unrecognised network renders nothing rather than the wrong network's mark.

## Naming

`MerchantCategory`, not `SpendCategory` — `clearModel` already has one of those and it means something else (a label and an amount, for Activity's breakdown). Two meanings behind one name is the shape of bug that made marking a notification read take two goes.

## Not built

**Category-tinted avatars.** `TransactionRows` has no avatar and is shared with Activity, so adding one changes a page nobody asked me to change.

573 tests, 19 new. Build and dist scan clean. Verified on screen.