### PR TITLE
Square shadow, blank back card, and a three-row back

### DIFF
--- a/app/public/card-embed.css
+++ b/app/public/card-embed.css
@@ -35,11 +35,32 @@ body * {
   border: 0 !important;
 }
 
-/* The number itself, which should read as the largest thing on the back. */
+/*
+ * Two rows, not three.
+ *
+ * Lithic stacks number, expiry and code as three blocks. On a card back that reads as a list rather
+ * than a card, and it is a row taller than the space wants. A two-column grid with the number
+ * spanning both puts expiry and the security code side by side, which is where they are on a real
+ * card.
+ *
+ * Grid on `body` because the embed's internal markup is theirs and could be anything; a grid parent
+ * lays out whatever children it is given without needing to know what they are called.
+ */
 body {
-  font-size: 15px;
-  letter-spacing: 1.6px;
-  line-height: 1.9;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 18px;
+  row-gap: 2px;
+  align-content: start;
+  font-size: 14px;
+  letter-spacing: 1.4px;
+  line-height: 1.5;
+}
+
+/* The number is the first thing and the widest — it takes the whole row. */
+body > *:first-child {
+  grid-column: 1 / -1;
+  font-size: 15.5px;
 }
 
 /* Labels — "Card Number", "Expiry", "CVV" — sit quieter than the values they name, the way they do

--- a/app/src/components/clear/ClearCardFace.tsx
+++ b/app/src/components/clear/ClearCardFace.tsx
@@ -144,6 +144,14 @@ export default function ClearCardFace({
   const shell = {
     aspectRatio: '1.5857',
     color: '#EDEAE3',
+    /*
+     * The radius lives here, not only on the faces.
+     *
+     * The faces are rounded and clipped, but the shadow is cast by THIS box — and without a radius
+     * it was cast around a rectangle, so four faint square corners sat just outside the card. A
+     * shadow does not inherit its shape from the children it sits behind.
+     */
+    borderRadius: 16,
     boxShadow:
       '0 1px 1px rgba(0,0,0,.10), 0 8px 20px -6px rgba(30,28,40,.40), 0 20px 44px -20px rgba(30,28,40,.32)',
   } as const;
@@ -168,25 +176,17 @@ export default function ClearCardFace({
         style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,.20), inset 0 -1px 0 rgba(0,0,0,.28), inset 0 0 0 .5px rgba(255,255,255,.07)' }}
       />
       <div className="relative z-[4] flex h-full flex-col">
-        {/*
-          * The countdown follows the card over.
-          *
-          * It is the front's tag slot that carries it while the card is face up, and losing it on
-          * the turn would leave a member watching a card number with no idea it is about to hide.
-          */}
-        {hidesInSeconds != null && (
-          <div className="flex justify-end px-5 pt-3.5">
-            <span
-              className="rounded-full px-2 py-[3px] text-[8.5px] uppercase tracking-[.9px]"
-              style={{ border: '.5px solid rgba(255,255,255,.5)', background: 'rgba(255,255,255,.06)' }}
-            >
-              Hides in {hidesInSeconds}s
-            </span>
-          </div>
-        )}
         {/* The magnetic stripe, full bleed, where it is on a real card. */}
-        <div className={`h-9 w-full ${hidesInSeconds != null ? 'mt-2' : 'mt-4'}`} style={{ background: 'rgba(0,0,0,.55)' }} />
-        <div className="flex-1 px-5 pt-3">
+        <div className="mt-5 h-9 w-full" style={{ background: 'rgba(0,0,0,.55)' }} />
+        {/*
+          * Two rows under the stripe, not three.
+          *
+          * The details and the footer were separate blocks with the countdown above them, which
+          * made the back four stacked things in a space that holds two comfortably. The countdown
+          * moves onto the name row — it is status, and it belongs beside the other small print
+          * rather than taking a line of its own.
+          */}
+        <div className="flex flex-1 flex-col justify-between px-5 pb-4 pt-3">
           {embedUrl ? (
             /*
              * The issuer draws the details, in its own frame, styled by a stylesheet we host.
@@ -197,7 +197,7 @@ export default function ClearCardFace({
             <iframe
               src={embedUrl}
               title="Card details"
-              className="h-[74px] w-full border-0 bg-transparent"
+              className="h-[58px] w-full border-0 bg-transparent"
               sandbox="allow-scripts"
               referrerPolicy="no-referrer"
             />
@@ -206,10 +206,17 @@ export default function ClearCardFace({
               Card details aren&rsquo;t available for this card yet.
             </p>
           )}
-        </div>
-        <div className="flex items-end justify-between px-5 pb-4">
-          <p className="m-0 text-[10px] uppercase tracking-[.8px] opacity-95">{cardholder}</p>
-          <NetworkMark network={card.network} className="h-3 w-[38px] opacity-95" />
+          <div className="flex items-end justify-between">
+            <p className="m-0 text-[10px] uppercase tracking-[.8px] opacity-95">{cardholder}</p>
+            <div className="flex items-center gap-2.5">
+              {hidesInSeconds != null && (
+                <span className="text-[8.5px] uppercase tracking-[.9px] opacity-70">
+                  Hides in {hidesInSeconds}s
+                </span>
+              )}
+              <NetworkMark network={card.network} className="h-3 w-[38px] opacity-95" />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/src/pages/app/CardPage.tsx
+++ b/app/src/pages/app/CardPage.tsx
@@ -111,10 +111,18 @@ export default function CardPage({
    * is more than one and the pager says how many. Alternating angles rather than fanning one way,
    * so a wallet of three does not lean over.
    */
+  /*
+   * The cards behind peek ABOVE the front one, not below it.
+   *
+   * Offset downward they showed their bottom edge — which on this design carries nothing, so a
+   * second card read as a blank purple sliver and looked like a rendering fault. Their top edge is
+   * where the mark and the type tag are, and those are what make it obvious a second card is there
+   * at all.
+   */
   const DEPTH = [
     { rotate: 0, y: 0, scale: 1, brightness: 1 },
-    { rotate: -3.2, y: 12, scale: 0.955, brightness: 0.88 },
-    { rotate: 2.4, y: 22, scale: 0.915, brightness: 0.78 },
+    { rotate: -3.4, y: -14, scale: 0.955, brightness: 0.9 },
+    { rotate: 2.6, y: -25, scale: 0.915, brightness: 0.82 },
   ];
 
   const behindCards = wallet
@@ -124,14 +132,15 @@ export default function CardPage({
     .sort((a, b) => b.depth - a.depth);
 
   const stack = (
-    <div className="relative">
+    // Padded for the cards leaning out above; without it they clip against whatever is over them.
+    <div className="relative pt-7">
       {behindCards.map(({ c, depth }) => {
         const d = DEPTH[depth];
         return (
           <div
             key={c.id}
             aria-hidden
-            className="absolute inset-x-0 top-0"
+            className="absolute inset-x-0 top-7"
             style={{
               transform: `translateY(${d.y}px) scale(${d.scale}) rotate(${d.rotate}deg)`,
               filter: `brightness(${d.brightness}) saturate(.92)`,
@@ -188,8 +197,7 @@ export default function CardPage({
           embedUrl={embedUrl}
         />
       </div>
-      {/* The stack leans below the front card, so the column needs the room. */}
-      {behindCards.length > 0 && <div style={{ height: DEPTH[behindCards[0].depth].y }} />}
+
     </div>
   );
 
@@ -486,6 +494,21 @@ export default function CardPage({
     <>
       <div className="lg:grid lg:grid-cols-[minmax(0,340px)_minmax(0,1fr)] lg:items-start lg:gap-6">
         <div>
+          {/*
+             * Mobile puts "Add a card" in the page header and drops the list below.
+             *
+             * The reference's reasoning, which holds: on a phone the swipe already tells you there
+             * is more than one, so a second list of the same cards is a screen's worth of
+             * repetition. The action is the part worth keeping, and the header is where it goes.
+             */}
+          {card.activated && onAddCard && (
+            <div className="mb-2 flex items-baseline justify-between lg:hidden">
+              <span className="text-[10px] uppercase tracking-[.5px] text-muted-foreground">Your cards</span>
+              <button type="button" className="text-[11.5px] text-tier-boost-fg underline" onClick={onAddCard}>
+                Add a card
+              </button>
+            </div>
+          )}
           {stack}
           {pager}
           {/* One card: the pager is absent, so the tiles need the space back. */}
@@ -493,7 +516,7 @@ export default function CardPage({
           {activate}
           <div className="hidden lg:block">{cardList}</div>
           {card.activated && onAddCard && (
-            <Button variant="clear" size="xs" className="mt-2.5 w-full text-xs" onClick={onAddCard}>
+            <Button variant="clear" size="xs" className="mt-2.5 hidden w-full text-xs lg:block" onClick={onAddCard}>
               Add a virtual card
             </Button>
           )}


### PR DESCRIPTION
## The faint sharp edges were the shadow

It's cast by the flip wrapper, and that box had **no border-radius** — so the shadow was drawn around a rectangle while the faces inside it were rounded, leaving four faint square corners just outside the card.

A shadow doesn't inherit its shape from the children sitting in front of it.

## The card behind was blank because it peeked the wrong way

Offset downward, it showed its **bottom** edge — which on this design carries nothing. Its mark and type tag are at the **top**, and those are the only things that make a second card recognisable *as a card*.

They lean above the front one now.

## The back was four stacked things in a space that holds two

| was | now |
|---|---|
| countdown row | merged onto the name row — it's status, and belongs beside the other small print |
| stripe | stripe |
| details (3 lines) | details (2 rows) |
| footer | — |

The issuer's own three fields become two: a grid with the number spanning both columns puts expiry and the security code **side by side**, where they are on a real card. Grid on `body` rather than named selectors, because the embed's markup is Lithic's and a grid parent lays out whatever children it's handed.

## The honest answer on the outstanding list

I named four things. Where they actually stand:

| | |
|---|---|
| **See all** | ✅ done |
| **Limit breakdown** | ✅ done — opens the same surface Home does, from the same rows |
| **Mobile "Add a card" header link** | ⚠️ **I substituted this without saying so.** I made the card list desktop-only, which is not the same thing. Built properly now. |
| **Partner dot + legend** | ❌ still not done, and I won't guess — `PARTNERS` is placeholder data with no API, so every dot would be invented |

573 tests, build and dist scan clean.

**Not verifiable in the harness:** the two-row iframe layout needs a provisioned Lithic card, and the stack needs two. Both are wired; neither has been seen working.