### PR TITLE
Reveal the number on the card, and make the stack swipable

### DIFF
--- a/app/src/assets/brand/networkMarks.ts
+++ b/app/src/assets/brand/networkMarks.ts
@@ -23,9 +23,17 @@ export interface NetworkMark {
   label: string;
 }
 
+/*
+ * The viewBox crops to the mark, not to the icon grid it was drawn on.
+ *
+ * simple-icons draws every icon inside 0 0 24 24 so a set of them line up. The Visa wordmark only
+ * occupies y≈8.26–15.76 of that box — under a third of its height — so sizing the <svg> to 18px
+ * rendered a mark about 5px tall, which is what "the Visa logo is really small" was. Cropping to
+ * the ink means the height you ask for is the height you get.
+ */
 export const VISA: NetworkMark = {
   path: 'M9.112 8.262L5.97 15.758H3.92L2.374 9.775c-.094-.368-.175-.503-.461-.658C1.447 8.864.677 8.627 0 8.479l.046-.217h3.3a.904.904 0 01.894.764l.817 4.338 2.018-5.102zm8.033 5.049c.008-1.979-2.736-2.088-2.717-2.972.006-.269.262-.555.822-.628a3.66 3.66 0 011.913.336l.34-1.59a5.207 5.207 0 00-1.814-.333c-1.917 0-3.266 1.02-3.278 2.479-.012 1.079.963 1.68 1.698 2.04.756.367 1.01.603 1.006.931-.005.504-.602.725-1.16.734-.975.015-1.54-.263-1.992-.473l-.351 1.642c.453.208 1.289.39 2.156.398 2.037 0 3.37-1.006 3.377-2.564m5.061 2.447H24l-1.565-7.496h-1.656a.883.883 0 00-.826.55l-2.909 6.946h2.036l.405-1.12h2.488zm-2.163-2.656l1.02-2.815.588 2.815zm-8.16-4.84l-1.603 7.496H8.34l1.605-7.496z',
-  viewBox: '0 0 24 24',
+  viewBox: '0 8.2 24 7.6',
   label: 'Visa',
 };
 

--- a/app/src/components/clear/ClearCardFace.tsx
+++ b/app/src/components/clear/ClearCardFace.tsx
@@ -108,6 +108,15 @@ export interface ClearCardFaceProps {
   hidesInSeconds?: number;
   /** The card behind in a stack: no number, no chip — a wallet, not a gallery. */
   behind?: boolean;
+  /**
+   * Lithic's card-details iframe, for the real number.
+   *
+   * A URL rather than values, deliberately: the PAN and CVV are rendered by the issuer inside their
+   * own frame and never enter our JavaScript, so they cannot reach our state, our logs or a
+   * screenshot in a bug report. The same reason the SSN passes through rather than being stored —
+   * a number we never hold is a number we cannot leak.
+   */
+  embedUrl?: string;
 }
 
 export default function ClearCardFace({
@@ -116,8 +125,9 @@ export default function ClearCardFace({
   revealNumber = false,
   hidesInSeconds,
   behind = false,
+  embedUrl,
 }: ClearCardFaceProps) {
-  const { variant, frozen, last4, cardholder, expiry, pan, cvc } = card;
+  const { variant, frozen, last4, cardholder, expiry, pan } = card;
   const revealed = revealNumber;
 
   const material = frozen ? MATERIAL.frozen : MATERIAL[variant];
@@ -192,39 +202,43 @@ export default function ClearCardFace({
               {variant === 'physical' && <Chip className="h-8 w-[42px]" />}
               <Contactless className="h-[19px] w-[15px]" />
             </div>
-            <p
-              className="mb-2.5 font-mono text-[14.5px] tracking-[2.2px]"
-              style={{ textShadow: '0 1px 1px rgba(0,0,0,.30)' }}
-            >
-              {groups.map((group, i) => (
-                <span key={i} className={i < groups.length - 1 ? 'mr-2' : undefined}>
-                  {group}
-                </span>
-              ))}
-            </p>
+            {revealed && embedUrl ? (
+              /*
+               * The issuer draws the number, in its own frame, over the space ours occupies.
+               *
+               * This replaced a dialog that showed `card.pan` — a field nothing ever filled for a
+               * real card, so it displayed the placeholder's number or nothing at all. The card is
+               * where a member looks for a card number, and an iframe is the only way to show a
+               * real one without our JavaScript ever touching it: the PAN and CVV are rendered by
+               * the issuer and cannot reach our state, our logs, or a screenshot in a bug report.
+               */
+              <iframe
+                src={embedUrl}
+                title="Card number"
+                className="mb-2 h-[54px] w-full border-0 bg-transparent"
+                sandbox="allow-scripts"
+                referrerPolicy="no-referrer"
+              />
+            ) : (
+              <p
+                className="mb-2.5 font-mono text-[14.5px] tracking-[2.2px]"
+                style={{ textShadow: '0 1px 1px rgba(0,0,0,.30)' }}
+              >
+                {groups.map((group, i) => (
+                  <span key={i} className={i < groups.length - 1 ? 'mr-2' : undefined}>
+                    {group}
+                  </span>
+                ))}
+              </p>
+            )}
             <div className="flex items-end justify-between">
-              {/*
-                * Expiry and CVV surface only when revealed, in the space the cardholder name
-                * occupies otherwise. A real card carries them on the back; this one has no back.
-                */}
-              {revealed && cvc ? (
-                <div className="flex gap-[18px]">
-                  <div>
-                    <p className="m-0 mb-[3px] text-[8px] uppercase tracking-[.7px] opacity-60">Expires</p>
-                    <p className="m-0 text-[10px] uppercase tracking-[.8px] opacity-95">{expiry}</p>
-                  </div>
-                  <div>
-                    <p className="m-0 mb-[3px] text-[8px] uppercase tracking-[.7px] opacity-60">CVV</p>
-                    <p className="m-0 text-[10px] uppercase tracking-[.8px] opacity-95">{cvc}</p>
-                  </div>
-                </div>
-              ) : (
-                <div>
-                  <p className="m-0 mb-[3px] text-[8px] uppercase tracking-[.7px] opacity-60">Valid thru {expiry}</p>
-                  <p className="m-0 text-[10px] uppercase tracking-[.8px] opacity-95">{cardholder}</p>
-                </div>
-              )}
-              <NetworkMark network={card.network} className="h-[18px] w-[27px] opacity-95" />
+              <div>
+                <p className="m-0 mb-[3px] text-[8px] uppercase tracking-[.7px] opacity-60">
+                  Valid thru {expiry}
+                </p>
+                <p className="m-0 text-[10px] uppercase tracking-[.8px] opacity-95">{cardholder}</p>
+              </div>
+              <NetworkMark network={card.network} className="h-3 w-[38px] opacity-95" />
             </div>
           </div>
         )}

--- a/app/src/pages/app/CardPage.tsx
+++ b/app/src/pages/app/CardPage.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useState } from 'react';
-import { Snowflake, Sun, Eye, CreditCard } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Snowflake, Sun, Eye, EyeOff, CreditCard } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import ClearCardFace from '@/components/clear/ClearCardFace';
 import { CompositionBar, LegendRow } from '@/components/clear/CompositionBar';
 import { totalsByCategory, CATEGORY_LABEL, type MerchantCategory } from '@/lib/mccCategory';
 import CardControlsCard from '@/components/clear/CardControlsCard';
-import CardDetailsDialog from '@/components/clear/CardDetailsDialog';
 import TransactionRows from '@/components/clear/TransactionRows';
 import TransactionDetailDialog from '@/components/clear/TransactionDetailDialog';
 import { CARD_DAY_ONE } from '@/data/clearPlaceholder';
@@ -31,6 +30,7 @@ export default function CardPage({
   notice = null,
   onAddToWallet,
   onAddCard,
+  onRevealDetails,
 }: {
   data?: CardData;
   /** Issues the card. Absent in the preview harness, where the page stands alone. */
@@ -41,13 +41,37 @@ export default function CardPage({
   notice?: string | null;
   onAddToWallet?: () => void;
   onAddCard?: () => void;
+  /** Fetches the issuer's short-lived card-details URL. Absent in the preview harness. */
+  onRevealDetails?: (cardId?: string) => Promise<string | undefined>;
 }) {
   const [frozen, setFrozen] = useState(data.frozen);
 
-  const [detailsOpen, setDetailsOpen] = useState(false);
+  /*
+   * The reveal lives on the card, not in a dialog.
+   *
+   * The dialog rendered `card.pan`, which nothing ever fills for a real card — so it showed the
+   * placeholder's number or nothing. A card number belongs on the card, and the countdown goes in
+   * the type tag, which already reads as status: no new element appears and the card never jumps.
+   */
+  const [revealSeconds, setRevealSeconds] = useState(0);
+  const [embedUrl, setEmbedUrl] = useState<string | undefined>(undefined);
   const [activeIndex, setActiveIndex] = useState(0);
+  const [dragX, setDragX] = useState(0);
+  const dragStart = useRef<number | null>(null);
   const [selected, setSelected] = useState<ActivityRow | null>(null);
   const card = { ...data, frozen };
+
+  useEffect(() => {
+    if (revealSeconds <= 0) return;
+    const id = setTimeout(() => setRevealSeconds((s) => s - 1), 1000);
+    return () => clearTimeout(id);
+  }, [revealSeconds]);
+
+  // The URL is short-lived and single-use, so it is dropped the moment the reveal ends rather than
+  // kept for a second look: a live link to a card number is not a thing to leave lying in state.
+  useEffect(() => {
+    if (revealSeconds === 0) setEmbedUrl(undefined);
+  }, [revealSeconds]);
 
   // Follow the server once it answers. The toggle below moves immediately so the card reads as
   // responsive, but the server is what decides — and if the freeze failed, the card must not go on
@@ -83,8 +107,43 @@ export default function CardPage({
           />
         </div>
       )}
-      <div className="relative z-[1]">
-        <ClearCardFace card={faceCard} />
+      <div
+        className="relative z-[1] touch-pan-y"
+        style={{ transform: `translateX(${dragX}px)`, transition: dragStart.current === null ? 'transform .2s' : 'none' }}
+        /*
+         * Swipe to change card.
+         *
+         * Pointer events rather than touch events, so a trackpad drag on a desktop works the same
+         * way — the stack is the affordance on both and it would be odd for only one to answer it.
+         */
+        onPointerDown={(e) => {
+          if (wallet.length < 2) return;
+          dragStart.current = e.clientX;
+        }}
+        onPointerMove={(e) => {
+          if (dragStart.current === null) return;
+          setDragX(e.clientX - dragStart.current);
+        }}
+        onPointerUp={() => {
+          const moved = dragX;
+          dragStart.current = null;
+          setDragX(0);
+          // A third of the card is far enough to mean it; less is a tap that wandered.
+          if (Math.abs(moved) > 60) {
+            setActiveIndex((i) => (moved < 0 ? (i + 1) % wallet.length : (i - 1 + wallet.length) % wallet.length));
+          }
+        }}
+        onPointerCancel={() => {
+          dragStart.current = null;
+          setDragX(0);
+        }}
+      >
+        <ClearCardFace
+          card={faceCard}
+          revealNumber={revealSeconds > 0}
+          hidesInSeconds={revealSeconds > 0 ? revealSeconds : undefined}
+          embedUrl={embedUrl}
+        />
       </div>
     </div>
   );
@@ -121,7 +180,28 @@ export default function CardPage({
   const tiles = card.activated && (
     <div className="mb-4 grid grid-cols-3 gap-[7px]">
       {[
-        { key: 'details', label: 'Show details', icon: Eye, tinted: true, onClick: () => setDetailsOpen(true), soon: false },
+        {
+          key: 'details',
+          label: revealSeconds > 0 ? 'Hide' : 'Show details',
+          icon: revealSeconds > 0 ? EyeOff : Eye,
+          tinted: true,
+          // Never disabled: without an issuer URL the reveal still shows what the card knows, and
+          // the preview harness has no handler at all. A dead-looking primary control is worse
+          // than one that reveals a masked number.
+          soon: false,
+          onClick: async () => {
+            if (revealSeconds > 0) {
+              setRevealSeconds(0);
+              return;
+            }
+            const url = await onRevealDetails?.(active?.id);
+            if (url) setEmbedUrl(url);
+            // Revealed either way: without an issuer URL the placeholder number shows, which is
+            // what the preview harness is for. A real card with no URL reveals nothing and says so
+            // by staying masked.
+            setRevealSeconds(30);
+          },
+        },
         {
           key: 'freeze',
           label: frozen ? 'Unfreeze' : 'Freeze',
@@ -149,7 +229,9 @@ export default function CardPage({
           onClick={tile.onClick}
           className={cn(
             'rounded-xl border border-border px-2 py-3.5 text-center transition-colors disabled:opacity-60',
-            tile.tinted ? 'bg-tier-boost/10 text-tier-boost-fg' : 'bg-card text-foreground',
+            // Freeze is transparent, not filled: it is the one control that undoes something, and a
+            // filled button reads as the thing to press.
+            tile.tinted ? 'bg-tier-boost/10 text-tier-boost-fg' : 'bg-transparent text-foreground',
           )}
         >
           <tile.icon className="mx-auto h-[17px] w-[17px]" strokeWidth={1.7} />
@@ -382,7 +464,6 @@ export default function CardPage({
         </div>
       </div>
 
-      <CardDetailsDialog card={card} open={detailsOpen} onOpenChange={setDetailsOpen} />
       {selected && (
         <TransactionDetailDialog
           row={selected}

--- a/app/src/pages/app/CardRoute.tsx
+++ b/app/src/pages/app/CardRoute.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useIdentity } from '@/context/IdentityContext';
 import CardPage from './CardPage';
 import { CARD_DAY_ONE } from '@/data/clearPlaceholder';
-import { createCard, getCards, setCardFrozen, getCredit, getCardTransactions, type CardTransaction, type CreditState, type MemberCard } from '@/utils/apiClient';
+import { createCard, getCards, setCardFrozen, getCredit, getCardTransactions, getCardEmbedUrl, type CardTransaction, type CreditState, type MemberCard } from '@/utils/apiClient';
 import { categoryForMcc } from '@/lib/mccCategory';
 import type { ActivityRow } from '@/lib/clearModel';
 import { onChainStale } from '@/lib/chainStale';
@@ -281,6 +281,18 @@ export default function CardRoute() {
       // Same call as activation — issuing a second virtual card is issuing a card. Passing the
       // handler is what makes the button appear at all, so it cannot render as a dead control.
       onAddCard={activate}
+      /*
+       * The issuer's short-lived details URL.
+       *
+       * Fetched on demand and handed straight to the card face, never held here: it is a live link
+       * to a card number and a minute old is a minute too long. The PAN itself never enters this
+       * app at all — Lithic renders it inside its own frame.
+       */
+      onRevealDetails={async (cardId) => {
+        const token = cardId ?? cards[0]?.token;
+        if (!token) return undefined;
+        return (await getCardEmbedUrl(token)) ?? undefined;
+      }}
     />
   );
 }


### PR DESCRIPTION
## The Visa mark was tiny for a findable reason

simple-icons draws every icon inside `0 0 24 24` so a set of them line up. The Visa wordmark occupies **y 8.26–15.76** of that box — under a third of its height. So asking for 18px got a mark about **5px tall**.

The viewBox crops to the ink now (`0 8.2 24 7.6`), so the height you ask for is the height you get.

## Show details showed nothing, and the modal was the wrong place anyway

It rendered `card.pan` — a field nothing fills for a real card — so it displayed the placeholder's number or a blank.

The reveal is **on the card** now: the number in the space it occupies masked, and the countdown in the type tag, which already reads as status. No new element appears and the card never jumps.

**The number is real, and never ours.** `GET /api/lithic/cards/:token/embed` has existed unused this whole time — a short-lived URL to the issuer's own iframe. The PAN and CVV are rendered by Lithic and never enter our JavaScript, so they can't reach our state, our logs, or a screenshot in a bug report. Same reasoning as the SSN passing through rather than being stored. The URL is dropped the moment the reveal ends rather than kept for a second look.

## The stack swipes

Pointer events rather than touch events, so a trackpad drag on desktop works the same way — the stack is the affordance on both, and it would be odd for only one to answer it. A third of the card is far enough to mean it; less is a tap that wandered.

## Freeze is transparent

It's the one control that *undoes* something, and a filled button reads as the thing to press.

---

One thing I got wrong mid-change: I disabled Show details when no issuer handler was passed, which greyed out the page's primary control in the preview harness. A dead-looking primary control is worse than one that reveals a masked number.

573 tests, build and dist scan clean. Verified on screen — including pressing the button and watching the countdown run.