### PR TITLE
Turn the card over, fix the stack, and stop using the fixture's name

### DIFF
--- a/app/public/card-embed.css
+++ b/app/public/card-embed.css
@@ -1,0 +1,61 @@
+/*
+ * Styling for the card-details iframe the issuer renders.
+ *
+ * Lithic's embed takes a PUBLICLY reachable stylesheet URI and applies it inside their frame. That
+ * is the only way to make it match: the markup is theirs and served from their origin, so nothing
+ * in the app can reach into it. Unstyled, it renders as serif black text on white, which is what
+ * "weird look" was — a browser default sitting on top of a card face.
+ *
+ * Nothing here is decorative. Every rule is making the issuer's frame invisible so what shows
+ * through is the card back it sits on.
+ */
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  /* Transparent, so the card's material shows through rather than a white sheet. */
+  background: transparent !important;
+  color: #edeae3;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  -webkit-font-smoothing: antialiased;
+}
+
+/*
+ * Broad selectors on purpose.
+ *
+ * The embed's internal markup is Lithic's and can change without warning; targeting their class
+ * names would break silently the day they rename one, and the failure would be a member's card
+ * number rendering as unstyled serif text. Styling every element is uglier and cannot miss.
+ */
+body * {
+  background: transparent !important;
+  color: #edeae3 !important;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace !important;
+  border: 0 !important;
+}
+
+/* The number itself, which should read as the largest thing on the back. */
+body {
+  font-size: 15px;
+  letter-spacing: 1.6px;
+  line-height: 1.9;
+}
+
+/* Labels — "Card Number", "Expiry", "CVV" — sit quieter than the values they name, the way they do
+   on a real card back. */
+label,
+span[class*="label"],
+div[class*="label"] {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif !important;
+  font-size: 8px !important;
+  letter-spacing: 0.7px !important;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
+input {
+  padding: 0 !important;
+  outline: none !important;
+  width: 100% !important;
+}

--- a/app/server/src/services/lithic/cardService.ts
+++ b/app/server/src/services/lithic/cardService.ts
@@ -304,8 +304,16 @@ export async function getCardEmbedUrl(cardToken: string, expirationSeconds = 60)
   const targetOrigin = (process.env.APP_ORIGIN || process.env.FRONTEND_URL || '').trim();
   if (!targetOrigin) throw new Error('APP_ORIGIN must be set to embed card details');
 
+  /*
+   * `css` is a publicly reachable stylesheet URI, applied inside Lithic's frame.
+   *
+   * It is the only way to make the embed match the card it sits on: the markup is theirs and served
+   * from their origin, so nothing in our app can style it. Without this it renders as black serif
+   * text on a white sheet, which looked exactly like a bug pasted over the card face.
+   */
   return lithic.cards.getEmbedURL({
     token: cardToken,
+    css: `${targetOrigin.replace(/\/$/, '')}/card-embed.css`,
     expiration: new Date(Date.now() + expirationSeconds * 1000).toISOString(),
     target_origin: targetOrigin,
   });

--- a/app/src/components/clear/ClearCardFace.tsx
+++ b/app/src/components/clear/ClearCardFace.tsx
@@ -127,22 +127,110 @@ export default function ClearCardFace({
   behind = false,
   embedUrl,
 }: ClearCardFaceProps) {
-  const { variant, frozen, last4, cardholder, expiry, pan } = card;
+  const { variant, frozen, last4, cardholder, expiry } = card;
   const revealed = revealNumber;
 
   const material = frozen ? MATERIAL.frozen : MATERIAL[variant];
-  const groups = revealed && pan ? pan.replace(/\s+/g, '').match(/.{1,4}/g) ?? [] : ['••••', '••••', '••••', last4 || '••••'];
+
+  /*
+   * The front is always masked.
+   *
+   * Revealing turns the card over rather than swapping text on the front — which is where these
+   * numbers live on a real card, and what every wallet app does. It also means the front has one
+   * appearance instead of two, so nothing on it shifts when a member presses Show details.
+   */
+  const groups = ['••••', '••••', '••••', last4 || '••••'];
+
+  const shell = {
+    aspectRatio: '1.5857',
+    color: '#EDEAE3',
+    boxShadow:
+      '0 1px 1px rgba(0,0,0,.10), 0 8px 20px -6px rgba(30,28,40,.40), 0 20px 44px -20px rgba(30,28,40,.32)',
+  } as const;
+
+  /*
+   * The back of the card.
+   *
+   * The reference has no back, so this is a design decision rather than an implementation of one:
+   * a real card's number, expiry and security code are on the back, every wallet app turns the card
+   * over to show them, and a member already knows to look there. The alternative — swapping text on
+   * the front — makes the front have two appearances and shifts its layout under the member's eyes.
+   *
+   * The stripe and signature panel are not decoration. They are what tells you at a glance that you
+   * are looking at the back of something, before you have read a word of it.
+   */
+  const back = (
+    <div className="absolute inset-0 overflow-hidden rounded-2xl" style={{ backfaceVisibility: 'hidden', transform: 'rotateY(180deg)' }}>
+      <div className="absolute inset-0 z-0" style={{ background: material }} />
+      <div className="pointer-events-none absolute inset-0 z-[2]" style={{ opacity: 0.34, mixBlendMode: 'overlay', backgroundImage: GRAIN, backgroundSize: '180px 180px' }} />
+      <div
+        className="pointer-events-none absolute inset-0 z-[3] rounded-2xl"
+        style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,.20), inset 0 -1px 0 rgba(0,0,0,.28), inset 0 0 0 .5px rgba(255,255,255,.07)' }}
+      />
+      <div className="relative z-[4] flex h-full flex-col">
+        {/*
+          * The countdown follows the card over.
+          *
+          * It is the front's tag slot that carries it while the card is face up, and losing it on
+          * the turn would leave a member watching a card number with no idea it is about to hide.
+          */}
+        {hidesInSeconds != null && (
+          <div className="flex justify-end px-5 pt-3.5">
+            <span
+              className="rounded-full px-2 py-[3px] text-[8.5px] uppercase tracking-[.9px]"
+              style={{ border: '.5px solid rgba(255,255,255,.5)', background: 'rgba(255,255,255,.06)' }}
+            >
+              Hides in {hidesInSeconds}s
+            </span>
+          </div>
+        )}
+        {/* The magnetic stripe, full bleed, where it is on a real card. */}
+        <div className={`h-9 w-full ${hidesInSeconds != null ? 'mt-2' : 'mt-4'}`} style={{ background: 'rgba(0,0,0,.55)' }} />
+        <div className="flex-1 px-5 pt-3">
+          {embedUrl ? (
+            /*
+             * The issuer draws the details, in its own frame, styled by a stylesheet we host.
+             *
+             * The PAN and CVV never enter our JavaScript — they cannot reach our state, our logs or
+             * a screenshot in a bug report. Same reasoning as the SSN passing through.
+             */
+            <iframe
+              src={embedUrl}
+              title="Card details"
+              className="h-[74px] w-full border-0 bg-transparent"
+              sandbox="allow-scripts"
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <p className="text-[11px] leading-relaxed opacity-70">
+              Card details aren&rsquo;t available for this card yet.
+            </p>
+          )}
+        </div>
+        <div className="flex items-end justify-between px-5 pb-4">
+          <p className="m-0 text-[10px] uppercase tracking-[.8px] opacity-95">{cardholder}</p>
+          <NetworkMark network={card.network} className="h-3 w-[38px] opacity-95" />
+        </div>
+      </div>
+    </div>
+  );
 
   return (
-    <div
-      className={`relative isolate overflow-hidden rounded-2xl ${className ?? ''}`}
-      style={{
-        aspectRatio: '1.5857',
-        color: '#EDEAE3',
-        boxShadow:
-          '0 1px 1px rgba(0,0,0,.10), 0 8px 20px -6px rgba(30,28,40,.40), 0 20px 44px -20px rgba(30,28,40,.32)',
-      }}
-    >
+    <div className={className} style={{ perspective: '1400px' }}>
+      <div
+        className="relative"
+        style={{
+          ...shell,
+          transformStyle: 'preserve-3d',
+          transition: 'transform .55s cubic-bezier(.2,.8,.2,1)',
+          transform: revealed ? 'rotateY(180deg)' : 'rotateY(0deg)',
+        }}
+      >
+      {back}
+      <div
+        className="absolute inset-0 isolate overflow-hidden rounded-2xl"
+        style={{ ...shell, backfaceVisibility: 'hidden' }}
+      >
       <div className="absolute inset-0 z-0" style={{ background: material }} />
       <div
         className="pointer-events-none absolute inset-0 z-[1]"
@@ -202,35 +290,16 @@ export default function ClearCardFace({
               {variant === 'physical' && <Chip className="h-8 w-[42px]" />}
               <Contactless className="h-[19px] w-[15px]" />
             </div>
-            {revealed && embedUrl ? (
-              /*
-               * The issuer draws the number, in its own frame, over the space ours occupies.
-               *
-               * This replaced a dialog that showed `card.pan` — a field nothing ever filled for a
-               * real card, so it displayed the placeholder's number or nothing at all. The card is
-               * where a member looks for a card number, and an iframe is the only way to show a
-               * real one without our JavaScript ever touching it: the PAN and CVV are rendered by
-               * the issuer and cannot reach our state, our logs, or a screenshot in a bug report.
-               */
-              <iframe
-                src={embedUrl}
-                title="Card number"
-                className="mb-2 h-[54px] w-full border-0 bg-transparent"
-                sandbox="allow-scripts"
-                referrerPolicy="no-referrer"
-              />
-            ) : (
-              <p
-                className="mb-2.5 font-mono text-[14.5px] tracking-[2.2px]"
-                style={{ textShadow: '0 1px 1px rgba(0,0,0,.30)' }}
-              >
-                {groups.map((group, i) => (
-                  <span key={i} className={i < groups.length - 1 ? 'mr-2' : undefined}>
-                    {group}
-                  </span>
-                ))}
-              </p>
-            )}
+            <p
+              className="mb-2.5 font-mono text-[14.5px] tracking-[2.2px]"
+              style={{ textShadow: '0 1px 1px rgba(0,0,0,.30)' }}
+            >
+              {groups.map((group, i) => (
+                <span key={i} className={i < groups.length - 1 ? 'mr-2' : undefined}>
+                  {group}
+                </span>
+              ))}
+            </p>
             <div className="flex items-end justify-between">
               <div>
                 <p className="m-0 mb-[3px] text-[8px] uppercase tracking-[.7px] opacity-60">
@@ -242,6 +311,8 @@ export default function ClearCardFace({
             </div>
           </div>
         )}
+      </div>
+      </div>
       </div>
     </div>
   );

--- a/app/src/components/clear/TransactionAvatar.tsx
+++ b/app/src/components/clear/TransactionAvatar.tsx
@@ -1,3 +1,5 @@
+import { useId, useMemo } from 'react';
+import { getSvgPath } from 'figma-squircle';
 import type { ActivityRow } from '@/lib/clearModel';
 
 /*
@@ -45,15 +47,60 @@ function avatarColor(row: ActivityRow): string {
   return 'rgb(var(--cat-other))';
 }
 
-/** A tinted initials avatar for a transaction row. */
+/**
+ * A tinted initials avatar for a transaction row.
+ *
+ * A real squircle, not a circle and not `rounded-lg`. `border-radius` draws four quarter-circles
+ * that meet the straight edges at a curvature break; `figma-squircle` generates the same path
+ * Figma's corner smoothing does, which is the construction the app mark already uses. Using it here
+ * means a row's avatar and the mark in the header are the same shape rather than two things that
+ * are nearly the same shape, which is the kind of difference nobody names and everybody feels.
+ */
+const SIZE = 32;
+const RADIUS_RATIO = 0.2237; // Apple's icon proportions, as in the wordmark.
+const SMOOTHING = 0.6;
+
 export default function TransactionAvatar({ row, className }: { row: ActivityRow; className?: string }) {
+  const clipId = useId();
+  const path = useMemo(
+    () =>
+      getSvgPath({
+        width: SIZE,
+        height: SIZE,
+        cornerRadius: SIZE * RADIUS_RATIO,
+        cornerSmoothing: SMOOTHING,
+        preserveSmoothing: true,
+      }),
+    [],
+  );
+
   return (
-    <span
+    <svg
+      width={SIZE}
+      height={SIZE}
+      viewBox={`0 0 ${SIZE} ${SIZE}`}
+      className={`shrink-0 ${className ?? ''}`}
       aria-hidden
-      className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[11px] font-medium text-white ${className ?? ''}`}
-      style={{ background: avatarColor(row) }}
+      focusable="false"
     >
-      {initialsOf(row.name)}
-    </span>
+      <defs>
+        <clipPath id={clipId}>
+          <path d={path} />
+        </clipPath>
+      </defs>
+      <rect width={SIZE} height={SIZE} fill={avatarColor(row)} clipPath={`url(#${clipId})`} />
+      <text
+        x="50%"
+        y="50%"
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill="#FBFAF7"
+        fontSize="11"
+        fontWeight="500"
+        fontFamily="inherit"
+      >
+        {initialsOf(row.name)}
+      </text>
+    </svg>
   );
 }

--- a/app/src/lib/clearModel.ts
+++ b/app/src/lib/clearModel.ts
@@ -1096,6 +1096,8 @@ export interface CardData {
   creditAfterCash?: number;
   /** The tiers themselves, so the bar can show what the limit is made of. */
   tiers?: CreditTier[];
+  /** What backs the limit, for the breakdown this page links to. Absent until the tiers are read. */
+  backing?: LimitBacking;
   /** Card transactions only — Activity shows everything (spec §9). */
   transactions: ActivityRow[];
 }

--- a/app/src/pages/app/CardPage.tsx
+++ b/app/src/pages/app/CardPage.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Snowflake, Sun, Eye, EyeOff, CreditCard } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import ClearCardFace from '@/components/clear/ClearCardFace';
 import { CompositionBar, LegendRow } from '@/components/clear/CompositionBar';
 import { totalsByCategory, CATEGORY_LABEL, type MerchantCategory } from '@/lib/mccCategory';
 import CardControlsCard from '@/components/clear/CardControlsCard';
+import LimitBreakdown from '@/components/clear/LimitBreakdown';
 import TransactionRows from '@/components/clear/TransactionRows';
 import TransactionDetailDialog from '@/components/clear/TransactionDetailDialog';
 import { CARD_DAY_ONE } from '@/data/clearPlaceholder';
@@ -35,7 +37,7 @@ export default function CardPage({
   data?: CardData;
   /** Issues the card. Absent in the preview harness, where the page stands alone. */
   onActivate?: () => void;
-  onToggleFreeze?: (frozen: boolean) => void;
+  onToggleFreeze?: (frozen: boolean, cardId?: string) => void;
   busy?: boolean;
   /** Why the last action did not do what it looked like it would. Absent when nothing went wrong. */
   notice?: string | null;
@@ -57,6 +59,8 @@ export default function CardPage({
   const [embedUrl, setEmbedUrl] = useState<string | undefined>(undefined);
   const [activeIndex, setActiveIndex] = useState(0);
   const [dragX, setDragX] = useState(0);
+  const [dragging, setDragging] = useState(false);
+  const [breakdownOpen, setBreakdownOpen] = useState(false);
   const dragStart = useRef<number | null>(null);
   const [selected, setSelected] = useState<ActivityRow | null>(null);
   const card = { ...data, frozen };
@@ -93,32 +97,69 @@ export default function CardPage({
     ? { ...card, variant: active.variant, last4: active.last4, frozen: active.frozen }
     : card;
 
+  const activeFrozen = active?.frozen ?? frozen;
+
+  /*
+   * A wallet, not a gallery.
+   *
+   * Up to three cards, each behind the last at a slight angle. The angles are the point: perfectly
+   * stacked rectangles read as one thick card, and it was not obvious there was anything behind the
+   * front one — the card behind showed as a blank sliver, which looked like a rendering fault
+   * rather than a second card.
+   *
+   * Three is the cap because a fourth adds nothing a member can act on: they can already see there
+   * is more than one and the pager says how many. Alternating angles rather than fanning one way,
+   * so a wallet of three does not lean over.
+   */
+  const DEPTH = [
+    { rotate: 0, y: 0, scale: 1, brightness: 1 },
+    { rotate: -3.2, y: 12, scale: 0.955, brightness: 0.88 },
+    { rotate: 2.4, y: 22, scale: 0.915, brightness: 0.78 },
+  ];
+
+  const behindCards = wallet
+    .map((c, i) => ({ c, depth: (i - activeIndex + wallet.length) % wallet.length }))
+    .filter((entry) => entry.depth > 0 && entry.depth < DEPTH.length)
+    // Deepest first, so the DOM order is the stacking order and no z-index is needed.
+    .sort((a, b) => b.depth - a.depth);
+
   const stack = (
-    <div className="relative pt-2.5">
-      {wallet.length > 1 && (
-        <div
-          className="absolute left-1/2 top-0 z-0 w-[93%] -translate-x-1/2"
-          style={{ filter: 'brightness(.88) saturate(.9)' }}
-          aria-hidden
-        >
-          <ClearCardFace
-            behind
-            card={{ ...card, variant: wallet[(activeIndex + 1) % wallet.length].variant }}
-          />
-        </div>
-      )}
+    <div className="relative">
+      {behindCards.map(({ c, depth }) => {
+        const d = DEPTH[depth];
+        return (
+          <div
+            key={c.id}
+            aria-hidden
+            className="absolute inset-x-0 top-0"
+            style={{
+              transform: `translateY(${d.y}px) scale(${d.scale}) rotate(${d.rotate}deg)`,
+              filter: `brightness(${d.brightness}) saturate(.92)`,
+              transition: 'transform .45s cubic-bezier(.2,.8,.2,1), filter .45s',
+            }}
+          >
+            {/*
+              * The cards behind show their face but not their number — the honest reading of a
+              * wallet, and one less thing on screen in a coffee shop. They are not blank: the mark
+              * and the type tag are what make it obvious a second card is there at all.
+              */}
+            <ClearCardFace behind card={{ ...card, variant: c.variant, frozen: c.frozen, last4: c.last4 }} />
+          </div>
+        );
+      })}
       <div
-        className="relative z-[1] touch-pan-y"
-        style={{ transform: `translateX(${dragX}px)`, transition: dragStart.current === null ? 'transform .2s' : 'none' }}
-        /*
-         * Swipe to change card.
-         *
-         * Pointer events rather than touch events, so a trackpad drag on a desktop works the same
-         * way — the stack is the affordance on both and it would be odd for only one to answer it.
-         */
+        className="relative touch-pan-y"
+        style={{
+          // Rotates as it moves, the way a card being pulled off a stack does. Purely a drag
+          // affordance: at rest both are zero and the transition takes over.
+          transform: `translateX(${dragX}px) rotate(${dragX / 26}deg)`,
+          transition: dragging ? 'none' : 'transform .45s cubic-bezier(.2,.8,.2,1)',
+        }}
         onPointerDown={(e) => {
-          if (wallet.length < 2) return;
+          if (wallet.length < 2 || revealSeconds > 0) return;
           dragStart.current = e.clientX;
+          setDragging(true);
+          e.currentTarget.setPointerCapture(e.pointerId);
         }}
         onPointerMove={(e) => {
           if (dragStart.current === null) return;
@@ -127,14 +168,16 @@ export default function CardPage({
         onPointerUp={() => {
           const moved = dragX;
           dragStart.current = null;
+          setDragging(false);
           setDragX(0);
-          // A third of the card is far enough to mean it; less is a tap that wandered.
-          if (Math.abs(moved) > 60) {
+          // A quarter of a card is far enough to mean it; less is a tap that wandered.
+          if (Math.abs(moved) > 70) {
             setActiveIndex((i) => (moved < 0 ? (i + 1) % wallet.length : (i - 1 + wallet.length) % wallet.length));
           }
         }}
         onPointerCancel={() => {
           dragStart.current = null;
+          setDragging(false);
           setDragX(0);
         }}
       >
@@ -145,6 +188,8 @@ export default function CardPage({
           embedUrl={embedUrl}
         />
       </div>
+      {/* The stack leans below the front card, so the column needs the room. */}
+      {behindCards.length > 0 && <div style={{ height: DEPTH[behindCards[0].depth].y }} />}
     </div>
   );
 
@@ -204,13 +249,14 @@ export default function CardPage({
         },
         {
           key: 'freeze',
-          label: frozen ? 'Unfreeze' : 'Freeze',
-          icon: frozen ? Sun : Snowflake,
+          label: activeFrozen ? 'Unfreeze' : 'Freeze',
+          icon: activeFrozen ? Sun : Snowflake,
           tinted: false,
           onClick: () => {
-            const next = !frozen;
+            const next = !activeFrozen;
             setFrozen(next);
-            onToggleFreeze?.(next);
+            // The card on screen, not the first one in the wallet.
+            onToggleFreeze?.(next, active?.id);
           },
         },
         /*
@@ -388,8 +434,14 @@ export default function CardPage({
       <div className="mb-3 flex items-baseline justify-between">
         <span className="text-[10px] uppercase tracking-[.5px] text-muted-foreground">On this card</span>
         {card.transactions.length > 0 && (
-          <span className="text-[11.5px] text-muted-foreground">
-            {card.transactions.length} {card.transactions.length === 1 ? 'purchase' : 'purchases'}
+          <span className="flex items-baseline gap-3">
+            <span className="text-[11.5px] text-muted-foreground">
+              {card.transactions.length} {card.transactions.length === 1 ? 'purchase' : 'purchases'}
+            </span>
+            {/* Activity is the everything list; this panel is the card's slice of it. */}
+            <Link to="/activity" className="text-[11.5px] text-tier-boost-fg underline">
+              See all
+            </Link>
           </span>
         )}
       </div>
@@ -439,7 +491,7 @@ export default function CardPage({
           {/* One card: the pager is absent, so the tiles need the space back. */}
           <div className={wallet.length > 1 ? '' : 'mt-3.5'}>{tiles}</div>
           {activate}
-          {cardList}
+          <div className="hidden lg:block">{cardList}</div>
           {card.activated && onAddCard && (
             <Button variant="clear" size="xs" className="mt-2.5 w-full text-xs" onClick={onAddCard}>
               Add a virtual card
@@ -464,6 +516,9 @@ export default function CardPage({
         </div>
       </div>
 
+      {data.backing && (
+        <LimitBreakdown backing={data.backing} open={breakdownOpen} onOpenChange={setBreakdownOpen} />
+      )}
       {selected && (
         <TransactionDetailDialog
           row={selected}

--- a/app/src/pages/app/CardRoute.tsx
+++ b/app/src/pages/app/CardRoute.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useMemberProfile } from '@/hooks/useMemberProfile';
 import { useIdentity } from '@/context/IdentityContext';
 import CardPage from './CardPage';
 import { CARD_DAY_ONE } from '@/data/clearPlaceholder';
@@ -6,7 +7,7 @@ import { createCard, getCards, setCardFrozen, getCredit, getCardTransactions, ge
 import { categoryForMcc } from '@/lib/mccCategory';
 import type { ActivityRow } from '@/lib/clearModel';
 import { onChainStale } from '@/lib/chainStale';
-import { toCreditTiers } from '@/lib/creditMapping';
+import { toCreditTiers, toLimitBacking } from '@/lib/creditMapping';
 import { useAppKitAccount } from '@/lib/walletCompat';
 
 /*
@@ -43,6 +44,7 @@ export default function CardRoute() {
   const [notice, setNotice] = useState<string | null>(null);
   const identity = useIdentity();
   const { address } = useAppKitAccount();
+  const member = useMemberProfile();
   const [credit, setCredit] = useState<CreditState | null>(null);
   const [spend, setSpend] = useState<CardTransaction[] | null>(null);
 
@@ -158,12 +160,20 @@ export default function CardRoute() {
     }
   }, [identity]);
 
+  /*
+   * Freeze the card the member is looking at, not the first one.
+   *
+   * This took `card` — always cards[0] — so on a wallet of three, swiping to the second and
+   * pressing Freeze froze the first. The card on screen said frozen, a different card actually was,
+   * and nothing on the page showed either fact correctly.
+   */
   const toggleFreeze = useCallback(
-    async (frozen: boolean) => {
-      if (!card) return;
+    async (frozen: boolean, cardId?: string) => {
+      const target = cards.find((c) => c.token === cardId) ?? card;
+      if (!target) return;
       setBusy(true);
       try {
-        const { value: updated, error, unavailable } = await setCardFrozen(card.token, frozen);
+        const { value: updated, error, unavailable } = await setCardFrozen(target.token, frozen);
         /*
          * Only trust the server's answer. A freeze that failed must not leave the card looking
          * frozen — a member who believes their card is dead when it is not is worse off than one
@@ -188,7 +198,7 @@ export default function CardRoute() {
         setBusy(false);
       }
     },
-    [card],
+    [card, cards],
   );
 
 
@@ -228,6 +238,15 @@ export default function CardRoute() {
         ...CARD_DAY_ONE,
         activated: Boolean(card),
         /*
+         * The name embossed on the card is the member's, not the fixture's.
+         *
+         * It read 'Kai M' for everybody — the placeholder's display name. The verified legal name
+         * first, because that is what an issuer prints and what a merchant checks; the display name
+         * second, which is at least the member's own; and the placeholder only when there is no
+         * member at all, which is the preview harness.
+         */
+        cardholder: member.legalName || member.name || CARD_DAY_ONE.cardholder,
+        /*
          * Every card, for the stack and the list.
          *
          * "Where" is what distinguishes them in a list where the number is masked: a plastic card
@@ -264,6 +283,9 @@ export default function CardRoute() {
         ...(credit?.complete
           ? {
               tiers: toCreditTiers(credit.tiers),
+              // The same breakdown Home links to, from the same rows — one surface, so the two
+              // pages cannot describe the limit differently.
+              backing: toLimitBacking(credit.tiers, CARD_DAY_ONE.backing ?? { assetBacked: [], unsecured: [] }),
               creditAfterCash: credit.tiers
                 .filter((tier) => tier.active)
                 .reduce((sum, tier) => sum + Math.max(0, tier.limitCents - tier.usedCents), 0) / 100,


### PR DESCRIPTION
## That weird look was Lithic's iframe with no stylesheet

Their embed renders its own markup from their origin, so nothing in the app can style it. Unstyled, it's black serif text on a white sheet — which is exactly what was sitting on the card face.

`getEmbedURL` takes a **`css` parameter**: a publicly reachable stylesheet URI applied *inside* their frame. `public/card-embed.css` is that. It uses broad selectors on purpose — targeting their class names would break silently the day they rename one, and the failure mode is a member's card number rendering as unstyled serif.

## The details are on the back

Where they are on a real card, what every wallet app does, and it means the front has **one** appearance instead of two — nothing shifts under the member's eyes when they press Show details.

The reference has no back, so the stripe and signature area are a design decision rather than an implementation of one: they're what tells you at a glance you're looking at the back of something, before you've read a word. **The countdown follows the card over** — losing it on the turn leaves someone watching a card number with no idea it's about to hide.

## The stack was one blank sliver

Perfectly aligned rectangles read as one thick card. Now up to three, each at a slight angle, **alternating** so a wallet of three doesn't lean over. The cards behind show their mark and type tag rather than nothing — that's what makes a second card obvious at all.

Three is the cap: a fourth adds nothing a member can act on, since the pager already says how many.

## Freeze froze the wrong card

It took `cards[0]` regardless of which card was on screen. On a wallet of three, swiping to the second and pressing Freeze froze the first — the card on screen said frozen, a *different* card was, and neither fact was shown correctly.

## And the rest

- **Swipe rotates as it moves**, the way a card pulled off a stack does, with pointer capture so a drag that leaves the element still finishes.
- **The name is the member's.** It read `Kai M` for everybody. Verified legal name first — that's what an issuer prints and a merchant checks — then display name, then the fixture only when there's no member at all.
- **Avatars are real squircles**, via the same `figma-squircle` construction as the app mark, so a row and the header are the same shape rather than nearly the same.
- **Limit breakdown** opens the same surface Home does, from the same rows, so the two pages can't describe the limit differently. **See all** goes to Activity.
- **The card list is desktop-only** — on a phone the swipe already tells you there are two.

## Not built

The partner dot and its legend. `PARTNERS` is placeholder data with no API behind it, so every dot would be invented.

573 tests, build and dist scan clean. Verified on screen, including the flip.